### PR TITLE
Add missing primitive topology when HDR is enabled

### DIFF
--- a/Samples/BulkLoadDemo/Core/Display.cpp
+++ b/Samples/BulkLoadDemo/Core/Display.cpp
@@ -349,7 +349,8 @@ void Display::Shutdown( void )
 void Graphics::PreparePresentHDR(void)
 {
     GraphicsContext& Context = GraphicsContext::Begin(L"Present");
-
+    Context.SetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    
     bool NeedsScaling = g_NativeWidth != g_DisplayWidth || g_NativeHeight != g_DisplayHeight;
 
     Context.SetRootSignature(s_PresentRS);


### PR DESCRIPTION
The project sets the primitive topology when HDR is disable but not when HDR is enabled. The default value is UNDEFINED which could cause some corruptions.