### PR TITLE
BulkLoadDemo Display Fix

### DIFF
--- a/Samples/BulkLoadDemo/BulkLoadDemo/BulkLoadDemo.cpp
+++ b/Samples/BulkLoadDemo/BulkLoadDemo/BulkLoadDemo.cpp
@@ -262,7 +262,7 @@ void BulkLoadDemo::Update(float deltaT)
         break;
 
     case State::ShowingASet:
-        if (m_marcFiles->GetTimeSinceLoad() > 10s)
+        if ((m_marcFiles->GetTimeSinceLoad() - m_marcFiles->GetLoadTime()) > 10s)
         {
             m_state = State::Unloading;
         }


### PR DESCRIPTION
The "ShowingASet" state tracked time since loading the Marc file, not since loading finished. If the demo takes, say, 20 seconds to load, this state lasts only briefly before switching to "Unloading." To ensure a consistent 10-second display, we now consider both load time and display duration.