### PR TITLE
Fix ambigious bit shifts in BulkLoadDemo HLSL

### DIFF
--- a/Samples/BulkLoadDemo/Core/Shaders/BitonicIndirectArgsCS.hlsl
+++ b/Samples/BulkLoadDemo/Core/Shaders/BitonicIndirectArgsCS.hlsl
@@ -22,7 +22,7 @@ cbuffer Constants : register(b0)
 
 uint NextPow2( uint Val )
 {
-    uint Mask = (1 << firstbithigh(Val)) - 1;
+    uint Mask = (1u << firstbithigh(Val)) - 1;
     return (Val + Mask) & ~Mask;
 }
 
@@ -34,7 +34,7 @@ void main( uint GI : SV_GroupIndex )
         return;
 
     uint ListCount = g_CounterBuffer.Load(CounterOffset);
-    uint k = 2048 << GI;
+    uint k = 2048u << GI;
 
     // We need one more iteration every time the number of thread groups doubles
     if (k > NextPow2((ListCount + 2047) & ~2047))

--- a/Samples/BulkLoadDemo/Core/Shaders/ParticleTileCullingCS.hlsl
+++ b/Samples/BulkLoadDemo/Core/Shaders/ParticleTileCullingCS.hlsl
@@ -106,7 +106,7 @@ void main( uint3 Gid : SV_GroupID, uint GI : SV_GroupIndex, uint3 GTid : SV_Grou
     ParticleCountInBin = min(MAX_PARTICLES_PER_BIN, ParticleCountInBin);
 
     // Compute the next power of two for the bitonic sort
-    uint NextPow2 = countbits(ParticleCountInBin) <= 1 ? ParticleCountInBin : (2 << firstbithigh(ParticleCountInBin));
+    uint NextPow2 = countbits(ParticleCountInBin) <= 1u ? ParticleCountInBin : (2u << firstbithigh(ParticleCountInBin));
 
     // Fill in the sort key array.  Each sort key has passenger data (in the least signficant
     // bits, so that as the sort keys are moved around, they retain a pointer to the particle

--- a/Samples/BulkLoadDemo/Core/Shaders/ParticleTileRenderCS.hlsl
+++ b/Samples/BulkLoadDemo/Core/Shaders/ParticleTileRenderCS.hlsl
@@ -135,7 +135,7 @@ float4x4 RenderParticles( uint2 TileCoord, uint2 ST, uint NumParticles, uint Hit
         {
             // Get the next bit and then clear it
             uint SubIdx = firstbitlow(ParticleMask);
-            ParticleMask ^= 1 << SubIdx;
+            ParticleMask ^= 1u << SubIdx;
 
             // Get global particle index from sorted buffer and then load the particle
             uint SortKey = g_SortedParticles[BinStart + SubIdx];

--- a/Samples/BulkLoadDemo/Model/Shaders/FillLightGridCS.hlsli
+++ b/Samples/BulkLoadDemo/Model/Shaders/FillLightGridCS.hlsli
@@ -176,7 +176,7 @@ void main(
         }
 
         // update bitmask
-        InterlockedOr(tileLightBitMask[lightIndex / 32], 1 << (lightIndex % 32));
+        InterlockedOr(tileLightBitMask[lightIndex / 32], 1u << (lightIndex % 32));
     }
 
     GroupMemoryBarrierWithGroupSync();

--- a/Samples/BulkLoadDemo/Model/Shaders/Lighting.hlsli
+++ b/Samples/BulkLoadDemo/Model/Shaders/Lighting.hlsli
@@ -308,7 +308,7 @@ uint64_t Ballot64(bool b)
 uint PullNextBit( inout uint bits )
 {
     uint bitIndex = firstbitlow(bits);
-    bits ^= 1 << bitIndex;
+    bits ^= 1u << bitIndex;
     return bitIndex;
 }
 


### PR DESCRIPTION
Resolves warnings (-Wambig-lit-shift) due to unclear bit shifts.