### PR TITLE
Fix GDeflateDemo and GDeflateTest not linking

### DIFF
--- a/GDeflate/GDeflateDemo/CMakeLists.txt
+++ b/GDeflate/GDeflateDemo/CMakeLists.txt
@@ -10,7 +10,7 @@ set(sources
     "pch.h"
 )
 
-set(libs GDeflate)
+set(libs GDeflate windowsapp.lib dxcompiler.lib)
 
 if (WIN32)
     set(sources ${sources} 

--- a/GDeflate/GDeflateTest/CMakeLists.txt
+++ b/GDeflate/GDeflateTest/CMakeLists.txt
@@ -17,7 +17,7 @@ exec_program(${NUGET_EXE}
 
 include_directories(${CMAKE_BINARY_DIR}/packages/Microsoft.Direct3D.DirectStorage/native/include)
 target_link_directories(GDeflateTest PRIVATE ${CMAKE_BINARY_DIR}/packages/Microsoft.Direct3D.DirectStorage/native/lib/$ENV{VSCMD_ARG_TGT_ARCH})
-target_link_libraries(GDeflateTest PRIVATE dstorage.lib)
+target_link_libraries(GDeflateTest PRIVATE dstorage.lib windowsapp.lib)
 
 target_link_libraries(GDeflateTest PRIVATE GDeflate)
 


### PR DESCRIPTION
Both executables are missing windowsapp.lib for several WinRT functions referenced by the WinRT headers, and GDeflateDemo is also missing a reference to DXC, causing both to fail to link.