### PR TITLE
Fix Reported Metrics in BulkLoadDemo

### DIFF
--- a/Samples/BulkLoadDemo/BulkLoadDemo/BulkLoadDemo.cpp
+++ b/Samples/BulkLoadDemo/BulkLoadDemo/BulkLoadDemo.cpp
@@ -570,9 +570,9 @@ void BulkLoadDemo::RenderUI(GraphicsContext& gfxContext)
         text.NewLine();
 
         text.DrawFormattedString("   Bandwidth: %7.2f GB/s\n", (total / time.count()) / 1000.0f / 1000.0f / 1000.0f);
-        text.DrawFormattedString("         RAM: %7.2f MiB\n", s.CpuByteCount / 1024.0f / 1024.0f);
-        text.DrawFormattedString("Texture VRAM: %7.2f MiB\n", s.TexturesByteCount / 1024.0f / 1024.0f);
-        text.DrawFormattedString("Buffer  VRAM: %7.2f MiB\n\n", s.BuffersByteCount / 1024.0f / 1024.0f);
+        text.DrawFormattedString("CPU Mem Data: %7.2f MiB\n", s.CpuByteCount / 1024.0f / 1024.0f);
+        text.DrawFormattedString("Texture Data: %7.2f MiB\n", s.TexturesByteCount / 1024.0f / 1024.0f);
+        text.DrawFormattedString(" Buffer Data: %7.2f MiB\n\n", s.BuffersByteCount / 1024.0f / 1024.0f);
 
         if (s.UncompressedByteCount > 0)
             text.DrawFormattedString("Uncompressed: %7.2f MB\n", s.UncompressedByteCount / 1000.0f / 1000.0f);

--- a/Samples/BulkLoadDemo/BulkLoadDemo/MarcFile.cpp
+++ b/Samples/BulkLoadDemo/BulkLoadDemo/MarcFile.cpp
@@ -707,6 +707,8 @@ MarcFile::DataSize MarcFile::GetRequiredDataSize() const
     accumulateSize(m_header.UnstructuredGpuData);
     accumulateSize(m_header.CpuData);
 
+    size.TexturesByteCount = 0;
+
     for (uint32_t textureIndex = 0; textureIndex < m_cpuMetadata->NumTextures; ++textureIndex)
     {
         auto& texture = m_cpuMetadata->Textures[textureIndex];
@@ -714,9 +716,11 @@ MarcFile::DataSize MarcFile::GetRequiredDataSize() const
         for (uint32_t singleMipIndex = 0; singleMipIndex < texture.NumSingleMips; ++singleMipIndex)
         {
             accumulateSize(texture.SingleMips[singleMipIndex]);
+            size.TexturesByteCount += texture.SingleMips[singleMipIndex].UncompressedSize;
         }
 
         accumulateSize(texture.RemainingMips);
+        size.TexturesByteCount += texture.RemainingMips.UncompressedSize;
     }
 
     return size;


### PR DESCRIPTION
BulkLoadDemo currently shows VRAM allocations, but those sizes may be larger than the amount of data actually loaded, e.g. texture VRAM also includes padding. And so using those numbers to calculate the bandwidth is incorrect.

This change fixes it so that the demo instead reports the data loaded and decompressed by DirectStorage, which will make the bandwidth more accurate.