### PR TITLE
Platform toolset143 compatibility

### DIFF
--- a/Samples/BulkLoadDemo/BulkLoadDemo/BulkLoadDemo.vcxproj
+++ b/Samples/BulkLoadDemo/BulkLoadDemo/BulkLoadDemo.vcxproj
@@ -1,145 +1,145 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.props')" />
-  <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|x64">
-      <Configuration>Debug</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Profile|x64">
-      <Configuration>Profile</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|x64">
-      <Configuration>Release</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-  </ItemGroup>
-  <PropertyGroup Label="Globals">
-    <RootNamespace>BulkLoadDemo</RootNamespace>
-    <ProjectGuid>{613E12A8-A3E7-441B-815A-14F757684DAF}</ProjectGuid>
-    <DefaultLanguage>en-US</DefaultLanguage>
-    <Keyword>Win32Proj</Keyword>
-    <PlatformToolset>v142</PlatformToolset>
-    <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
-    <TargetRuntime>Native</TargetRuntime>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-  </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-    <EmbedManifest>false</EmbedManifest>
-  </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <ImportGroup Label="ExtensionSettings" />
-  <ImportGroup Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\PropertySheets\Build.props" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Platform)'=='x64'" Label="PropertySheets">
-    <Import Project="..\PropertySheets\Desktop.props" />
-  </ImportGroup>
-  <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup>
-    <ClCompile>
-      <AdditionalIncludeDirectories>..\Model;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link Condition="'$(Configuration)'=='Debug'">
-      <AdditionalOptions>/nodefaultlib:MSVCRT %(AdditionalOptions)</AdditionalOptions>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
-    <Link>
-      <AdditionalDependencies>
+	<Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.props')" />
+	<ItemGroup Label="ProjectConfigurations">
+		<ProjectConfiguration Include="Debug|x64">
+			<Configuration>Debug</Configuration>
+			<Platform>x64</Platform>
+		</ProjectConfiguration>
+		<ProjectConfiguration Include="Profile|x64">
+			<Configuration>Profile</Configuration>
+			<Platform>x64</Platform>
+		</ProjectConfiguration>
+		<ProjectConfiguration Include="Release|x64">
+			<Configuration>Release</Configuration>
+			<Platform>x64</Platform>
+		</ProjectConfiguration>
+	</ItemGroup>
+	<PropertyGroup Label="Globals">
+		<RootNamespace>BulkLoadDemo</RootNamespace>
+		<ProjectGuid>{613E12A8-A3E7-441B-815A-14F757684DAF}</ProjectGuid>
+		<DefaultLanguage>en-US</DefaultLanguage>
+		<Keyword>Win32Proj</Keyword>
+		<PlatformToolset>v142</PlatformToolset>
+		<MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
+		<TargetRuntime>Native</TargetRuntime>
+		<WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+	</PropertyGroup>
+	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+	<PropertyGroup Label="Configuration">
+		<ConfigurationType>Application</ConfigurationType>
+		<PlatformToolset>v142</PlatformToolset>
+		<CharacterSet>Unicode</CharacterSet>
+		<EmbedManifest>false</EmbedManifest>
+	</PropertyGroup>
+	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+	<ImportGroup Label="ExtensionSettings" />
+	<ImportGroup Label="PropertySheets">
+		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+		<Import Project="..\PropertySheets\Build.props" />
+	</ImportGroup>
+	<ImportGroup Condition="'$(Platform)'=='x64'" Label="PropertySheets">
+		<Import Project="..\PropertySheets\Desktop.props" />
+	</ImportGroup>
+	<PropertyGroup Label="UserMacros" />
+	<ItemDefinitionGroup>
+		<ClCompile>
+			<AdditionalIncludeDirectories>..\Model;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+		</ClCompile>
+		<Link Condition="'$(Configuration)'=='Debug'">
+			<AdditionalOptions>/nodefaultlib:MSVCRT %(AdditionalOptions)</AdditionalOptions>
+		</Link>
+	</ItemDefinitionGroup>
+	<ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
+		<Link>
+			<AdditionalDependencies>
 				kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)
 			</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup>
-    <Link>
-      <AdditionalLibraryDirectories>..\..\Packages\zlib-msvc-x64.1.2.11.8900\build\native\lib_release;..\..\Packages\directxtex_desktop_win10.2019.2.7.1\lib\x64\Release;..\..\Packages\directxmesh_desktop_win10.2019.2.7.1\lib\x64\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>zlibstatic.lib;DirectXMesh.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Platform)'=='x64'">DirectXTex.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <SubSystem>Console</SubSystem>
-      <EntryPointSymbol>wWinMainCRTStartup</EntryPointSymbol>
-      <MinimumRequiredVersion>10</MinimumRequiredVersion>
-    </Link>
-    <ClCompile>
-      <LanguageStandard>stdcpp20</LanguageStandard>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemGroup>
-    <ClCompile Include="CpuPerformance.cpp" />
-    <ClCompile Include="DStorageLoader.cpp" />
-    <ClCompile Include="BulkLoadDemo.cpp" />
-    <ClCompile Include="MarcFile.cpp" />
-    <ClCompile Include="MarcFileManager.cpp" />
-    <ClInclude Include="CpuPerformance.h" />
-    <ClInclude Include="DStorageLoader.h" />
-    <ClInclude Include="MarcFile.h" />
-    <ClInclude Include="MarcFileFormat.h" />
-    <ClInclude Include="MarcFileManager.h" />
-    <ClInclude Include="MemoryRegion.h" />
-    <ClInclude Include="MultiHeap.h" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="../Core/Core.vcxproj">
-      <Project>{86A58508-0D6A-4786-A32F-01A301FDC6F3}</Project>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-    </ProjectReference>
-    <ProjectReference Include="..\MiniArchive\MiniArchive.vcxproj">
-      <Project>{a2631beb-8f09-4d0f-a729-f4470d765fc6}</Project>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-    </ProjectReference>
-    <ProjectReference Include="..\Model\Model.vcxproj">
-      <Project>{5d3aeefb-8789-48e5-9bd9-09c667052d09}</Project>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <CopyFileToFolders Include="Textures\Stonewall_diffuseIBL.dds">
-      <DeploymentContent>true</DeploymentContent>
-      <DestinationFileName>%(RelativeDir)%(Filename)%(Extension)</DestinationFileName>
-    </CopyFileToFolders>
-    <CopyFileToFolders Include="Textures\Stonewall_specularIBL.dds">
-      <DeploymentContent>true</DeploymentContent>
-      <DestinationFileName>%(RelativeDir)%(Filename)%(Extension)</DestinationFileName>
-    </CopyFileToFolders>
-    <MarcFile Include="SampleModel/Avocado.gltf">
-      <Options>-gdeflate -bc</Options>
-    </MarcFile>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <PropertyGroup>
-    <MiniArchive>$(OutDir)../miniarchive/miniarchive.exe</MiniArchive>
-  </PropertyGroup>
-  <Target Name="BuildMarcFiles" AfterTargets="PrepareForBuild" Inputs="@(MarcFile);$(MiniArchive)" Outputs="@(MarcFile -> '$(OutDir)%(Filename).marc')">
-    <Exec Command="@(MarcFile -> '&quot;$(MiniArchive)&quot; &quot;%(Identity)&quot; &quot;$(OutDir)%(Filename).marc&quot; %(Options)')" />
-  </Target>
-  <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
-    <Import Project="..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
-    <Import Project="..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets" Condition="Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" />
-    <Import Project="..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets" Condition="Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" />
-    <Import Project="..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets" Condition="Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" />
-    <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets" Condition="Exists('..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" />
-  </ImportGroup>
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
-    <Error Condition="!Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets'))" />
-    <Error Condition="!Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets'))" />
-    <Error Condition="!Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets'))" />
-  </Target>
+		</Link>
+	</ItemDefinitionGroup>
+	<ItemDefinitionGroup>
+		<Link>
+			<AdditionalLibraryDirectories>..\..\Packages\zlib-msvc-x64.1.2.11.8900\build\native\lib_release;..\..\Packages\directxtex_desktop_win10.2019.2.7.1\lib\x64\Release;..\..\Packages\directxmesh_desktop_win10.2019.2.7.1\lib\x64\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+			<AdditionalDependencies>zlibstatic.lib;DirectXMesh.lib;%(AdditionalDependencies)</AdditionalDependencies>
+			<AdditionalDependencies Condition="'$(Platform)'=='x64'">DirectXTex.lib;%(AdditionalDependencies)</AdditionalDependencies>
+			<SubSystem>Console</SubSystem>
+			<EntryPointSymbol>wWinMainCRTStartup</EntryPointSymbol>
+			<MinimumRequiredVersion>10</MinimumRequiredVersion>
+		</Link>
+		<ClCompile>
+			<LanguageStandard>stdcpp20</LanguageStandard>
+		</ClCompile>
+	</ItemDefinitionGroup>
+	<ItemGroup>
+		<ClCompile Include="CpuPerformance.cpp" />
+		<ClCompile Include="DStorageLoader.cpp" />
+		<ClCompile Include="BulkLoadDemo.cpp" />
+		<ClCompile Include="MarcFile.cpp" />
+		<ClCompile Include="MarcFileManager.cpp" />
+		<ClInclude Include="CpuPerformance.h" />
+		<ClInclude Include="DStorageLoader.h" />
+		<ClInclude Include="MarcFile.h" />
+		<ClInclude Include="MarcFileFormat.h" />
+		<ClInclude Include="MarcFileManager.h" />
+		<ClInclude Include="MemoryRegion.h" />
+		<ClInclude Include="MultiHeap.h" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="../Core/Core.vcxproj">
+			<Project>{86A58508-0D6A-4786-A32F-01A301FDC6F3}</Project>
+			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+		</ProjectReference>
+		<ProjectReference Include="..\MiniArchive\MiniArchive.vcxproj">
+			<Project>{a2631beb-8f09-4d0f-a729-f4470d765fc6}</Project>
+			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+		</ProjectReference>
+		<ProjectReference Include="..\Model\Model.vcxproj">
+			<Project>{5d3aeefb-8789-48e5-9bd9-09c667052d09}</Project>
+		</ProjectReference>
+	</ItemGroup>
+	<ItemGroup>
+		<CopyFileToFolders Include="Textures\Stonewall_diffuseIBL.dds">
+			<DeploymentContent>true</DeploymentContent>
+			<DestinationFileName>%(RelativeDir)%(Filename)%(Extension)</DestinationFileName>
+		</CopyFileToFolders>
+		<CopyFileToFolders Include="Textures\Stonewall_specularIBL.dds">
+			<DeploymentContent>true</DeploymentContent>
+			<DestinationFileName>%(RelativeDir)%(Filename)%(Extension)</DestinationFileName>
+		</CopyFileToFolders>
+		<MarcFile Include="SampleModel/Avocado.gltf">
+			<Options>-gdeflate -bc</Options>
+		</MarcFile>
+	</ItemGroup>
+	<ItemGroup>
+		<None Include="packages.config" />
+	</ItemGroup>
+	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+	<PropertyGroup>
+		<MiniArchive>$(OutDir)../miniarchive/miniarchive.exe</MiniArchive>
+	</PropertyGroup>
+	<Target Name="BuildMarcFiles" AfterTargets="PrepareForBuild" Inputs="@(MarcFile);$(MiniArchive)" Outputs="@(MarcFile -> '$(OutDir)%(Filename).marc')">
+		<Exec Command="@(MarcFile -> '&quot;$(MiniArchive)&quot; &quot;%(Identity)&quot; &quot;$(OutDir)%(Filename).marc&quot; %(Options)')" />
+	</Target>
+	<ImportGroup Label="ExtensionTargets">
+		<Import Project="..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
+		<Import Project="..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+		<Import Project="..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets" Condition="Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" />
+		<Import Project="..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets" Condition="Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" />
+		<Import Project="..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets" Condition="Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" />
+		<Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
+		<Import Project="..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets" Condition="Exists('..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" />
+	</ImportGroup>
+	<Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+		<PropertyGroup>
+			<ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+		</PropertyGroup>
+		<Error Condition="!Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
+		<Error Condition="!Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+		<Error Condition="!Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets'))" />
+		<Error Condition="!Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets'))" />
+		<Error Condition="!Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets'))" />
+		<Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
+		<Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+		<Error Condition="!Exists('..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets'))" />
+	</Target>
 </Project>

--- a/Samples/BulkLoadDemo/BulkLoadDemo/BulkLoadDemo.vcxproj
+++ b/Samples/BulkLoadDemo/BulkLoadDemo/BulkLoadDemo.vcxproj
@@ -1,145 +1,144 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.props')" />
-    <ItemGroup Label="ProjectConfigurations">
-        <ProjectConfiguration Include="Debug|x64">
-            <Configuration>Debug</Configuration>
-            <Platform>x64</Platform>
-        </ProjectConfiguration>
-        <ProjectConfiguration Include="Profile|x64">
-            <Configuration>Profile</Configuration>
-            <Platform>x64</Platform>
-        </ProjectConfiguration>
-        <ProjectConfiguration Include="Release|x64">
-            <Configuration>Release</Configuration>
-            <Platform>x64</Platform>
-        </ProjectConfiguration>
-    </ItemGroup>
-    <PropertyGroup Label="Globals">
-        <RootNamespace>BulkLoadDemo</RootNamespace>
-        <ProjectGuid>{613E12A8-A3E7-441B-815A-14F757684DAF}</ProjectGuid>
-        <DefaultLanguage>en-US</DefaultLanguage>
-        <Keyword>Win32Proj</Keyword>
-        <PlatformToolset>v142</PlatformToolset>
-        <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
-        <TargetRuntime>Native</TargetRuntime>
-        <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-    </PropertyGroup>
-    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-    <PropertyGroup Label="Configuration">
-        <ConfigurationType>Application</ConfigurationType>
-        <PlatformToolset>v142</PlatformToolset>
-        <CharacterSet>Unicode</CharacterSet>
-        <EmbedManifest>false</EmbedManifest>
-    </PropertyGroup>
-    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-    <ImportGroup Label="ExtensionSettings" />
-    <ImportGroup Label="PropertySheets">
-        <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-        <Import Project="..\PropertySheets\Build.props" />
-    </ImportGroup>
-    <ImportGroup Condition="'$(Platform)'=='x64'" Label="PropertySheets">
-        <Import Project="..\PropertySheets\Desktop.props" />
-    </ImportGroup>
-    <PropertyGroup Label="UserMacros" />
-    <ItemDefinitionGroup>
-        <ClCompile>
-            <AdditionalIncludeDirectories>..\Model;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-        </ClCompile>
-        <Link Condition="'$(Configuration)'=='Debug'">
-            <AdditionalOptions>/nodefaultlib:MSVCRT %(AdditionalOptions)</AdditionalOptions>
-        </Link>
-    </ItemDefinitionGroup>
-    <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
-        <Link>
-            <AdditionalDependencies>
-                kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)
-            </AdditionalDependencies>
-        </Link>
-    </ItemDefinitionGroup>
-    <ItemDefinitionGroup>
-        <Link>
-            <AdditionalLibraryDirectories>..\..\Packages\zlib-msvc-x64.1.2.11.8900\build\native\lib_release;..\..\Packages\directxtex_desktop_win10.2019.2.7.1\lib\x64\Release;..\..\Packages\directxmesh_desktop_win10.2019.2.7.1\lib\x64\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-            <AdditionalDependencies>zlibstatic.lib;DirectXMesh.lib;%(AdditionalDependencies)</AdditionalDependencies>
-            <AdditionalDependencies Condition="'$(Platform)'=='x64'">DirectXTex.lib;%(AdditionalDependencies)</AdditionalDependencies>
-            <SubSystem>Console</SubSystem>
-            <EntryPointSymbol>wWinMainCRTStartup</EntryPointSymbol>
-            <MinimumRequiredVersion>10</MinimumRequiredVersion>
-        </Link>
-        <ClCompile>
-            <LanguageStandard>stdcpp20</LanguageStandard>
-        </ClCompile>
-    </ItemDefinitionGroup>
-    <ItemGroup>
-        <ClCompile Include="CpuPerformance.cpp" />
-        <ClCompile Include="DStorageLoader.cpp" />
-        <ClCompile Include="BulkLoadDemo.cpp" />
-        <ClCompile Include="MarcFile.cpp" />
-        <ClCompile Include="MarcFileManager.cpp" />
-        <ClInclude Include="CpuPerformance.h" />
-        <ClInclude Include="DStorageLoader.h" />
-        <ClInclude Include="MarcFile.h" />
-        <ClInclude Include="MarcFileFormat.h" />
-        <ClInclude Include="MarcFileManager.h" />
-        <ClInclude Include="MemoryRegion.h" />
-        <ClInclude Include="MultiHeap.h" />
-    </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="../Core/Core.vcxproj">
-            <Project>{86A58508-0D6A-4786-A32F-01A301FDC6F3}</Project>
-            <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-        </ProjectReference>
-        <ProjectReference Include="..\MiniArchive\MiniArchive.vcxproj">
-            <Project>{a2631beb-8f09-4d0f-a729-f4470d765fc6}</Project>
-            <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-        </ProjectReference>
-        <ProjectReference Include="..\Model\Model.vcxproj">
-            <Project>{5d3aeefb-8789-48e5-9bd9-09c667052d09}</Project>
-        </ProjectReference>
-    </ItemGroup>
-    <ItemGroup>
-        <CopyFileToFolders Include="Textures\Stonewall_diffuseIBL.dds">
-            <DeploymentContent>true</DeploymentContent>
-            <DestinationFileName>%(RelativeDir)%(Filename)%(Extension)</DestinationFileName>
-        </CopyFileToFolders>
-        <CopyFileToFolders Include="Textures\Stonewall_specularIBL.dds">
-            <DeploymentContent>true</DeploymentContent>
-            <DestinationFileName>%(RelativeDir)%(Filename)%(Extension)</DestinationFileName>
-        </CopyFileToFolders>
-        <MarcFile Include="SampleModel/Avocado.gltf">
-            <Options>-gdeflate -bc</Options>
-        </MarcFile>
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="packages.config" />
-    </ItemGroup>
-    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Profile|x64">
+      <Configuration>Profile</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <RootNamespace>BulkLoadDemo</RootNamespace>
+    <ProjectGuid>{613E12A8-A3E7-441B-815A-14F757684DAF}</ProjectGuid>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <Keyword>Win32Proj</Keyword>
+    <PlatformToolset>v142</PlatformToolset>
+    <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
+    <TargetRuntime>Native</TargetRuntime>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <EmbedManifest>false</EmbedManifest>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\PropertySheets\Build.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Platform)'=='x64'" Label="PropertySheets">
+    <Import Project="..\PropertySheets\Desktop.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\Model;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link Condition="'$(Configuration)'=='Debug'">
+      <AdditionalOptions>/nodefaultlib:MSVCRT %(AdditionalOptions)</AdditionalOptions>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
+    <Link>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)
+	  </AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup>
+    <Link>
+      <AdditionalLibraryDirectories>..\..\Packages\zlib-msvc-x64.1.2.11.8900\build\native\lib_release;..\..\Packages\directxtex_desktop_win10.2019.2.7.1\lib\x64\Release;..\..\Packages\directxmesh_desktop_win10.2019.2.7.1\lib\x64\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>zlibstatic.lib;DirectXMesh.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Platform)'=='x64'">DirectXTex.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Console</SubSystem>
+      <EntryPointSymbol>wWinMainCRTStartup</EntryPointSymbol>
+      <MinimumRequiredVersion>10</MinimumRequiredVersion>
+    </Link>
+    <ClCompile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="CpuPerformance.cpp" />
+    <ClCompile Include="DStorageLoader.cpp" />
+    <ClCompile Include="BulkLoadDemo.cpp" />
+    <ClCompile Include="MarcFile.cpp" />
+    <ClCompile Include="MarcFileManager.cpp" />
+    <ClInclude Include="CpuPerformance.h" />
+    <ClInclude Include="DStorageLoader.h" />
+    <ClInclude Include="MarcFile.h" />
+    <ClInclude Include="MarcFileFormat.h" />
+    <ClInclude Include="MarcFileManager.h" />
+    <ClInclude Include="MemoryRegion.h" />
+    <ClInclude Include="MultiHeap.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Core/Core.vcxproj">
+      <Project>{86A58508-0D6A-4786-A32F-01A301FDC6F3}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="..\MiniArchive\MiniArchive.vcxproj">
+      <Project>{a2631beb-8f09-4d0f-a729-f4470d765fc6}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="..\Model\Model.vcxproj">
+      <Project>{5d3aeefb-8789-48e5-9bd9-09c667052d09}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <CopyFileToFolders Include="Textures\Stonewall_diffuseIBL.dds">
+      <DeploymentContent>true</DeploymentContent>
+      <DestinationFileName>%(RelativeDir)%(Filename)%(Extension)</DestinationFileName>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="Textures\Stonewall_specularIBL.dds">
+      <DeploymentContent>true</DeploymentContent>
+      <DestinationFileName>%(RelativeDir)%(Filename)%(Extension)</DestinationFileName>
+    </CopyFileToFolders>
+    <MarcFile Include="SampleModel/Avocado.gltf">
+      <Options>-gdeflate -bc</Options>
+    </MarcFile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <PropertyGroup>
+    <MiniArchive>$(OutDir)../miniarchive/miniarchive.exe</MiniArchive>
+  </PropertyGroup>
+  <Target Name="BuildMarcFiles" AfterTargets="PrepareForBuild" Inputs="@(MarcFile);$(MiniArchive)" Outputs="@(MarcFile -> '$(OutDir)%(Filename).marc')">
+    <Exec Command="@(MarcFile -> '&quot;$(MiniArchive)&quot; &quot;%(Identity)&quot; &quot;$(OutDir)%(Filename).marc&quot; %(Options)')" />
+  </Target>
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
+    <Import Project="..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+    <Import Project="..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets" Condition="Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" />
+    <Import Project="..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets" Condition="Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" />
+    <Import Project="..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets" Condition="Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" />
+    <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets" Condition="Exists('..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-        <MiniArchive>$(OutDir)../miniarchive/miniarchive.exe</MiniArchive>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Target Name="BuildMarcFiles" AfterTargets="PrepareForBuild" Inputs="@(MarcFile);$(MiniArchive)" Outputs="@(MarcFile -> '$(OutDir)%(Filename).marc')">
-        <Exec Command="@(MarcFile -> '&quot;$(MiniArchive)&quot; &quot;%(Identity)&quot; &quot;$(OutDir)%(Filename).marc&quot; %(Options)')" />
-    </Target>
-    <ImportGroup Label="ExtensionTargets">
-        <Import Project="..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
-        <Import Project="..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
-        <Import Project="..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets" Condition="Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" />
-        <Import Project="..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets" Condition="Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" />
-        <Import Project="..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets" Condition="Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" />
-        <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
-        <Import Project="..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets" Condition="Exists('..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" />
-    </ImportGroup>
-    <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-        <PropertyGroup>
-            <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-        </PropertyGroup>
-        <Error Condition="!Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
-        <Error Condition="!Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
-        <Error Condition="!Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets'))" />
-        <Error Condition="!Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets'))" />
-        <Error Condition="!Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets'))" />
-        <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
-        <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-        <Error Condition="!Exists('..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets'))" />
-    </Target>
+    <Error Condition="!Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+    <Error Condition="!Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets'))" />
+    <Error Condition="!Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets'))" />
+    <Error Condition="!Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets'))" />
+  </Target>
 </Project>

--- a/Samples/BulkLoadDemo/BulkLoadDemo/BulkLoadDemo.vcxproj
+++ b/Samples/BulkLoadDemo/BulkLoadDemo/BulkLoadDemo.vcxproj
@@ -28,7 +28,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <EmbedManifest>false</EmbedManifest>
   </PropertyGroup>
@@ -52,8 +52,9 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
     <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)
-	  </AdditionalDependencies>
+      <AdditionalDependencies>
+				kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)
+			</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup>

--- a/Samples/BulkLoadDemo/BulkLoadDemo/BulkLoadDemo.vcxproj
+++ b/Samples/BulkLoadDemo/BulkLoadDemo/BulkLoadDemo.vcxproj
@@ -1,145 +1,145 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.props')" />
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="Debug|x64">
-			<Configuration>Debug</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="Profile|x64">
-			<Configuration>Profile</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="Release|x64">
-			<Configuration>Release</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-	</ItemGroup>
-	<PropertyGroup Label="Globals">
-		<RootNamespace>BulkLoadDemo</RootNamespace>
-		<ProjectGuid>{613E12A8-A3E7-441B-815A-14F757684DAF}</ProjectGuid>
-		<DefaultLanguage>en-US</DefaultLanguage>
-		<Keyword>Win32Proj</Keyword>
-		<PlatformToolset>v142</PlatformToolset>
-		<MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
-		<TargetRuntime>Native</TargetRuntime>
-		<WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-	<PropertyGroup Label="Configuration">
-		<ConfigurationType>Application</ConfigurationType>
-		<PlatformToolset>v142</PlatformToolset>
-		<CharacterSet>Unicode</CharacterSet>
-		<EmbedManifest>false</EmbedManifest>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-	<ImportGroup Label="ExtensionSettings" />
-	<ImportGroup Label="PropertySheets">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-		<Import Project="..\PropertySheets\Build.props" />
-	</ImportGroup>
-	<ImportGroup Condition="'$(Platform)'=='x64'" Label="PropertySheets">
-		<Import Project="..\PropertySheets\Desktop.props" />
-	</ImportGroup>
-	<PropertyGroup Label="UserMacros" />
-	<ItemDefinitionGroup>
-		<ClCompile>
-			<AdditionalIncludeDirectories>..\Model;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-		</ClCompile>
-		<Link Condition="'$(Configuration)'=='Debug'">
-			<AdditionalOptions>/nodefaultlib:MSVCRT %(AdditionalOptions)</AdditionalOptions>
-		</Link>
-	</ItemDefinitionGroup>
-	<ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
-		<Link>
-			<AdditionalDependencies>
-				kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)
-			</AdditionalDependencies>
-		</Link>
-	</ItemDefinitionGroup>
-	<ItemDefinitionGroup>
-		<Link>
-			<AdditionalLibraryDirectories>..\..\Packages\zlib-msvc-x64.1.2.11.8900\build\native\lib_release;..\..\Packages\directxtex_desktop_win10.2019.2.7.1\lib\x64\Release;..\..\Packages\directxmesh_desktop_win10.2019.2.7.1\lib\x64\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<AdditionalDependencies>zlibstatic.lib;DirectXMesh.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<AdditionalDependencies Condition="'$(Platform)'=='x64'">DirectXTex.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<SubSystem>Console</SubSystem>
-			<EntryPointSymbol>wWinMainCRTStartup</EntryPointSymbol>
-			<MinimumRequiredVersion>10</MinimumRequiredVersion>
-		</Link>
-		<ClCompile>
-			<LanguageStandard>stdcpp20</LanguageStandard>
-		</ClCompile>
-	</ItemDefinitionGroup>
-	<ItemGroup>
-		<ClCompile Include="CpuPerformance.cpp" />
-		<ClCompile Include="DStorageLoader.cpp" />
-		<ClCompile Include="BulkLoadDemo.cpp" />
-		<ClCompile Include="MarcFile.cpp" />
-		<ClCompile Include="MarcFileManager.cpp" />
-		<ClInclude Include="CpuPerformance.h" />
-		<ClInclude Include="DStorageLoader.h" />
-		<ClInclude Include="MarcFile.h" />
-		<ClInclude Include="MarcFileFormat.h" />
-		<ClInclude Include="MarcFileManager.h" />
-		<ClInclude Include="MemoryRegion.h" />
-		<ClInclude Include="MultiHeap.h" />
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="../Core/Core.vcxproj">
-			<Project>{86A58508-0D6A-4786-A32F-01A301FDC6F3}</Project>
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		</ProjectReference>
-		<ProjectReference Include="..\MiniArchive\MiniArchive.vcxproj">
-			<Project>{a2631beb-8f09-4d0f-a729-f4470d765fc6}</Project>
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		</ProjectReference>
-		<ProjectReference Include="..\Model\Model.vcxproj">
-			<Project>{5d3aeefb-8789-48e5-9bd9-09c667052d09}</Project>
-		</ProjectReference>
-	</ItemGroup>
-	<ItemGroup>
-		<CopyFileToFolders Include="Textures\Stonewall_diffuseIBL.dds">
-			<DeploymentContent>true</DeploymentContent>
-			<DestinationFileName>%(RelativeDir)%(Filename)%(Extension)</DestinationFileName>
-		</CopyFileToFolders>
-		<CopyFileToFolders Include="Textures\Stonewall_specularIBL.dds">
-			<DeploymentContent>true</DeploymentContent>
-			<DestinationFileName>%(RelativeDir)%(Filename)%(Extension)</DestinationFileName>
-		</CopyFileToFolders>
-		<MarcFile Include="SampleModel/Avocado.gltf">
-			<Options>-gdeflate -bc</Options>
-		</MarcFile>
-	</ItemGroup>
-	<ItemGroup>
-		<None Include="packages.config" />
-	</ItemGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-	<PropertyGroup>
-		<MiniArchive>$(OutDir)../miniarchive/miniarchive.exe</MiniArchive>
-	</PropertyGroup>
-	<Target Name="BuildMarcFiles" AfterTargets="PrepareForBuild" Inputs="@(MarcFile);$(MiniArchive)" Outputs="@(MarcFile -> '$(OutDir)%(Filename).marc')">
-		<Exec Command="@(MarcFile -> '&quot;$(MiniArchive)&quot; &quot;%(Identity)&quot; &quot;$(OutDir)%(Filename).marc&quot; %(Options)')" />
-	</Target>
-	<ImportGroup Label="ExtensionTargets">
-		<Import Project="..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
-		<Import Project="..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
-		<Import Project="..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets" Condition="Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" />
-		<Import Project="..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets" Condition="Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" />
-		<Import Project="..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets" Condition="Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" />
-		<Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
-		<Import Project="..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets" Condition="Exists('..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" />
-	</ImportGroup>
-	<Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-		<PropertyGroup>
-			<ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-		</PropertyGroup>
-		<Error Condition="!Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
-		<Error Condition="!Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
-		<Error Condition="!Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets'))" />
-		<Error Condition="!Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets'))" />
-		<Error Condition="!Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets'))" />
-		<Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
-		<Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-		<Error Condition="!Exists('..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets'))" />
-	</Target>
+    <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.props')" />
+    <ItemGroup Label="ProjectConfigurations">
+        <ProjectConfiguration Include="Debug|x64">
+            <Configuration>Debug</Configuration>
+            <Platform>x64</Platform>
+        </ProjectConfiguration>
+        <ProjectConfiguration Include="Profile|x64">
+            <Configuration>Profile</Configuration>
+            <Platform>x64</Platform>
+        </ProjectConfiguration>
+        <ProjectConfiguration Include="Release|x64">
+            <Configuration>Release</Configuration>
+            <Platform>x64</Platform>
+        </ProjectConfiguration>
+    </ItemGroup>
+    <PropertyGroup Label="Globals">
+        <RootNamespace>BulkLoadDemo</RootNamespace>
+        <ProjectGuid>{613E12A8-A3E7-441B-815A-14F757684DAF}</ProjectGuid>
+        <DefaultLanguage>en-US</DefaultLanguage>
+        <Keyword>Win32Proj</Keyword>
+        <PlatformToolset>v142</PlatformToolset>
+        <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
+        <TargetRuntime>Native</TargetRuntime>
+        <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    </PropertyGroup>
+    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+    <PropertyGroup Label="Configuration">
+        <ConfigurationType>Application</ConfigurationType>
+        <PlatformToolset>v142</PlatformToolset>
+        <CharacterSet>Unicode</CharacterSet>
+        <EmbedManifest>false</EmbedManifest>
+    </PropertyGroup>
+    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+    <ImportGroup Label="ExtensionSettings" />
+    <ImportGroup Label="PropertySheets">
+        <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+        <Import Project="..\PropertySheets\Build.props" />
+    </ImportGroup>
+    <ImportGroup Condition="'$(Platform)'=='x64'" Label="PropertySheets">
+        <Import Project="..\PropertySheets\Desktop.props" />
+    </ImportGroup>
+    <PropertyGroup Label="UserMacros" />
+    <ItemDefinitionGroup>
+        <ClCompile>
+            <AdditionalIncludeDirectories>..\Model;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+        </ClCompile>
+        <Link Condition="'$(Configuration)'=='Debug'">
+            <AdditionalOptions>/nodefaultlib:MSVCRT %(AdditionalOptions)</AdditionalOptions>
+        </Link>
+    </ItemDefinitionGroup>
+    <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
+        <Link>
+            <AdditionalDependencies>
+                kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)
+            </AdditionalDependencies>
+        </Link>
+    </ItemDefinitionGroup>
+    <ItemDefinitionGroup>
+        <Link>
+            <AdditionalLibraryDirectories>..\..\Packages\zlib-msvc-x64.1.2.11.8900\build\native\lib_release;..\..\Packages\directxtex_desktop_win10.2019.2.7.1\lib\x64\Release;..\..\Packages\directxmesh_desktop_win10.2019.2.7.1\lib\x64\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+            <AdditionalDependencies>zlibstatic.lib;DirectXMesh.lib;%(AdditionalDependencies)</AdditionalDependencies>
+            <AdditionalDependencies Condition="'$(Platform)'=='x64'">DirectXTex.lib;%(AdditionalDependencies)</AdditionalDependencies>
+            <SubSystem>Console</SubSystem>
+            <EntryPointSymbol>wWinMainCRTStartup</EntryPointSymbol>
+            <MinimumRequiredVersion>10</MinimumRequiredVersion>
+        </Link>
+        <ClCompile>
+            <LanguageStandard>stdcpp20</LanguageStandard>
+        </ClCompile>
+    </ItemDefinitionGroup>
+    <ItemGroup>
+        <ClCompile Include="CpuPerformance.cpp" />
+        <ClCompile Include="DStorageLoader.cpp" />
+        <ClCompile Include="BulkLoadDemo.cpp" />
+        <ClCompile Include="MarcFile.cpp" />
+        <ClCompile Include="MarcFileManager.cpp" />
+        <ClInclude Include="CpuPerformance.h" />
+        <ClInclude Include="DStorageLoader.h" />
+        <ClInclude Include="MarcFile.h" />
+        <ClInclude Include="MarcFileFormat.h" />
+        <ClInclude Include="MarcFileManager.h" />
+        <ClInclude Include="MemoryRegion.h" />
+        <ClInclude Include="MultiHeap.h" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="../Core/Core.vcxproj">
+            <Project>{86A58508-0D6A-4786-A32F-01A301FDC6F3}</Project>
+            <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+        </ProjectReference>
+        <ProjectReference Include="..\MiniArchive\MiniArchive.vcxproj">
+            <Project>{a2631beb-8f09-4d0f-a729-f4470d765fc6}</Project>
+            <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+        </ProjectReference>
+        <ProjectReference Include="..\Model\Model.vcxproj">
+            <Project>{5d3aeefb-8789-48e5-9bd9-09c667052d09}</Project>
+        </ProjectReference>
+    </ItemGroup>
+    <ItemGroup>
+        <CopyFileToFolders Include="Textures\Stonewall_diffuseIBL.dds">
+            <DeploymentContent>true</DeploymentContent>
+            <DestinationFileName>%(RelativeDir)%(Filename)%(Extension)</DestinationFileName>
+        </CopyFileToFolders>
+        <CopyFileToFolders Include="Textures\Stonewall_specularIBL.dds">
+            <DeploymentContent>true</DeploymentContent>
+            <DestinationFileName>%(RelativeDir)%(Filename)%(Extension)</DestinationFileName>
+        </CopyFileToFolders>
+        <MarcFile Include="SampleModel/Avocado.gltf">
+            <Options>-gdeflate -bc</Options>
+        </MarcFile>
+    </ItemGroup>
+    <ItemGroup>
+        <None Include="packages.config" />
+    </ItemGroup>
+    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+    <PropertyGroup>
+        <MiniArchive>$(OutDir)../miniarchive/miniarchive.exe</MiniArchive>
+    </PropertyGroup>
+    <Target Name="BuildMarcFiles" AfterTargets="PrepareForBuild" Inputs="@(MarcFile);$(MiniArchive)" Outputs="@(MarcFile -> '$(OutDir)%(Filename).marc')">
+        <Exec Command="@(MarcFile -> '&quot;$(MiniArchive)&quot; &quot;%(Identity)&quot; &quot;$(OutDir)%(Filename).marc&quot; %(Options)')" />
+    </Target>
+    <ImportGroup Label="ExtensionTargets">
+        <Import Project="..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
+        <Import Project="..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+        <Import Project="..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets" Condition="Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" />
+        <Import Project="..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets" Condition="Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" />
+        <Import Project="..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets" Condition="Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" />
+        <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
+        <Import Project="..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets" Condition="Exists('..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" />
+    </ImportGroup>
+    <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+        <PropertyGroup>
+            <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+        </PropertyGroup>
+        <Error Condition="!Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
+        <Error Condition="!Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+        <Error Condition="!Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets'))" />
+        <Error Condition="!Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets'))" />
+        <Error Condition="!Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets'))" />
+        <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
+        <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.220912.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+        <Error Condition="!Exists('..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets'))" />
+    </Target>
 </Project>

--- a/Samples/BulkLoadDemo/BulkLoadDemo/BulkLoadDemo.vcxproj
+++ b/Samples/BulkLoadDemo/BulkLoadDemo/BulkLoadDemo.vcxproj
@@ -23,7 +23,7 @@
     <PlatformToolset>v142</PlatformToolset>
     <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
     <TargetRuntime>Native</TargetRuntime>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">

--- a/Samples/BulkLoadDemo/BulkLoadDemo/BulkLoadDemo.vcxproj
+++ b/Samples/BulkLoadDemo/BulkLoadDemo/BulkLoadDemo.vcxproj
@@ -23,12 +23,12 @@
     <PlatformToolset>v142</PlatformToolset>
     <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
     <TargetRuntime>Native</TargetRuntime>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <EmbedManifest>false</EmbedManifest>
   </PropertyGroup>

--- a/Samples/BulkLoadDemo/Core/Core.vcxproj
+++ b/Samples/BulkLoadDemo/Core/Core.vcxproj
@@ -20,7 +20,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <Keyword>Win32Proj</Keyword>
     <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <TargetRuntime>Native</TargetRuntime>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/Samples/BulkLoadDemo/Core/Core.vcxproj
+++ b/Samples/BulkLoadDemo/Core/Core.vcxproj
@@ -20,13 +20,13 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <Keyword>Win32Proj</Keyword>
     <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <TargetRuntime>Native</TargetRuntime>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <EmbedManifest>false</EmbedManifest>
     <GenerateManifest>false</GenerateManifest>

--- a/Samples/BulkLoadDemo/Core/Core.vcxproj
+++ b/Samples/BulkLoadDemo/Core/Core.vcxproj
@@ -26,7 +26,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <EmbedManifest>false</EmbedManifest>
     <GenerateManifest>false</GenerateManifest>

--- a/Samples/BulkLoadDemo/Core/Core.vcxproj
+++ b/Samples/BulkLoadDemo/Core/Core.vcxproj
@@ -1,454 +1,454 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <ItemGroup Label="ProjectConfigurations">
-        <ProjectConfiguration Include="Debug|x64">
-            <Configuration>Debug</Configuration>
-            <Platform>x64</Platform>
-        </ProjectConfiguration>
-        <ProjectConfiguration Include="Profile|x64">
-            <Configuration>Profile</Configuration>
-            <Platform>x64</Platform>
-        </ProjectConfiguration>
-        <ProjectConfiguration Include="Release|x64">
-            <Configuration>Release</Configuration>
-            <Platform>x64</Platform>
-        </ProjectConfiguration>
-    </ItemGroup>
-    <PropertyGroup Label="Globals">
-        <RootNamespace>Core</RootNamespace>
-        <ProjectGuid>{86A58508-0D6A-4786-A32F-01A301FDC6F3}</ProjectGuid>
-        <DefaultLanguage>en-US</DefaultLanguage>
-        <Keyword>Win32Proj</Keyword>
-        <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
-        <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-        <TargetRuntime>Native</TargetRuntime>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Profile|x64">
+      <Configuration>Profile</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <RootNamespace>Core</RootNamespace>
+    <ProjectGuid>{86A58508-0D6A-4786-A32F-01A301FDC6F3}</ProjectGuid>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <Keyword>Win32Proj</Keyword>
+    <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <TargetRuntime>Native</TargetRuntime>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <EmbedManifest>false</EmbedManifest>
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\PropertySheets\Build.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Platform)'=='x64'" Label="PropertySheets">
+    <Import Project="..\PropertySheets\Desktop.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
+    <Link>
+      <AdditionalDependencies>d3d11.lib;dxguid.lib;winmm.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Windows</SubSystem>
+      <DataExecutionPrevention>true</DataExecutionPrevention>
+    </Link>
+    <Manifest>
+      <EnableDPIAwareness>true</EnableDPIAwareness>
+    </Manifest>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="BitonicSort.h" />
+    <ClInclude Include="BuddyAllocator.h" />
+    <ClInclude Include="BufferManager.h" />
+    <ClInclude Include="Camera.h" />
+    <ClInclude Include="CameraController.h" />
+    <ClInclude Include="Color.h" />
+    <ClInclude Include="ColorBuffer.h" />
+    <ClInclude Include="CommandAllocatorPool.h" />
+    <ClInclude Include="CommandContext.h" />
+    <ClInclude Include="CommandListManager.h" />
+    <ClInclude Include="CommandSignature.h" />
+    <ClInclude Include="d3dx12.h" />
+    <ClInclude Include="dds.h" />
+    <ClInclude Include="DDSTextureLoader.h" />
+    <ClInclude Include="DepthBuffer.h" />
+    <ClInclude Include="DepthOfField.h" />
+    <ClInclude Include="DynamicDescriptorHeap.h" />
+    <ClInclude Include="DescriptorHeap.h" />
+    <ClInclude Include="GpuBuffer.h" />
+    <ClInclude Include="EngineProfiling.h" />
+    <ClInclude Include="EsramAllocator.h" />
+    <ClInclude Include="FileUtility.h" />
+    <ClInclude Include="FXAA.h" />
+    <ClInclude Include="GameInput.h" />
+    <ClInclude Include="GpuResource.h" />
+    <ClInclude Include="GpuTimeManager.h" />
+    <ClInclude Include="GameCore.h" />
+    <ClInclude Include="GraphicsCommon.h" />
+    <ClInclude Include="GraphicsCore.h" />
+    <ClInclude Include="GraphRenderer.h" />
+    <ClInclude Include="Hash.h" />
+    <ClInclude Include="ImageScaling.h" />
+    <ClInclude Include="LinearAllocator.h" />
+    <ClInclude Include="Math\BoundingBox.h" />
+    <ClInclude Include="Math\BoundingPlane.h" />
+    <ClInclude Include="Math\BoundingSphere.h" />
+    <ClInclude Include="Math\Common.h" />
+    <ClInclude Include="Math\Frustum.h" />
+    <ClInclude Include="Math\Matrix3.h" />
+    <ClInclude Include="Math\Matrix4.h" />
+    <ClInclude Include="Math\Quaternion.h" />
+    <ClInclude Include="Math\Random.h" />
+    <ClInclude Include="Math\Scalar.h" />
+    <ClInclude Include="Math\Transform.h" />
+    <ClInclude Include="Math\Vector.h" />
+    <ClInclude Include="MotionBlur.h" />
+    <ClInclude Include="ParticleEffect.h" />
+    <ClInclude Include="ParticleEffectManager.h" />
+    <ClInclude Include="ParticleEffectProperties.h" />
+    <ClInclude Include="ParticleShaderStructs.h" />
+    <ClInclude Include="pch.h" />
+    <ClInclude Include="PipelineState.h" />
+    <ClInclude Include="PixelBuffer.h" />
+    <ClInclude Include="PostEffects.h" />
+    <ClInclude Include="EngineTuning.h" />
+    <ClInclude Include="Display.h" />
+    <ClInclude Include="ReadbackBuffer.h" />
+    <ClInclude Include="RootSignature.h" />
+    <ClInclude Include="SamplerManager.h" />
+    <ClInclude Include="ShadowBuffer.h" />
+    <ClInclude Include="ShadowCamera.h" />
+    <ClInclude Include="SSAO.h" />
+    <ClInclude Include="SystemTime.h" />
+    <ClInclude Include="TemporalEffects.h" />
+    <ClInclude Include="TextRenderer.h" />
+    <ClInclude Include="Texture.h" />
+    <ClInclude Include="TextureManager.h" />
+    <ClInclude Include="UploadBuffer.h" />
+    <ClInclude Include="Utility.h" />
+    <ClInclude Include="Util\CommandLineArg.h" />
+    <ClInclude Include="VectorMath.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="BitonicSort.cpp" />
+    <ClCompile Include="BuddyAllocator.cpp" />
+    <ClCompile Include="BufferManager.cpp" />
+    <ClCompile Include="Camera.cpp" />
+    <ClCompile Include="CameraController.cpp" />
+    <ClCompile Include="Color.cpp" />
+    <ClCompile Include="ColorBuffer.cpp" />
+    <ClCompile Include="CommandAllocatorPool.cpp" />
+    <ClCompile Include="CommandContext.cpp" />
+    <ClCompile Include="CommandListManager.cpp" />
+    <ClCompile Include="CommandSignature.cpp" />
+    <ClCompile Include="DDSTextureLoader.cpp" />
+    <ClCompile Include="DepthBuffer.cpp" />
+    <ClCompile Include="DepthOfField.cpp" />
+    <ClCompile Include="DynamicDescriptorHeap.cpp" />
+    <ClCompile Include="DescriptorHeap.cpp" />
+    <ClCompile Include="EngineProfiling.cpp" />
+    <ClCompile Include="EngineTuning.cpp" />
+    <ClCompile Include="FileUtility.cpp" />
+    <ClCompile Include="FXAA.cpp" />
+    <ClCompile Include="Input.cpp" />
+    <ClCompile Include="GameCore.cpp" />
+    <ClCompile Include="GpuBuffer.cpp" />
+    <ClCompile Include="GpuTimeManager.cpp" />
+    <ClCompile Include="GraphicsCommon.cpp" />
+    <ClCompile Include="GraphicsCore.cpp" />
+    <ClCompile Include="GraphRenderer.cpp" />
+    <ClCompile Include="ImageScaling.cpp" />
+    <ClCompile Include="LinearAllocator.cpp" />
+    <ClCompile Include="Math\BoundingSphere.cpp" />
+    <ClCompile Include="Math\Frustum.cpp" />
+    <ClCompile Include="Math\Random.cpp" />
+    <ClCompile Include="MotionBlur.cpp" />
+    <ClCompile Include="ParticleEffect.cpp" />
+    <ClCompile Include="ParticleEffectManager.cpp" />
+    <ClCompile Include="ParticleEmissionProperties.cpp" />
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="PipelineState.cpp" />
+    <ClCompile Include="PixelBuffer.cpp" />
+    <ClCompile Include="PostEffects.cpp" />
+    <ClCompile Include="Display.cpp" />
+    <ClCompile Include="ReadbackBuffer.cpp" />
+    <ClCompile Include="RootSignature.cpp" />
+    <ClCompile Include="SamplerManager.cpp" />
+    <ClCompile Include="ShadowBuffer.cpp" />
+    <ClCompile Include="ShadowCamera.cpp" />
+    <ClCompile Include="SSAO.cpp" />
+    <ClCompile Include="SystemTime.cpp" />
+    <ClCompile Include="TemporalEffects.cpp" />
+    <ClCompile Include="TextRenderer.cpp" />
+    <ClCompile Include="Texture.cpp" />
+    <ClCompile Include="TextureManager.cpp" />
+    <ClCompile Include="UploadBuffer.cpp" />
+    <ClCompile Include="Utility.cpp" />
+    <ClCompile Include="Util\CommandLineArg.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <FxCompile Include="Shaders\AdaptExposureCS.hlsl" />
+    <FxCompile Include="Shaders\AoBlurUpsampleBlendOutCS.hlsl" />
+    <FxCompile Include="Shaders\AoBlurUpsampleCS.hlsl" />
+    <FxCompile Include="Shaders\AoBlurUpsamplePreMinBlendOutCS.hlsl" />
+    <FxCompile Include="Shaders\AoBlurUpsamplePreMinCS.hlsl" />
+    <FxCompile Include="Shaders\AoPrepareDepthBuffers1CS.hlsl" />
+    <FxCompile Include="Shaders\AoPrepareDepthBuffers2CS.hlsl" />
+    <FxCompile Include="Shaders\AoRender1CS.hlsl" />
+    <FxCompile Include="Shaders\AoRender2CS.hlsl" />
+    <FxCompile Include="Shaders\ApplyBloom2CS.hlsl" />
+    <FxCompile Include="Shaders\ApplyBloomCS.hlsl" />
+    <FxCompile Include="Shaders\AverageLumaCS.hlsl" />
+    <FxCompile Include="Shaders\BicubicHorizontalUpsamplePS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\BicubicUpsampleCS.hlsl" />
+    <FxCompile Include="Shaders\BicubicUpsampleFast16CS.hlsl" />
+    <FxCompile Include="Shaders\BicubicUpsampleFast24CS.hlsl" />
+    <FxCompile Include="Shaders\BicubicUpsampleFast32CS.hlsl" />
+    <FxCompile Include="Shaders\BicubicUpsampleGammaPS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\BicubicUpsamplePS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\BicubicVerticalUpsamplePS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\BilinearUpsamplePS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\Bitonic32InnerSortCS.hlsl" />
+    <FxCompile Include="Shaders\Bitonic32OuterSortCS.hlsl" />
+    <FxCompile Include="Shaders\Bitonic32PreSortCS.hlsl" />
+    <FxCompile Include="Shaders\Bitonic64InnerSortCS.hlsl" />
+    <FxCompile Include="Shaders\Bitonic64OuterSortCS.hlsl" />
+    <FxCompile Include="Shaders\Bitonic64PreSortCS.hlsl" />
+    <FxCompile Include="Shaders\BitonicIndirectArgsCS.hlsl" />
+    <FxCompile Include="Shaders\BlendUIHDRPS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\BloomExtractAndDownsampleHdrCS.hlsl" />
+    <FxCompile Include="Shaders\BloomExtractAndDownsampleLdrCS.hlsl" />
+    <FxCompile Include="Shaders\BlurCS.hlsl" />
+    <FxCompile Include="Shaders\BoundNeighborhoodCS.hlsl" />
+    <FxCompile Include="Shaders\BufferCopyPS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\CameraMotionBlurPrePassCS.hlsl" />
+    <FxCompile Include="Shaders\CameraMotionBlurPrePassLinearZCS.hlsl" />
+    <FxCompile Include="Shaders\CameraVelocityCS.hlsl" />
+    <FxCompile Include="Shaders\CompositeHDRPS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\CompositeSDRPS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\CopyBackPostBufferCS.hlsl" />
+    <FxCompile Include="Shaders\DebugDrawHistogramCS.hlsl" />
+    <FxCompile Include="Shaders\DebugLuminanceHdr2CS.hlsl" />
+    <FxCompile Include="Shaders\DebugLuminanceHdrCS.hlsl" />
+    <FxCompile Include="Shaders\DebugLuminanceLdr2CS.hlsl" />
+    <FxCompile Include="Shaders\DebugLuminanceLdrCS.hlsl" />
+    <FxCompile Include="Shaders\DebugSSAOCS.hlsl" />
+    <FxCompile Include="Shaders\DoFCombine2CS.hlsl" />
+    <FxCompile Include="Shaders\DoFCombineCS.hlsl" />
+    <FxCompile Include="Shaders\DoFCombineFast2CS.hlsl" />
+    <FxCompile Include="Shaders\DoFCombineFastCS.hlsl" />
+    <FxCompile Include="Shaders\DoFDebugBlueCS.hlsl" />
+    <FxCompile Include="Shaders\DoFDebugGreenCS.hlsl" />
+    <FxCompile Include="Shaders\DoFDebugRedCS.hlsl" />
+    <FxCompile Include="Shaders\DoFMedianFilterCS.hlsl" />
+    <FxCompile Include="Shaders\DoFMedianFilterFixupCS.hlsl" />
+    <FxCompile Include="Shaders\DoFMedianFilterSepAlphaCS.hlsl" />
+    <FxCompile Include="Shaders\DoFPass1CS.hlsl" />
+    <FxCompile Include="Shaders\DoFPass2CS.hlsl" />
+    <FxCompile Include="Shaders\DoFPass2DebugCS.hlsl" />
+    <FxCompile Include="Shaders\DoFPass2FastCS.hlsl" />
+    <FxCompile Include="Shaders\DoFPass2FixupCS.hlsl" />
+    <FxCompile Include="Shaders\DoFPreFilterCS.hlsl" />
+    <FxCompile Include="Shaders\DoFPreFilterFastCS.hlsl" />
+    <FxCompile Include="Shaders\DoFPreFilterFixupCS.hlsl" />
+    <FxCompile Include="Shaders\DoFTilePassCS.hlsl" />
+    <FxCompile Include="Shaders\DoFTilePassFixupCS.hlsl" />
+    <FxCompile Include="Shaders\DownsampleBloomAllCS.hlsl" />
+    <FxCompile Include="Shaders\DownsampleBloomCS.hlsl" />
+    <FxCompile Include="Shaders\DownsampleDepthPS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\ExtractLumaCS.hlsl" />
+    <FxCompile Include="Shaders\FXAAPass1_Luma2_CS.hlsl" />
+    <FxCompile Include="Shaders\FXAAPass1_Luma_CS.hlsl" />
+    <FxCompile Include="Shaders\FXAAPass1_RGB2_CS.hlsl" />
+    <FxCompile Include="Shaders\FXAAPass1_RGB_CS.hlsl" />
+    <FxCompile Include="Shaders\FXAAPass2H2CS.hlsl" />
+    <FxCompile Include="Shaders\FXAAPass2HDebug2CS.hlsl" />
+    <FxCompile Include="Shaders\FXAAPass2HDebugCS.hlsl" />
+    <FxCompile Include="Shaders\FXAAPass2V2CS.hlsl" />
+    <FxCompile Include="Shaders\FXAAPass2VDebug2CS.hlsl" />
+    <FxCompile Include="Shaders\FXAAPass2VDebugCS.hlsl" />
+    <FxCompile Include="Shaders\GenerateHistogramCS.hlsl" />
+    <FxCompile Include="Shaders\FXAAPass2HCS.hlsl" />
+    <FxCompile Include="Shaders\FXAAPass2VCS.hlsl" />
+    <FxCompile Include="Shaders\GenerateMipsGammaCS.hlsl" />
+    <FxCompile Include="Shaders\GenerateMipsGammaOddCS.hlsl" />
+    <FxCompile Include="Shaders\GenerateMipsGammaOddXCS.hlsl" />
+    <FxCompile Include="Shaders\GenerateMipsGammaOddYCS.hlsl" />
+    <FxCompile Include="Shaders\GenerateMipsLinearCS.hlsl" />
+    <FxCompile Include="Shaders\GenerateMipsLinearOddCS.hlsl" />
+    <FxCompile Include="Shaders\GenerateMipsLinearOddXCS.hlsl" />
+    <FxCompile Include="Shaders\GenerateMipsLinearOddYCS.hlsl" />
+    <FxCompile Include="Shaders\LanczosCS.hlsl" />
+    <FxCompile Include="Shaders\LanczosFast16CS.hlsl" />
+    <FxCompile Include="Shaders\LanczosFast24CS.hlsl" />
+    <FxCompile Include="Shaders\LanczosFast32CS.hlsl" />
+    <FxCompile Include="Shaders\LanczosHorizontalPS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\LanczosVerticalPS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\LinearizeDepthCS.hlsl" />
+    <FxCompile Include="Shaders\MagnifyPixelsPS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\MotionBlurFinalPassCS.hlsl" />
+    <FxCompile Include="Shaders\MotionBlurFinalPassPS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\MotionBlurPrePassCS.hlsl" />
+    <FxCompile Include="Shaders\FXAAResolveWorkQueueCS.hlsl" />
+    <FxCompile Include="Shaders\ParticleBinCullingCS.hlsl" />
+    <FxCompile Include="Shaders\ParticleDepthBoundsCS.hlsl" />
+    <FxCompile Include="Shaders\ParticleDispatchIndirectArgsCS.hlsl" />
+    <FxCompile Include="Shaders\ParticleFinalDispatchIndirectArgsCS.hlsl" />
+    <FxCompile Include="Shaders\ParticleLargeBinCullingCS.hlsl" />
+    <FxCompile Include="Shaders\ParticleNoSortVS.hlsl">
+      <ShaderType>Vertex</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\ParticlePreSortCS.hlsl" />
+    <FxCompile Include="Shaders\ParticlePS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\ParticleSortIndirectArgsCS.hlsl" />
+    <FxCompile Include="Shaders\ParticleSpawnCS.hlsl" />
+    <FxCompile Include="Shaders\ParticleTileCullingCS.hlsl" />
+    <FxCompile Include="Shaders\ParticleTileRender2CS.hlsl" />
+    <FxCompile Include="Shaders\ParticleTileRenderCS.hlsl" />
+    <FxCompile Include="Shaders\ParticleTileRenderFast2CS.hlsl" />
+    <FxCompile Include="Shaders\ParticleTileRenderFastCS.hlsl" />
+    <FxCompile Include="Shaders\ParticleTileRenderFastDynamic2CS.hlsl" />
+    <FxCompile Include="Shaders\ParticleTileRenderFastDynamicCS.hlsl" />
+    <FxCompile Include="Shaders\ParticleTileRenderFastLowRes2CS.hlsl" />
+    <FxCompile Include="Shaders\ParticleTileRenderFastLowResCS.hlsl" />
+    <FxCompile Include="Shaders\ParticleTileRenderSlowDynamic2CS.hlsl" />
+    <FxCompile Include="Shaders\ParticleTileRenderSlowDynamicCS.hlsl" />
+    <FxCompile Include="Shaders\ParticleTileRenderSlowLowRes2CS.hlsl" />
+    <FxCompile Include="Shaders\ParticleTileRenderSlowLowResCS.hlsl" />
+    <FxCompile Include="Shaders\ParticleUpdateCS.hlsl" />
+    <FxCompile Include="Shaders\ParticleVS.hlsl">
+      <ShaderType>Vertex</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\PerfGraphBackgroundVS.hlsl">
+      <ShaderType>Vertex</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\PerfGraphPS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\PerfGraphVS.hlsl">
+      <ShaderType>Vertex</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\PresentHDRPS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\PresentSDRPS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\ResolveTAACS.hlsl" />
+    <FxCompile Include="Shaders\ScaleAndCompositeHDRPS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\ScaleAndCompositeSDRPS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\ScreenQuadCommonVS.hlsl">
+      <ShaderType>Vertex</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\ScreenQuadPresentVS.hlsl">
+      <ShaderType>Vertex</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\SharpeningUpsampleGammaPS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\SharpeningUpsamplePS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\SharpenTAACS.hlsl" />
+    <FxCompile Include="Shaders\TemporalBlendCS.hlsl" />
+    <FxCompile Include="Shaders\TextAntialiasPS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\TextShadowPS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\TextVS.hlsl">
+      <ShaderType>Vertex</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\ToneMapHDR2CS.hlsl" />
+    <FxCompile Include="Shaders\ToneMapHDRCS.hlsl" />
+    <None Include="Math\Functions.inl" />
+    <None Include="packages.config" />
+    <None Include="Shaders\AoBlurAndUpsampleCS.hlsli" />
+    <None Include="Shaders\AoRenderCS.hlsli" />
+    <None Include="Shaders\BicubicFilterFunctions.hlsli" />
+    <None Include="Shaders\BitonicSortCommon.hlsli" />
+    <None Include="Shaders\ColorSpaceUtility.hlsli" />
+    <None Include="Shaders\CommonRS.hlsli" />
+    <None Include="Shaders\DoFCommon.hlsli" />
+    <None Include="Shaders\DoFRS.hlsli" />
+    <None Include="Shaders\FXAAPass1CS.hlsli" />
+    <None Include="Shaders\FXAAPass2CS.hlsli" />
+    <None Include="Shaders\FXAARootSignature.hlsli" />
+    <None Include="Shaders\GenerateMipsCS.hlsli" />
+    <None Include="Shaders\LanczosFunctions.hlsli" />
+    <None Include="Shaders\MotionBlurRS.hlsli" />
+    <None Include="Shaders\ParticleRS.hlsli" />
+    <None Include="Shaders\ParticleUpdateCommon.hlsli" />
+    <None Include="Shaders\ParticleUtility.hlsli" />
+    <None Include="Shaders\PerfGraphRS.hlsli" />
+    <None Include="Shaders\PixelPacking_R11G11B10.hlsli" />
+    <None Include="Shaders\PixelPacking_RGBE.hlsli" />
+    <None Include="Shaders\PixelPacking_RGBM.hlsli" />
+    <None Include="Shaders\PostEffectsRS.hlsli" />
+    <None Include="Shaders\PresentRS.hlsli" />
+    <None Include="Shaders\ShaderUtility.hlsli" />
+    <FxCompile Include="Shaders\ToneMap2CS.hlsl" />
+    <FxCompile Include="Shaders\ToneMapCS.hlsl" />
+    <FxCompile Include="Shaders\UpsampleAndBlurCS.hlsl" />
+    <None Include="Shaders\PixelPacking.hlsli" />
+    <None Include="Shaders\SSAORS.hlsli" />
+    <None Include="Shaders\TextRS.hlsli" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\Packages\zlib-msvc-x64.1.2.11.8900\build\native\include;..\..\Packages\WinPixEventRuntime.1.0.210209001\Include\WinPixEventRuntime;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_GAMING_DESKTOP;__WRL_NO_DEFAULT_LIB__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
+    <Import Project="..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets" Condition="Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-    <PropertyGroup Label="Configuration">
-        <ConfigurationType>StaticLibrary</ConfigurationType>
-        <PlatformToolset>v142</PlatformToolset>
-        <CharacterSet>Unicode</CharacterSet>
-        <EmbedManifest>false</EmbedManifest>
-        <GenerateManifest>false</GenerateManifest>
-    </PropertyGroup>
-    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-    <ImportGroup Label="ExtensionSettings" />
-    <ImportGroup Label="PropertySheets">
-        <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-        <Import Project="..\PropertySheets\Build.props" />
-    </ImportGroup>
-    <ImportGroup Condition="'$(Platform)'=='x64'" Label="PropertySheets">
-        <Import Project="..\PropertySheets\Desktop.props" />
-    </ImportGroup>
-    <PropertyGroup Label="UserMacros" />
-    <ItemDefinitionGroup>
-        <ClCompile>
-            <PrecompiledHeader>Use</PrecompiledHeader>
-            <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-            <RuntimeTypeInfo>true</RuntimeTypeInfo>
-        </ClCompile>
-    </ItemDefinitionGroup>
-    <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
-        <Link>
-            <AdditionalDependencies>d3d11.lib;dxguid.lib;winmm.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-            <SubSystem>Windows</SubSystem>
-            <DataExecutionPrevention>true</DataExecutionPrevention>
-        </Link>
-        <Manifest>
-            <EnableDPIAwareness>true</EnableDPIAwareness>
-        </Manifest>
-    </ItemDefinitionGroup>
-    <ItemGroup>
-        <ClInclude Include="BitonicSort.h" />
-        <ClInclude Include="BuddyAllocator.h" />
-        <ClInclude Include="BufferManager.h" />
-        <ClInclude Include="Camera.h" />
-        <ClInclude Include="CameraController.h" />
-        <ClInclude Include="Color.h" />
-        <ClInclude Include="ColorBuffer.h" />
-        <ClInclude Include="CommandAllocatorPool.h" />
-        <ClInclude Include="CommandContext.h" />
-        <ClInclude Include="CommandListManager.h" />
-        <ClInclude Include="CommandSignature.h" />
-        <ClInclude Include="d3dx12.h" />
-        <ClInclude Include="dds.h" />
-        <ClInclude Include="DDSTextureLoader.h" />
-        <ClInclude Include="DepthBuffer.h" />
-        <ClInclude Include="DepthOfField.h" />
-        <ClInclude Include="DynamicDescriptorHeap.h" />
-        <ClInclude Include="DescriptorHeap.h" />
-        <ClInclude Include="GpuBuffer.h" />
-        <ClInclude Include="EngineProfiling.h" />
-        <ClInclude Include="EsramAllocator.h" />
-        <ClInclude Include="FileUtility.h" />
-        <ClInclude Include="FXAA.h" />
-        <ClInclude Include="GameInput.h" />
-        <ClInclude Include="GpuResource.h" />
-        <ClInclude Include="GpuTimeManager.h" />
-        <ClInclude Include="GameCore.h" />
-        <ClInclude Include="GraphicsCommon.h" />
-        <ClInclude Include="GraphicsCore.h" />
-        <ClInclude Include="GraphRenderer.h" />
-        <ClInclude Include="Hash.h" />
-        <ClInclude Include="ImageScaling.h" />
-        <ClInclude Include="LinearAllocator.h" />
-        <ClInclude Include="Math\BoundingBox.h" />
-        <ClInclude Include="Math\BoundingPlane.h" />
-        <ClInclude Include="Math\BoundingSphere.h" />
-        <ClInclude Include="Math\Common.h" />
-        <ClInclude Include="Math\Frustum.h" />
-        <ClInclude Include="Math\Matrix3.h" />
-        <ClInclude Include="Math\Matrix4.h" />
-        <ClInclude Include="Math\Quaternion.h" />
-        <ClInclude Include="Math\Random.h" />
-        <ClInclude Include="Math\Scalar.h" />
-        <ClInclude Include="Math\Transform.h" />
-        <ClInclude Include="Math\Vector.h" />
-        <ClInclude Include="MotionBlur.h" />
-        <ClInclude Include="ParticleEffect.h" />
-        <ClInclude Include="ParticleEffectManager.h" />
-        <ClInclude Include="ParticleEffectProperties.h" />
-        <ClInclude Include="ParticleShaderStructs.h" />
-        <ClInclude Include="pch.h" />
-        <ClInclude Include="PipelineState.h" />
-        <ClInclude Include="PixelBuffer.h" />
-        <ClInclude Include="PostEffects.h" />
-        <ClInclude Include="EngineTuning.h" />
-        <ClInclude Include="Display.h" />
-        <ClInclude Include="ReadbackBuffer.h" />
-        <ClInclude Include="RootSignature.h" />
-        <ClInclude Include="SamplerManager.h" />
-        <ClInclude Include="ShadowBuffer.h" />
-        <ClInclude Include="ShadowCamera.h" />
-        <ClInclude Include="SSAO.h" />
-        <ClInclude Include="SystemTime.h" />
-        <ClInclude Include="TemporalEffects.h" />
-        <ClInclude Include="TextRenderer.h" />
-        <ClInclude Include="Texture.h" />
-        <ClInclude Include="TextureManager.h" />
-        <ClInclude Include="UploadBuffer.h" />
-        <ClInclude Include="Utility.h" />
-        <ClInclude Include="Util\CommandLineArg.h" />
-        <ClInclude Include="VectorMath.h" />
-    </ItemGroup>
-    <ItemGroup>
-        <ClCompile Include="BitonicSort.cpp" />
-        <ClCompile Include="BuddyAllocator.cpp" />
-        <ClCompile Include="BufferManager.cpp" />
-        <ClCompile Include="Camera.cpp" />
-        <ClCompile Include="CameraController.cpp" />
-        <ClCompile Include="Color.cpp" />
-        <ClCompile Include="ColorBuffer.cpp" />
-        <ClCompile Include="CommandAllocatorPool.cpp" />
-        <ClCompile Include="CommandContext.cpp" />
-        <ClCompile Include="CommandListManager.cpp" />
-        <ClCompile Include="CommandSignature.cpp" />
-        <ClCompile Include="DDSTextureLoader.cpp" />
-        <ClCompile Include="DepthBuffer.cpp" />
-        <ClCompile Include="DepthOfField.cpp" />
-        <ClCompile Include="DynamicDescriptorHeap.cpp" />
-        <ClCompile Include="DescriptorHeap.cpp" />
-        <ClCompile Include="EngineProfiling.cpp" />
-        <ClCompile Include="EngineTuning.cpp" />
-        <ClCompile Include="FileUtility.cpp" />
-        <ClCompile Include="FXAA.cpp" />
-        <ClCompile Include="Input.cpp" />
-        <ClCompile Include="GameCore.cpp" />
-        <ClCompile Include="GpuBuffer.cpp" />
-        <ClCompile Include="GpuTimeManager.cpp" />
-        <ClCompile Include="GraphicsCommon.cpp" />
-        <ClCompile Include="GraphicsCore.cpp" />
-        <ClCompile Include="GraphRenderer.cpp" />
-        <ClCompile Include="ImageScaling.cpp" />
-        <ClCompile Include="LinearAllocator.cpp" />
-        <ClCompile Include="Math\BoundingSphere.cpp" />
-        <ClCompile Include="Math\Frustum.cpp" />
-        <ClCompile Include="Math\Random.cpp" />
-        <ClCompile Include="MotionBlur.cpp" />
-        <ClCompile Include="ParticleEffect.cpp" />
-        <ClCompile Include="ParticleEffectManager.cpp" />
-        <ClCompile Include="ParticleEmissionProperties.cpp" />
-        <ClCompile Include="pch.cpp">
-            <PrecompiledHeader>Create</PrecompiledHeader>
-        </ClCompile>
-        <ClCompile Include="PipelineState.cpp" />
-        <ClCompile Include="PixelBuffer.cpp" />
-        <ClCompile Include="PostEffects.cpp" />
-        <ClCompile Include="Display.cpp" />
-        <ClCompile Include="ReadbackBuffer.cpp" />
-        <ClCompile Include="RootSignature.cpp" />
-        <ClCompile Include="SamplerManager.cpp" />
-        <ClCompile Include="ShadowBuffer.cpp" />
-        <ClCompile Include="ShadowCamera.cpp" />
-        <ClCompile Include="SSAO.cpp" />
-        <ClCompile Include="SystemTime.cpp" />
-        <ClCompile Include="TemporalEffects.cpp" />
-        <ClCompile Include="TextRenderer.cpp" />
-        <ClCompile Include="Texture.cpp" />
-        <ClCompile Include="TextureManager.cpp" />
-        <ClCompile Include="UploadBuffer.cpp" />
-        <ClCompile Include="Utility.cpp" />
-        <ClCompile Include="Util\CommandLineArg.cpp" />
-    </ItemGroup>
-    <ItemGroup>
-        <FxCompile Include="Shaders\AdaptExposureCS.hlsl" />
-        <FxCompile Include="Shaders\AoBlurUpsampleBlendOutCS.hlsl" />
-        <FxCompile Include="Shaders\AoBlurUpsampleCS.hlsl" />
-        <FxCompile Include="Shaders\AoBlurUpsamplePreMinBlendOutCS.hlsl" />
-        <FxCompile Include="Shaders\AoBlurUpsamplePreMinCS.hlsl" />
-        <FxCompile Include="Shaders\AoPrepareDepthBuffers1CS.hlsl" />
-        <FxCompile Include="Shaders\AoPrepareDepthBuffers2CS.hlsl" />
-        <FxCompile Include="Shaders\AoRender1CS.hlsl" />
-        <FxCompile Include="Shaders\AoRender2CS.hlsl" />
-        <FxCompile Include="Shaders\ApplyBloom2CS.hlsl" />
-        <FxCompile Include="Shaders\ApplyBloomCS.hlsl" />
-        <FxCompile Include="Shaders\AverageLumaCS.hlsl" />
-        <FxCompile Include="Shaders\BicubicHorizontalUpsamplePS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\BicubicUpsampleCS.hlsl" />
-        <FxCompile Include="Shaders\BicubicUpsampleFast16CS.hlsl" />
-        <FxCompile Include="Shaders\BicubicUpsampleFast24CS.hlsl" />
-        <FxCompile Include="Shaders\BicubicUpsampleFast32CS.hlsl" />
-        <FxCompile Include="Shaders\BicubicUpsampleGammaPS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\BicubicUpsamplePS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\BicubicVerticalUpsamplePS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\BilinearUpsamplePS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\Bitonic32InnerSortCS.hlsl" />
-        <FxCompile Include="Shaders\Bitonic32OuterSortCS.hlsl" />
-        <FxCompile Include="Shaders\Bitonic32PreSortCS.hlsl" />
-        <FxCompile Include="Shaders\Bitonic64InnerSortCS.hlsl" />
-        <FxCompile Include="Shaders\Bitonic64OuterSortCS.hlsl" />
-        <FxCompile Include="Shaders\Bitonic64PreSortCS.hlsl" />
-        <FxCompile Include="Shaders\BitonicIndirectArgsCS.hlsl" />
-        <FxCompile Include="Shaders\BlendUIHDRPS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\BloomExtractAndDownsampleHdrCS.hlsl" />
-        <FxCompile Include="Shaders\BloomExtractAndDownsampleLdrCS.hlsl" />
-        <FxCompile Include="Shaders\BlurCS.hlsl" />
-        <FxCompile Include="Shaders\BoundNeighborhoodCS.hlsl" />
-        <FxCompile Include="Shaders\BufferCopyPS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\CameraMotionBlurPrePassCS.hlsl" />
-        <FxCompile Include="Shaders\CameraMotionBlurPrePassLinearZCS.hlsl" />
-        <FxCompile Include="Shaders\CameraVelocityCS.hlsl" />
-        <FxCompile Include="Shaders\CompositeHDRPS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\CompositeSDRPS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\CopyBackPostBufferCS.hlsl" />
-        <FxCompile Include="Shaders\DebugDrawHistogramCS.hlsl" />
-        <FxCompile Include="Shaders\DebugLuminanceHdr2CS.hlsl" />
-        <FxCompile Include="Shaders\DebugLuminanceHdrCS.hlsl" />
-        <FxCompile Include="Shaders\DebugLuminanceLdr2CS.hlsl" />
-        <FxCompile Include="Shaders\DebugLuminanceLdrCS.hlsl" />
-        <FxCompile Include="Shaders\DebugSSAOCS.hlsl" />
-        <FxCompile Include="Shaders\DoFCombine2CS.hlsl" />
-        <FxCompile Include="Shaders\DoFCombineCS.hlsl" />
-        <FxCompile Include="Shaders\DoFCombineFast2CS.hlsl" />
-        <FxCompile Include="Shaders\DoFCombineFastCS.hlsl" />
-        <FxCompile Include="Shaders\DoFDebugBlueCS.hlsl" />
-        <FxCompile Include="Shaders\DoFDebugGreenCS.hlsl" />
-        <FxCompile Include="Shaders\DoFDebugRedCS.hlsl" />
-        <FxCompile Include="Shaders\DoFMedianFilterCS.hlsl" />
-        <FxCompile Include="Shaders\DoFMedianFilterFixupCS.hlsl" />
-        <FxCompile Include="Shaders\DoFMedianFilterSepAlphaCS.hlsl" />
-        <FxCompile Include="Shaders\DoFPass1CS.hlsl" />
-        <FxCompile Include="Shaders\DoFPass2CS.hlsl" />
-        <FxCompile Include="Shaders\DoFPass2DebugCS.hlsl" />
-        <FxCompile Include="Shaders\DoFPass2FastCS.hlsl" />
-        <FxCompile Include="Shaders\DoFPass2FixupCS.hlsl" />
-        <FxCompile Include="Shaders\DoFPreFilterCS.hlsl" />
-        <FxCompile Include="Shaders\DoFPreFilterFastCS.hlsl" />
-        <FxCompile Include="Shaders\DoFPreFilterFixupCS.hlsl" />
-        <FxCompile Include="Shaders\DoFTilePassCS.hlsl" />
-        <FxCompile Include="Shaders\DoFTilePassFixupCS.hlsl" />
-        <FxCompile Include="Shaders\DownsampleBloomAllCS.hlsl" />
-        <FxCompile Include="Shaders\DownsampleBloomCS.hlsl" />
-        <FxCompile Include="Shaders\DownsampleDepthPS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\ExtractLumaCS.hlsl" />
-        <FxCompile Include="Shaders\FXAAPass1_Luma2_CS.hlsl" />
-        <FxCompile Include="Shaders\FXAAPass1_Luma_CS.hlsl" />
-        <FxCompile Include="Shaders\FXAAPass1_RGB2_CS.hlsl" />
-        <FxCompile Include="Shaders\FXAAPass1_RGB_CS.hlsl" />
-        <FxCompile Include="Shaders\FXAAPass2H2CS.hlsl" />
-        <FxCompile Include="Shaders\FXAAPass2HDebug2CS.hlsl" />
-        <FxCompile Include="Shaders\FXAAPass2HDebugCS.hlsl" />
-        <FxCompile Include="Shaders\FXAAPass2V2CS.hlsl" />
-        <FxCompile Include="Shaders\FXAAPass2VDebug2CS.hlsl" />
-        <FxCompile Include="Shaders\FXAAPass2VDebugCS.hlsl" />
-        <FxCompile Include="Shaders\GenerateHistogramCS.hlsl" />
-        <FxCompile Include="Shaders\FXAAPass2HCS.hlsl" />
-        <FxCompile Include="Shaders\FXAAPass2VCS.hlsl" />
-        <FxCompile Include="Shaders\GenerateMipsGammaCS.hlsl" />
-        <FxCompile Include="Shaders\GenerateMipsGammaOddCS.hlsl" />
-        <FxCompile Include="Shaders\GenerateMipsGammaOddXCS.hlsl" />
-        <FxCompile Include="Shaders\GenerateMipsGammaOddYCS.hlsl" />
-        <FxCompile Include="Shaders\GenerateMipsLinearCS.hlsl" />
-        <FxCompile Include="Shaders\GenerateMipsLinearOddCS.hlsl" />
-        <FxCompile Include="Shaders\GenerateMipsLinearOddXCS.hlsl" />
-        <FxCompile Include="Shaders\GenerateMipsLinearOddYCS.hlsl" />
-        <FxCompile Include="Shaders\LanczosCS.hlsl" />
-        <FxCompile Include="Shaders\LanczosFast16CS.hlsl" />
-        <FxCompile Include="Shaders\LanczosFast24CS.hlsl" />
-        <FxCompile Include="Shaders\LanczosFast32CS.hlsl" />
-        <FxCompile Include="Shaders\LanczosHorizontalPS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\LanczosVerticalPS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\LinearizeDepthCS.hlsl" />
-        <FxCompile Include="Shaders\MagnifyPixelsPS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\MotionBlurFinalPassCS.hlsl" />
-        <FxCompile Include="Shaders\MotionBlurFinalPassPS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\MotionBlurPrePassCS.hlsl" />
-        <FxCompile Include="Shaders\FXAAResolveWorkQueueCS.hlsl" />
-        <FxCompile Include="Shaders\ParticleBinCullingCS.hlsl" />
-        <FxCompile Include="Shaders\ParticleDepthBoundsCS.hlsl" />
-        <FxCompile Include="Shaders\ParticleDispatchIndirectArgsCS.hlsl" />
-        <FxCompile Include="Shaders\ParticleFinalDispatchIndirectArgsCS.hlsl" />
-        <FxCompile Include="Shaders\ParticleLargeBinCullingCS.hlsl" />
-        <FxCompile Include="Shaders\ParticleNoSortVS.hlsl">
-            <ShaderType>Vertex</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\ParticlePreSortCS.hlsl" />
-        <FxCompile Include="Shaders\ParticlePS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\ParticleSortIndirectArgsCS.hlsl" />
-        <FxCompile Include="Shaders\ParticleSpawnCS.hlsl" />
-        <FxCompile Include="Shaders\ParticleTileCullingCS.hlsl" />
-        <FxCompile Include="Shaders\ParticleTileRender2CS.hlsl" />
-        <FxCompile Include="Shaders\ParticleTileRenderCS.hlsl" />
-        <FxCompile Include="Shaders\ParticleTileRenderFast2CS.hlsl" />
-        <FxCompile Include="Shaders\ParticleTileRenderFastCS.hlsl" />
-        <FxCompile Include="Shaders\ParticleTileRenderFastDynamic2CS.hlsl" />
-        <FxCompile Include="Shaders\ParticleTileRenderFastDynamicCS.hlsl" />
-        <FxCompile Include="Shaders\ParticleTileRenderFastLowRes2CS.hlsl" />
-        <FxCompile Include="Shaders\ParticleTileRenderFastLowResCS.hlsl" />
-        <FxCompile Include="Shaders\ParticleTileRenderSlowDynamic2CS.hlsl" />
-        <FxCompile Include="Shaders\ParticleTileRenderSlowDynamicCS.hlsl" />
-        <FxCompile Include="Shaders\ParticleTileRenderSlowLowRes2CS.hlsl" />
-        <FxCompile Include="Shaders\ParticleTileRenderSlowLowResCS.hlsl" />
-        <FxCompile Include="Shaders\ParticleUpdateCS.hlsl" />
-        <FxCompile Include="Shaders\ParticleVS.hlsl">
-            <ShaderType>Vertex</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\PerfGraphBackgroundVS.hlsl">
-            <ShaderType>Vertex</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\PerfGraphPS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\PerfGraphVS.hlsl">
-            <ShaderType>Vertex</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\PresentHDRPS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\PresentSDRPS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\ResolveTAACS.hlsl" />
-        <FxCompile Include="Shaders\ScaleAndCompositeHDRPS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\ScaleAndCompositeSDRPS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\ScreenQuadCommonVS.hlsl">
-            <ShaderType>Vertex</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\ScreenQuadPresentVS.hlsl">
-            <ShaderType>Vertex</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\SharpeningUpsampleGammaPS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\SharpeningUpsamplePS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\SharpenTAACS.hlsl" />
-        <FxCompile Include="Shaders\TemporalBlendCS.hlsl" />
-        <FxCompile Include="Shaders\TextAntialiasPS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\TextShadowPS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\TextVS.hlsl">
-            <ShaderType>Vertex</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\ToneMapHDR2CS.hlsl" />
-        <FxCompile Include="Shaders\ToneMapHDRCS.hlsl" />
-        <None Include="Math\Functions.inl" />
-        <None Include="packages.config" />
-        <None Include="Shaders\AoBlurAndUpsampleCS.hlsli" />
-        <None Include="Shaders\AoRenderCS.hlsli" />
-        <None Include="Shaders\BicubicFilterFunctions.hlsli" />
-        <None Include="Shaders\BitonicSortCommon.hlsli" />
-        <None Include="Shaders\ColorSpaceUtility.hlsli" />
-        <None Include="Shaders\CommonRS.hlsli" />
-        <None Include="Shaders\DoFCommon.hlsli" />
-        <None Include="Shaders\DoFRS.hlsli" />
-        <None Include="Shaders\FXAAPass1CS.hlsli" />
-        <None Include="Shaders\FXAAPass2CS.hlsli" />
-        <None Include="Shaders\FXAARootSignature.hlsli" />
-        <None Include="Shaders\GenerateMipsCS.hlsli" />
-        <None Include="Shaders\LanczosFunctions.hlsli" />
-        <None Include="Shaders\MotionBlurRS.hlsli" />
-        <None Include="Shaders\ParticleRS.hlsli" />
-        <None Include="Shaders\ParticleUpdateCommon.hlsli" />
-        <None Include="Shaders\ParticleUtility.hlsli" />
-        <None Include="Shaders\PerfGraphRS.hlsli" />
-        <None Include="Shaders\PixelPacking_R11G11B10.hlsli" />
-        <None Include="Shaders\PixelPacking_RGBE.hlsli" />
-        <None Include="Shaders\PixelPacking_RGBM.hlsli" />
-        <None Include="Shaders\PostEffectsRS.hlsli" />
-        <None Include="Shaders\PresentRS.hlsli" />
-        <None Include="Shaders\ShaderUtility.hlsli" />
-        <FxCompile Include="Shaders\ToneMap2CS.hlsl" />
-        <FxCompile Include="Shaders\ToneMapCS.hlsl" />
-        <FxCompile Include="Shaders\UpsampleAndBlurCS.hlsl" />
-        <None Include="Shaders\PixelPacking.hlsli" />
-        <None Include="Shaders\SSAORS.hlsli" />
-        <None Include="Shaders\TextRS.hlsli" />
-    </ItemGroup>
-    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-    <ItemDefinitionGroup>
-        <ClCompile>
-            <AdditionalIncludeDirectories>..\..\Packages\zlib-msvc-x64.1.2.11.8900\build\native\include;..\..\Packages\WinPixEventRuntime.1.0.210209001\Include\WinPixEventRuntime;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-            <PreprocessorDefinitions>_GAMING_DESKTOP;__WRL_NO_DEFAULT_LIB__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-        </ClCompile>
-    </ItemDefinitionGroup>
-    <ImportGroup Label="ExtensionTargets">
-        <Import Project="..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
-        <Import Project="..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets" Condition="Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" />
-    </ImportGroup>
-    <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-        <PropertyGroup>
-            <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-        </PropertyGroup>
-        <Error Condition="!Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
-        <Error Condition="!Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets'))" />
-    </Target>
+    <Error Condition="!Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
+    <Error Condition="!Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets'))" />
+  </Target>
 </Project>

--- a/Samples/BulkLoadDemo/Core/Core.vcxproj
+++ b/Samples/BulkLoadDemo/Core/Core.vcxproj
@@ -1,454 +1,454 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="Debug|x64">
-			<Configuration>Debug</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="Profile|x64">
-			<Configuration>Profile</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="Release|x64">
-			<Configuration>Release</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-	</ItemGroup>
-	<PropertyGroup Label="Globals">
-		<RootNamespace>Core</RootNamespace>
-		<ProjectGuid>{86A58508-0D6A-4786-A32F-01A301FDC6F3}</ProjectGuid>
-		<DefaultLanguage>en-US</DefaultLanguage>
-		<Keyword>Win32Proj</Keyword>
-		<MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
-		<WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
-		<TargetRuntime>Native</TargetRuntime>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-	<PropertyGroup Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v142</PlatformToolset>
-		<CharacterSet>Unicode</CharacterSet>
-		<EmbedManifest>false</EmbedManifest>
-		<GenerateManifest>false</GenerateManifest>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-	<ImportGroup Label="ExtensionSettings" />
-	<ImportGroup Label="PropertySheets">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-		<Import Project="..\PropertySheets\Build.props" />
-	</ImportGroup>
-	<ImportGroup Condition="'$(Platform)'=='x64'" Label="PropertySheets">
-		<Import Project="..\PropertySheets\Desktop.props" />
-	</ImportGroup>
-	<PropertyGroup Label="UserMacros" />
-	<ItemDefinitionGroup>
-		<ClCompile>
-			<PrecompiledHeader>Use</PrecompiledHeader>
-			<PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-			<RuntimeTypeInfo>true</RuntimeTypeInfo>
-		</ClCompile>
-	</ItemDefinitionGroup>
-	<ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
-		<Link>
-			<AdditionalDependencies>d3d11.lib;dxguid.lib;winmm.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<SubSystem>Windows</SubSystem>
-			<DataExecutionPrevention>true</DataExecutionPrevention>
-		</Link>
-		<Manifest>
-			<EnableDPIAwareness>true</EnableDPIAwareness>
-		</Manifest>
-	</ItemDefinitionGroup>
-	<ItemGroup>
-		<ClInclude Include="BitonicSort.h" />
-		<ClInclude Include="BuddyAllocator.h" />
-		<ClInclude Include="BufferManager.h" />
-		<ClInclude Include="Camera.h" />
-		<ClInclude Include="CameraController.h" />
-		<ClInclude Include="Color.h" />
-		<ClInclude Include="ColorBuffer.h" />
-		<ClInclude Include="CommandAllocatorPool.h" />
-		<ClInclude Include="CommandContext.h" />
-		<ClInclude Include="CommandListManager.h" />
-		<ClInclude Include="CommandSignature.h" />
-		<ClInclude Include="d3dx12.h" />
-		<ClInclude Include="dds.h" />
-		<ClInclude Include="DDSTextureLoader.h" />
-		<ClInclude Include="DepthBuffer.h" />
-		<ClInclude Include="DepthOfField.h" />
-		<ClInclude Include="DynamicDescriptorHeap.h" />
-		<ClInclude Include="DescriptorHeap.h" />
-		<ClInclude Include="GpuBuffer.h" />
-		<ClInclude Include="EngineProfiling.h" />
-		<ClInclude Include="EsramAllocator.h" />
-		<ClInclude Include="FileUtility.h" />
-		<ClInclude Include="FXAA.h" />
-		<ClInclude Include="GameInput.h" />
-		<ClInclude Include="GpuResource.h" />
-		<ClInclude Include="GpuTimeManager.h" />
-		<ClInclude Include="GameCore.h" />
-		<ClInclude Include="GraphicsCommon.h" />
-		<ClInclude Include="GraphicsCore.h" />
-		<ClInclude Include="GraphRenderer.h" />
-		<ClInclude Include="Hash.h" />
-		<ClInclude Include="ImageScaling.h" />
-		<ClInclude Include="LinearAllocator.h" />
-		<ClInclude Include="Math\BoundingBox.h" />
-		<ClInclude Include="Math\BoundingPlane.h" />
-		<ClInclude Include="Math\BoundingSphere.h" />
-		<ClInclude Include="Math\Common.h" />
-		<ClInclude Include="Math\Frustum.h" />
-		<ClInclude Include="Math\Matrix3.h" />
-		<ClInclude Include="Math\Matrix4.h" />
-		<ClInclude Include="Math\Quaternion.h" />
-		<ClInclude Include="Math\Random.h" />
-		<ClInclude Include="Math\Scalar.h" />
-		<ClInclude Include="Math\Transform.h" />
-		<ClInclude Include="Math\Vector.h" />
-		<ClInclude Include="MotionBlur.h" />
-		<ClInclude Include="ParticleEffect.h" />
-		<ClInclude Include="ParticleEffectManager.h" />
-		<ClInclude Include="ParticleEffectProperties.h" />
-		<ClInclude Include="ParticleShaderStructs.h" />
-		<ClInclude Include="pch.h" />
-		<ClInclude Include="PipelineState.h" />
-		<ClInclude Include="PixelBuffer.h" />
-		<ClInclude Include="PostEffects.h" />
-		<ClInclude Include="EngineTuning.h" />
-		<ClInclude Include="Display.h" />
-		<ClInclude Include="ReadbackBuffer.h" />
-		<ClInclude Include="RootSignature.h" />
-		<ClInclude Include="SamplerManager.h" />
-		<ClInclude Include="ShadowBuffer.h" />
-		<ClInclude Include="ShadowCamera.h" />
-		<ClInclude Include="SSAO.h" />
-		<ClInclude Include="SystemTime.h" />
-		<ClInclude Include="TemporalEffects.h" />
-		<ClInclude Include="TextRenderer.h" />
-		<ClInclude Include="Texture.h" />
-		<ClInclude Include="TextureManager.h" />
-		<ClInclude Include="UploadBuffer.h" />
-		<ClInclude Include="Utility.h" />
-		<ClInclude Include="Util\CommandLineArg.h" />
-		<ClInclude Include="VectorMath.h" />
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="BitonicSort.cpp" />
-		<ClCompile Include="BuddyAllocator.cpp" />
-		<ClCompile Include="BufferManager.cpp" />
-		<ClCompile Include="Camera.cpp" />
-		<ClCompile Include="CameraController.cpp" />
-		<ClCompile Include="Color.cpp" />
-		<ClCompile Include="ColorBuffer.cpp" />
-		<ClCompile Include="CommandAllocatorPool.cpp" />
-		<ClCompile Include="CommandContext.cpp" />
-		<ClCompile Include="CommandListManager.cpp" />
-		<ClCompile Include="CommandSignature.cpp" />
-		<ClCompile Include="DDSTextureLoader.cpp" />
-		<ClCompile Include="DepthBuffer.cpp" />
-		<ClCompile Include="DepthOfField.cpp" />
-		<ClCompile Include="DynamicDescriptorHeap.cpp" />
-		<ClCompile Include="DescriptorHeap.cpp" />
-		<ClCompile Include="EngineProfiling.cpp" />
-		<ClCompile Include="EngineTuning.cpp" />
-		<ClCompile Include="FileUtility.cpp" />
-		<ClCompile Include="FXAA.cpp" />
-		<ClCompile Include="Input.cpp" />
-		<ClCompile Include="GameCore.cpp" />
-		<ClCompile Include="GpuBuffer.cpp" />
-		<ClCompile Include="GpuTimeManager.cpp" />
-		<ClCompile Include="GraphicsCommon.cpp" />
-		<ClCompile Include="GraphicsCore.cpp" />
-		<ClCompile Include="GraphRenderer.cpp" />
-		<ClCompile Include="ImageScaling.cpp" />
-		<ClCompile Include="LinearAllocator.cpp" />
-		<ClCompile Include="Math\BoundingSphere.cpp" />
-		<ClCompile Include="Math\Frustum.cpp" />
-		<ClCompile Include="Math\Random.cpp" />
-		<ClCompile Include="MotionBlur.cpp" />
-		<ClCompile Include="ParticleEffect.cpp" />
-		<ClCompile Include="ParticleEffectManager.cpp" />
-		<ClCompile Include="ParticleEmissionProperties.cpp" />
-		<ClCompile Include="pch.cpp">
-			<PrecompiledHeader>Create</PrecompiledHeader>
-		</ClCompile>
-		<ClCompile Include="PipelineState.cpp" />
-		<ClCompile Include="PixelBuffer.cpp" />
-		<ClCompile Include="PostEffects.cpp" />
-		<ClCompile Include="Display.cpp" />
-		<ClCompile Include="ReadbackBuffer.cpp" />
-		<ClCompile Include="RootSignature.cpp" />
-		<ClCompile Include="SamplerManager.cpp" />
-		<ClCompile Include="ShadowBuffer.cpp" />
-		<ClCompile Include="ShadowCamera.cpp" />
-		<ClCompile Include="SSAO.cpp" />
-		<ClCompile Include="SystemTime.cpp" />
-		<ClCompile Include="TemporalEffects.cpp" />
-		<ClCompile Include="TextRenderer.cpp" />
-		<ClCompile Include="Texture.cpp" />
-		<ClCompile Include="TextureManager.cpp" />
-		<ClCompile Include="UploadBuffer.cpp" />
-		<ClCompile Include="Utility.cpp" />
-		<ClCompile Include="Util\CommandLineArg.cpp" />
-	</ItemGroup>
-	<ItemGroup>
-		<FxCompile Include="Shaders\AdaptExposureCS.hlsl" />
-		<FxCompile Include="Shaders\AoBlurUpsampleBlendOutCS.hlsl" />
-		<FxCompile Include="Shaders\AoBlurUpsampleCS.hlsl" />
-		<FxCompile Include="Shaders\AoBlurUpsamplePreMinBlendOutCS.hlsl" />
-		<FxCompile Include="Shaders\AoBlurUpsamplePreMinCS.hlsl" />
-		<FxCompile Include="Shaders\AoPrepareDepthBuffers1CS.hlsl" />
-		<FxCompile Include="Shaders\AoPrepareDepthBuffers2CS.hlsl" />
-		<FxCompile Include="Shaders\AoRender1CS.hlsl" />
-		<FxCompile Include="Shaders\AoRender2CS.hlsl" />
-		<FxCompile Include="Shaders\ApplyBloom2CS.hlsl" />
-		<FxCompile Include="Shaders\ApplyBloomCS.hlsl" />
-		<FxCompile Include="Shaders\AverageLumaCS.hlsl" />
-		<FxCompile Include="Shaders\BicubicHorizontalUpsamplePS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\BicubicUpsampleCS.hlsl" />
-		<FxCompile Include="Shaders\BicubicUpsampleFast16CS.hlsl" />
-		<FxCompile Include="Shaders\BicubicUpsampleFast24CS.hlsl" />
-		<FxCompile Include="Shaders\BicubicUpsampleFast32CS.hlsl" />
-		<FxCompile Include="Shaders\BicubicUpsampleGammaPS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\BicubicUpsamplePS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\BicubicVerticalUpsamplePS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\BilinearUpsamplePS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\Bitonic32InnerSortCS.hlsl" />
-		<FxCompile Include="Shaders\Bitonic32OuterSortCS.hlsl" />
-		<FxCompile Include="Shaders\Bitonic32PreSortCS.hlsl" />
-		<FxCompile Include="Shaders\Bitonic64InnerSortCS.hlsl" />
-		<FxCompile Include="Shaders\Bitonic64OuterSortCS.hlsl" />
-		<FxCompile Include="Shaders\Bitonic64PreSortCS.hlsl" />
-		<FxCompile Include="Shaders\BitonicIndirectArgsCS.hlsl" />
-		<FxCompile Include="Shaders\BlendUIHDRPS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\BloomExtractAndDownsampleHdrCS.hlsl" />
-		<FxCompile Include="Shaders\BloomExtractAndDownsampleLdrCS.hlsl" />
-		<FxCompile Include="Shaders\BlurCS.hlsl" />
-		<FxCompile Include="Shaders\BoundNeighborhoodCS.hlsl" />
-		<FxCompile Include="Shaders\BufferCopyPS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\CameraMotionBlurPrePassCS.hlsl" />
-		<FxCompile Include="Shaders\CameraMotionBlurPrePassLinearZCS.hlsl" />
-		<FxCompile Include="Shaders\CameraVelocityCS.hlsl" />
-		<FxCompile Include="Shaders\CompositeHDRPS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\CompositeSDRPS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\CopyBackPostBufferCS.hlsl" />
-		<FxCompile Include="Shaders\DebugDrawHistogramCS.hlsl" />
-		<FxCompile Include="Shaders\DebugLuminanceHdr2CS.hlsl" />
-		<FxCompile Include="Shaders\DebugLuminanceHdrCS.hlsl" />
-		<FxCompile Include="Shaders\DebugLuminanceLdr2CS.hlsl" />
-		<FxCompile Include="Shaders\DebugLuminanceLdrCS.hlsl" />
-		<FxCompile Include="Shaders\DebugSSAOCS.hlsl" />
-		<FxCompile Include="Shaders\DoFCombine2CS.hlsl" />
-		<FxCompile Include="Shaders\DoFCombineCS.hlsl" />
-		<FxCompile Include="Shaders\DoFCombineFast2CS.hlsl" />
-		<FxCompile Include="Shaders\DoFCombineFastCS.hlsl" />
-		<FxCompile Include="Shaders\DoFDebugBlueCS.hlsl" />
-		<FxCompile Include="Shaders\DoFDebugGreenCS.hlsl" />
-		<FxCompile Include="Shaders\DoFDebugRedCS.hlsl" />
-		<FxCompile Include="Shaders\DoFMedianFilterCS.hlsl" />
-		<FxCompile Include="Shaders\DoFMedianFilterFixupCS.hlsl" />
-		<FxCompile Include="Shaders\DoFMedianFilterSepAlphaCS.hlsl" />
-		<FxCompile Include="Shaders\DoFPass1CS.hlsl" />
-		<FxCompile Include="Shaders\DoFPass2CS.hlsl" />
-		<FxCompile Include="Shaders\DoFPass2DebugCS.hlsl" />
-		<FxCompile Include="Shaders\DoFPass2FastCS.hlsl" />
-		<FxCompile Include="Shaders\DoFPass2FixupCS.hlsl" />
-		<FxCompile Include="Shaders\DoFPreFilterCS.hlsl" />
-		<FxCompile Include="Shaders\DoFPreFilterFastCS.hlsl" />
-		<FxCompile Include="Shaders\DoFPreFilterFixupCS.hlsl" />
-		<FxCompile Include="Shaders\DoFTilePassCS.hlsl" />
-		<FxCompile Include="Shaders\DoFTilePassFixupCS.hlsl" />
-		<FxCompile Include="Shaders\DownsampleBloomAllCS.hlsl" />
-		<FxCompile Include="Shaders\DownsampleBloomCS.hlsl" />
-		<FxCompile Include="Shaders\DownsampleDepthPS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\ExtractLumaCS.hlsl" />
-		<FxCompile Include="Shaders\FXAAPass1_Luma2_CS.hlsl" />
-		<FxCompile Include="Shaders\FXAAPass1_Luma_CS.hlsl" />
-		<FxCompile Include="Shaders\FXAAPass1_RGB2_CS.hlsl" />
-		<FxCompile Include="Shaders\FXAAPass1_RGB_CS.hlsl" />
-		<FxCompile Include="Shaders\FXAAPass2H2CS.hlsl" />
-		<FxCompile Include="Shaders\FXAAPass2HDebug2CS.hlsl" />
-		<FxCompile Include="Shaders\FXAAPass2HDebugCS.hlsl" />
-		<FxCompile Include="Shaders\FXAAPass2V2CS.hlsl" />
-		<FxCompile Include="Shaders\FXAAPass2VDebug2CS.hlsl" />
-		<FxCompile Include="Shaders\FXAAPass2VDebugCS.hlsl" />
-		<FxCompile Include="Shaders\GenerateHistogramCS.hlsl" />
-		<FxCompile Include="Shaders\FXAAPass2HCS.hlsl" />
-		<FxCompile Include="Shaders\FXAAPass2VCS.hlsl" />
-		<FxCompile Include="Shaders\GenerateMipsGammaCS.hlsl" />
-		<FxCompile Include="Shaders\GenerateMipsGammaOddCS.hlsl" />
-		<FxCompile Include="Shaders\GenerateMipsGammaOddXCS.hlsl" />
-		<FxCompile Include="Shaders\GenerateMipsGammaOddYCS.hlsl" />
-		<FxCompile Include="Shaders\GenerateMipsLinearCS.hlsl" />
-		<FxCompile Include="Shaders\GenerateMipsLinearOddCS.hlsl" />
-		<FxCompile Include="Shaders\GenerateMipsLinearOddXCS.hlsl" />
-		<FxCompile Include="Shaders\GenerateMipsLinearOddYCS.hlsl" />
-		<FxCompile Include="Shaders\LanczosCS.hlsl" />
-		<FxCompile Include="Shaders\LanczosFast16CS.hlsl" />
-		<FxCompile Include="Shaders\LanczosFast24CS.hlsl" />
-		<FxCompile Include="Shaders\LanczosFast32CS.hlsl" />
-		<FxCompile Include="Shaders\LanczosHorizontalPS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\LanczosVerticalPS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\LinearizeDepthCS.hlsl" />
-		<FxCompile Include="Shaders\MagnifyPixelsPS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\MotionBlurFinalPassCS.hlsl" />
-		<FxCompile Include="Shaders\MotionBlurFinalPassPS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\MotionBlurPrePassCS.hlsl" />
-		<FxCompile Include="Shaders\FXAAResolveWorkQueueCS.hlsl" />
-		<FxCompile Include="Shaders\ParticleBinCullingCS.hlsl" />
-		<FxCompile Include="Shaders\ParticleDepthBoundsCS.hlsl" />
-		<FxCompile Include="Shaders\ParticleDispatchIndirectArgsCS.hlsl" />
-		<FxCompile Include="Shaders\ParticleFinalDispatchIndirectArgsCS.hlsl" />
-		<FxCompile Include="Shaders\ParticleLargeBinCullingCS.hlsl" />
-		<FxCompile Include="Shaders\ParticleNoSortVS.hlsl">
-			<ShaderType>Vertex</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\ParticlePreSortCS.hlsl" />
-		<FxCompile Include="Shaders\ParticlePS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\ParticleSortIndirectArgsCS.hlsl" />
-		<FxCompile Include="Shaders\ParticleSpawnCS.hlsl" />
-		<FxCompile Include="Shaders\ParticleTileCullingCS.hlsl" />
-		<FxCompile Include="Shaders\ParticleTileRender2CS.hlsl" />
-		<FxCompile Include="Shaders\ParticleTileRenderCS.hlsl" />
-		<FxCompile Include="Shaders\ParticleTileRenderFast2CS.hlsl" />
-		<FxCompile Include="Shaders\ParticleTileRenderFastCS.hlsl" />
-		<FxCompile Include="Shaders\ParticleTileRenderFastDynamic2CS.hlsl" />
-		<FxCompile Include="Shaders\ParticleTileRenderFastDynamicCS.hlsl" />
-		<FxCompile Include="Shaders\ParticleTileRenderFastLowRes2CS.hlsl" />
-		<FxCompile Include="Shaders\ParticleTileRenderFastLowResCS.hlsl" />
-		<FxCompile Include="Shaders\ParticleTileRenderSlowDynamic2CS.hlsl" />
-		<FxCompile Include="Shaders\ParticleTileRenderSlowDynamicCS.hlsl" />
-		<FxCompile Include="Shaders\ParticleTileRenderSlowLowRes2CS.hlsl" />
-		<FxCompile Include="Shaders\ParticleTileRenderSlowLowResCS.hlsl" />
-		<FxCompile Include="Shaders\ParticleUpdateCS.hlsl" />
-		<FxCompile Include="Shaders\ParticleVS.hlsl">
-			<ShaderType>Vertex</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\PerfGraphBackgroundVS.hlsl">
-			<ShaderType>Vertex</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\PerfGraphPS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\PerfGraphVS.hlsl">
-			<ShaderType>Vertex</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\PresentHDRPS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\PresentSDRPS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\ResolveTAACS.hlsl" />
-		<FxCompile Include="Shaders\ScaleAndCompositeHDRPS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\ScaleAndCompositeSDRPS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\ScreenQuadCommonVS.hlsl">
-			<ShaderType>Vertex</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\ScreenQuadPresentVS.hlsl">
-			<ShaderType>Vertex</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\SharpeningUpsampleGammaPS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\SharpeningUpsamplePS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\SharpenTAACS.hlsl" />
-		<FxCompile Include="Shaders\TemporalBlendCS.hlsl" />
-		<FxCompile Include="Shaders\TextAntialiasPS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\TextShadowPS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\TextVS.hlsl">
-			<ShaderType>Vertex</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\ToneMapHDR2CS.hlsl" />
-		<FxCompile Include="Shaders\ToneMapHDRCS.hlsl" />
-		<None Include="Math\Functions.inl" />
-		<None Include="packages.config" />
-		<None Include="Shaders\AoBlurAndUpsampleCS.hlsli" />
-		<None Include="Shaders\AoRenderCS.hlsli" />
-		<None Include="Shaders\BicubicFilterFunctions.hlsli" />
-		<None Include="Shaders\BitonicSortCommon.hlsli" />
-		<None Include="Shaders\ColorSpaceUtility.hlsli" />
-		<None Include="Shaders\CommonRS.hlsli" />
-		<None Include="Shaders\DoFCommon.hlsli" />
-		<None Include="Shaders\DoFRS.hlsli" />
-		<None Include="Shaders\FXAAPass1CS.hlsli" />
-		<None Include="Shaders\FXAAPass2CS.hlsli" />
-		<None Include="Shaders\FXAARootSignature.hlsli" />
-		<None Include="Shaders\GenerateMipsCS.hlsli" />
-		<None Include="Shaders\LanczosFunctions.hlsli" />
-		<None Include="Shaders\MotionBlurRS.hlsli" />
-		<None Include="Shaders\ParticleRS.hlsli" />
-		<None Include="Shaders\ParticleUpdateCommon.hlsli" />
-		<None Include="Shaders\ParticleUtility.hlsli" />
-		<None Include="Shaders\PerfGraphRS.hlsli" />
-		<None Include="Shaders\PixelPacking_R11G11B10.hlsli" />
-		<None Include="Shaders\PixelPacking_RGBE.hlsli" />
-		<None Include="Shaders\PixelPacking_RGBM.hlsli" />
-		<None Include="Shaders\PostEffectsRS.hlsli" />
-		<None Include="Shaders\PresentRS.hlsli" />
-		<None Include="Shaders\ShaderUtility.hlsli" />
-		<FxCompile Include="Shaders\ToneMap2CS.hlsl" />
-		<FxCompile Include="Shaders\ToneMapCS.hlsl" />
-		<FxCompile Include="Shaders\UpsampleAndBlurCS.hlsl" />
-		<None Include="Shaders\PixelPacking.hlsli" />
-		<None Include="Shaders\SSAORS.hlsli" />
-		<None Include="Shaders\TextRS.hlsli" />
-	</ItemGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-	<ItemDefinitionGroup>
-		<ClCompile>
-			<AdditionalIncludeDirectories>..\..\Packages\zlib-msvc-x64.1.2.11.8900\build\native\include;..\..\Packages\WinPixEventRuntime.1.0.210209001\Include\WinPixEventRuntime;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>_GAMING_DESKTOP;__WRL_NO_DEFAULT_LIB__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-		</ClCompile>
-	</ItemDefinitionGroup>
-	<ImportGroup Label="ExtensionTargets">
-		<Import Project="..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
-		<Import Project="..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets" Condition="Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" />
-	</ImportGroup>
-	<Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-		<PropertyGroup>
-			<ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-		</PropertyGroup>
-		<Error Condition="!Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
-		<Error Condition="!Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets'))" />
-	</Target>
+    <ItemGroup Label="ProjectConfigurations">
+        <ProjectConfiguration Include="Debug|x64">
+            <Configuration>Debug</Configuration>
+            <Platform>x64</Platform>
+        </ProjectConfiguration>
+        <ProjectConfiguration Include="Profile|x64">
+            <Configuration>Profile</Configuration>
+            <Platform>x64</Platform>
+        </ProjectConfiguration>
+        <ProjectConfiguration Include="Release|x64">
+            <Configuration>Release</Configuration>
+            <Platform>x64</Platform>
+        </ProjectConfiguration>
+    </ItemGroup>
+    <PropertyGroup Label="Globals">
+        <RootNamespace>Core</RootNamespace>
+        <ProjectGuid>{86A58508-0D6A-4786-A32F-01A301FDC6F3}</ProjectGuid>
+        <DefaultLanguage>en-US</DefaultLanguage>
+        <Keyword>Win32Proj</Keyword>
+        <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
+        <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+        <TargetRuntime>Native</TargetRuntime>
+    </PropertyGroup>
+    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+    <PropertyGroup Label="Configuration">
+        <ConfigurationType>StaticLibrary</ConfigurationType>
+        <PlatformToolset>v142</PlatformToolset>
+        <CharacterSet>Unicode</CharacterSet>
+        <EmbedManifest>false</EmbedManifest>
+        <GenerateManifest>false</GenerateManifest>
+    </PropertyGroup>
+    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+    <ImportGroup Label="ExtensionSettings" />
+    <ImportGroup Label="PropertySheets">
+        <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+        <Import Project="..\PropertySheets\Build.props" />
+    </ImportGroup>
+    <ImportGroup Condition="'$(Platform)'=='x64'" Label="PropertySheets">
+        <Import Project="..\PropertySheets\Desktop.props" />
+    </ImportGroup>
+    <PropertyGroup Label="UserMacros" />
+    <ItemDefinitionGroup>
+        <ClCompile>
+            <PrecompiledHeader>Use</PrecompiledHeader>
+            <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+            <RuntimeTypeInfo>true</RuntimeTypeInfo>
+        </ClCompile>
+    </ItemDefinitionGroup>
+    <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
+        <Link>
+            <AdditionalDependencies>d3d11.lib;dxguid.lib;winmm.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+            <SubSystem>Windows</SubSystem>
+            <DataExecutionPrevention>true</DataExecutionPrevention>
+        </Link>
+        <Manifest>
+            <EnableDPIAwareness>true</EnableDPIAwareness>
+        </Manifest>
+    </ItemDefinitionGroup>
+    <ItemGroup>
+        <ClInclude Include="BitonicSort.h" />
+        <ClInclude Include="BuddyAllocator.h" />
+        <ClInclude Include="BufferManager.h" />
+        <ClInclude Include="Camera.h" />
+        <ClInclude Include="CameraController.h" />
+        <ClInclude Include="Color.h" />
+        <ClInclude Include="ColorBuffer.h" />
+        <ClInclude Include="CommandAllocatorPool.h" />
+        <ClInclude Include="CommandContext.h" />
+        <ClInclude Include="CommandListManager.h" />
+        <ClInclude Include="CommandSignature.h" />
+        <ClInclude Include="d3dx12.h" />
+        <ClInclude Include="dds.h" />
+        <ClInclude Include="DDSTextureLoader.h" />
+        <ClInclude Include="DepthBuffer.h" />
+        <ClInclude Include="DepthOfField.h" />
+        <ClInclude Include="DynamicDescriptorHeap.h" />
+        <ClInclude Include="DescriptorHeap.h" />
+        <ClInclude Include="GpuBuffer.h" />
+        <ClInclude Include="EngineProfiling.h" />
+        <ClInclude Include="EsramAllocator.h" />
+        <ClInclude Include="FileUtility.h" />
+        <ClInclude Include="FXAA.h" />
+        <ClInclude Include="GameInput.h" />
+        <ClInclude Include="GpuResource.h" />
+        <ClInclude Include="GpuTimeManager.h" />
+        <ClInclude Include="GameCore.h" />
+        <ClInclude Include="GraphicsCommon.h" />
+        <ClInclude Include="GraphicsCore.h" />
+        <ClInclude Include="GraphRenderer.h" />
+        <ClInclude Include="Hash.h" />
+        <ClInclude Include="ImageScaling.h" />
+        <ClInclude Include="LinearAllocator.h" />
+        <ClInclude Include="Math\BoundingBox.h" />
+        <ClInclude Include="Math\BoundingPlane.h" />
+        <ClInclude Include="Math\BoundingSphere.h" />
+        <ClInclude Include="Math\Common.h" />
+        <ClInclude Include="Math\Frustum.h" />
+        <ClInclude Include="Math\Matrix3.h" />
+        <ClInclude Include="Math\Matrix4.h" />
+        <ClInclude Include="Math\Quaternion.h" />
+        <ClInclude Include="Math\Random.h" />
+        <ClInclude Include="Math\Scalar.h" />
+        <ClInclude Include="Math\Transform.h" />
+        <ClInclude Include="Math\Vector.h" />
+        <ClInclude Include="MotionBlur.h" />
+        <ClInclude Include="ParticleEffect.h" />
+        <ClInclude Include="ParticleEffectManager.h" />
+        <ClInclude Include="ParticleEffectProperties.h" />
+        <ClInclude Include="ParticleShaderStructs.h" />
+        <ClInclude Include="pch.h" />
+        <ClInclude Include="PipelineState.h" />
+        <ClInclude Include="PixelBuffer.h" />
+        <ClInclude Include="PostEffects.h" />
+        <ClInclude Include="EngineTuning.h" />
+        <ClInclude Include="Display.h" />
+        <ClInclude Include="ReadbackBuffer.h" />
+        <ClInclude Include="RootSignature.h" />
+        <ClInclude Include="SamplerManager.h" />
+        <ClInclude Include="ShadowBuffer.h" />
+        <ClInclude Include="ShadowCamera.h" />
+        <ClInclude Include="SSAO.h" />
+        <ClInclude Include="SystemTime.h" />
+        <ClInclude Include="TemporalEffects.h" />
+        <ClInclude Include="TextRenderer.h" />
+        <ClInclude Include="Texture.h" />
+        <ClInclude Include="TextureManager.h" />
+        <ClInclude Include="UploadBuffer.h" />
+        <ClInclude Include="Utility.h" />
+        <ClInclude Include="Util\CommandLineArg.h" />
+        <ClInclude Include="VectorMath.h" />
+    </ItemGroup>
+    <ItemGroup>
+        <ClCompile Include="BitonicSort.cpp" />
+        <ClCompile Include="BuddyAllocator.cpp" />
+        <ClCompile Include="BufferManager.cpp" />
+        <ClCompile Include="Camera.cpp" />
+        <ClCompile Include="CameraController.cpp" />
+        <ClCompile Include="Color.cpp" />
+        <ClCompile Include="ColorBuffer.cpp" />
+        <ClCompile Include="CommandAllocatorPool.cpp" />
+        <ClCompile Include="CommandContext.cpp" />
+        <ClCompile Include="CommandListManager.cpp" />
+        <ClCompile Include="CommandSignature.cpp" />
+        <ClCompile Include="DDSTextureLoader.cpp" />
+        <ClCompile Include="DepthBuffer.cpp" />
+        <ClCompile Include="DepthOfField.cpp" />
+        <ClCompile Include="DynamicDescriptorHeap.cpp" />
+        <ClCompile Include="DescriptorHeap.cpp" />
+        <ClCompile Include="EngineProfiling.cpp" />
+        <ClCompile Include="EngineTuning.cpp" />
+        <ClCompile Include="FileUtility.cpp" />
+        <ClCompile Include="FXAA.cpp" />
+        <ClCompile Include="Input.cpp" />
+        <ClCompile Include="GameCore.cpp" />
+        <ClCompile Include="GpuBuffer.cpp" />
+        <ClCompile Include="GpuTimeManager.cpp" />
+        <ClCompile Include="GraphicsCommon.cpp" />
+        <ClCompile Include="GraphicsCore.cpp" />
+        <ClCompile Include="GraphRenderer.cpp" />
+        <ClCompile Include="ImageScaling.cpp" />
+        <ClCompile Include="LinearAllocator.cpp" />
+        <ClCompile Include="Math\BoundingSphere.cpp" />
+        <ClCompile Include="Math\Frustum.cpp" />
+        <ClCompile Include="Math\Random.cpp" />
+        <ClCompile Include="MotionBlur.cpp" />
+        <ClCompile Include="ParticleEffect.cpp" />
+        <ClCompile Include="ParticleEffectManager.cpp" />
+        <ClCompile Include="ParticleEmissionProperties.cpp" />
+        <ClCompile Include="pch.cpp">
+            <PrecompiledHeader>Create</PrecompiledHeader>
+        </ClCompile>
+        <ClCompile Include="PipelineState.cpp" />
+        <ClCompile Include="PixelBuffer.cpp" />
+        <ClCompile Include="PostEffects.cpp" />
+        <ClCompile Include="Display.cpp" />
+        <ClCompile Include="ReadbackBuffer.cpp" />
+        <ClCompile Include="RootSignature.cpp" />
+        <ClCompile Include="SamplerManager.cpp" />
+        <ClCompile Include="ShadowBuffer.cpp" />
+        <ClCompile Include="ShadowCamera.cpp" />
+        <ClCompile Include="SSAO.cpp" />
+        <ClCompile Include="SystemTime.cpp" />
+        <ClCompile Include="TemporalEffects.cpp" />
+        <ClCompile Include="TextRenderer.cpp" />
+        <ClCompile Include="Texture.cpp" />
+        <ClCompile Include="TextureManager.cpp" />
+        <ClCompile Include="UploadBuffer.cpp" />
+        <ClCompile Include="Utility.cpp" />
+        <ClCompile Include="Util\CommandLineArg.cpp" />
+    </ItemGroup>
+    <ItemGroup>
+        <FxCompile Include="Shaders\AdaptExposureCS.hlsl" />
+        <FxCompile Include="Shaders\AoBlurUpsampleBlendOutCS.hlsl" />
+        <FxCompile Include="Shaders\AoBlurUpsampleCS.hlsl" />
+        <FxCompile Include="Shaders\AoBlurUpsamplePreMinBlendOutCS.hlsl" />
+        <FxCompile Include="Shaders\AoBlurUpsamplePreMinCS.hlsl" />
+        <FxCompile Include="Shaders\AoPrepareDepthBuffers1CS.hlsl" />
+        <FxCompile Include="Shaders\AoPrepareDepthBuffers2CS.hlsl" />
+        <FxCompile Include="Shaders\AoRender1CS.hlsl" />
+        <FxCompile Include="Shaders\AoRender2CS.hlsl" />
+        <FxCompile Include="Shaders\ApplyBloom2CS.hlsl" />
+        <FxCompile Include="Shaders\ApplyBloomCS.hlsl" />
+        <FxCompile Include="Shaders\AverageLumaCS.hlsl" />
+        <FxCompile Include="Shaders\BicubicHorizontalUpsamplePS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\BicubicUpsampleCS.hlsl" />
+        <FxCompile Include="Shaders\BicubicUpsampleFast16CS.hlsl" />
+        <FxCompile Include="Shaders\BicubicUpsampleFast24CS.hlsl" />
+        <FxCompile Include="Shaders\BicubicUpsampleFast32CS.hlsl" />
+        <FxCompile Include="Shaders\BicubicUpsampleGammaPS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\BicubicUpsamplePS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\BicubicVerticalUpsamplePS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\BilinearUpsamplePS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\Bitonic32InnerSortCS.hlsl" />
+        <FxCompile Include="Shaders\Bitonic32OuterSortCS.hlsl" />
+        <FxCompile Include="Shaders\Bitonic32PreSortCS.hlsl" />
+        <FxCompile Include="Shaders\Bitonic64InnerSortCS.hlsl" />
+        <FxCompile Include="Shaders\Bitonic64OuterSortCS.hlsl" />
+        <FxCompile Include="Shaders\Bitonic64PreSortCS.hlsl" />
+        <FxCompile Include="Shaders\BitonicIndirectArgsCS.hlsl" />
+        <FxCompile Include="Shaders\BlendUIHDRPS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\BloomExtractAndDownsampleHdrCS.hlsl" />
+        <FxCompile Include="Shaders\BloomExtractAndDownsampleLdrCS.hlsl" />
+        <FxCompile Include="Shaders\BlurCS.hlsl" />
+        <FxCompile Include="Shaders\BoundNeighborhoodCS.hlsl" />
+        <FxCompile Include="Shaders\BufferCopyPS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\CameraMotionBlurPrePassCS.hlsl" />
+        <FxCompile Include="Shaders\CameraMotionBlurPrePassLinearZCS.hlsl" />
+        <FxCompile Include="Shaders\CameraVelocityCS.hlsl" />
+        <FxCompile Include="Shaders\CompositeHDRPS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\CompositeSDRPS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\CopyBackPostBufferCS.hlsl" />
+        <FxCompile Include="Shaders\DebugDrawHistogramCS.hlsl" />
+        <FxCompile Include="Shaders\DebugLuminanceHdr2CS.hlsl" />
+        <FxCompile Include="Shaders\DebugLuminanceHdrCS.hlsl" />
+        <FxCompile Include="Shaders\DebugLuminanceLdr2CS.hlsl" />
+        <FxCompile Include="Shaders\DebugLuminanceLdrCS.hlsl" />
+        <FxCompile Include="Shaders\DebugSSAOCS.hlsl" />
+        <FxCompile Include="Shaders\DoFCombine2CS.hlsl" />
+        <FxCompile Include="Shaders\DoFCombineCS.hlsl" />
+        <FxCompile Include="Shaders\DoFCombineFast2CS.hlsl" />
+        <FxCompile Include="Shaders\DoFCombineFastCS.hlsl" />
+        <FxCompile Include="Shaders\DoFDebugBlueCS.hlsl" />
+        <FxCompile Include="Shaders\DoFDebugGreenCS.hlsl" />
+        <FxCompile Include="Shaders\DoFDebugRedCS.hlsl" />
+        <FxCompile Include="Shaders\DoFMedianFilterCS.hlsl" />
+        <FxCompile Include="Shaders\DoFMedianFilterFixupCS.hlsl" />
+        <FxCompile Include="Shaders\DoFMedianFilterSepAlphaCS.hlsl" />
+        <FxCompile Include="Shaders\DoFPass1CS.hlsl" />
+        <FxCompile Include="Shaders\DoFPass2CS.hlsl" />
+        <FxCompile Include="Shaders\DoFPass2DebugCS.hlsl" />
+        <FxCompile Include="Shaders\DoFPass2FastCS.hlsl" />
+        <FxCompile Include="Shaders\DoFPass2FixupCS.hlsl" />
+        <FxCompile Include="Shaders\DoFPreFilterCS.hlsl" />
+        <FxCompile Include="Shaders\DoFPreFilterFastCS.hlsl" />
+        <FxCompile Include="Shaders\DoFPreFilterFixupCS.hlsl" />
+        <FxCompile Include="Shaders\DoFTilePassCS.hlsl" />
+        <FxCompile Include="Shaders\DoFTilePassFixupCS.hlsl" />
+        <FxCompile Include="Shaders\DownsampleBloomAllCS.hlsl" />
+        <FxCompile Include="Shaders\DownsampleBloomCS.hlsl" />
+        <FxCompile Include="Shaders\DownsampleDepthPS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\ExtractLumaCS.hlsl" />
+        <FxCompile Include="Shaders\FXAAPass1_Luma2_CS.hlsl" />
+        <FxCompile Include="Shaders\FXAAPass1_Luma_CS.hlsl" />
+        <FxCompile Include="Shaders\FXAAPass1_RGB2_CS.hlsl" />
+        <FxCompile Include="Shaders\FXAAPass1_RGB_CS.hlsl" />
+        <FxCompile Include="Shaders\FXAAPass2H2CS.hlsl" />
+        <FxCompile Include="Shaders\FXAAPass2HDebug2CS.hlsl" />
+        <FxCompile Include="Shaders\FXAAPass2HDebugCS.hlsl" />
+        <FxCompile Include="Shaders\FXAAPass2V2CS.hlsl" />
+        <FxCompile Include="Shaders\FXAAPass2VDebug2CS.hlsl" />
+        <FxCompile Include="Shaders\FXAAPass2VDebugCS.hlsl" />
+        <FxCompile Include="Shaders\GenerateHistogramCS.hlsl" />
+        <FxCompile Include="Shaders\FXAAPass2HCS.hlsl" />
+        <FxCompile Include="Shaders\FXAAPass2VCS.hlsl" />
+        <FxCompile Include="Shaders\GenerateMipsGammaCS.hlsl" />
+        <FxCompile Include="Shaders\GenerateMipsGammaOddCS.hlsl" />
+        <FxCompile Include="Shaders\GenerateMipsGammaOddXCS.hlsl" />
+        <FxCompile Include="Shaders\GenerateMipsGammaOddYCS.hlsl" />
+        <FxCompile Include="Shaders\GenerateMipsLinearCS.hlsl" />
+        <FxCompile Include="Shaders\GenerateMipsLinearOddCS.hlsl" />
+        <FxCompile Include="Shaders\GenerateMipsLinearOddXCS.hlsl" />
+        <FxCompile Include="Shaders\GenerateMipsLinearOddYCS.hlsl" />
+        <FxCompile Include="Shaders\LanczosCS.hlsl" />
+        <FxCompile Include="Shaders\LanczosFast16CS.hlsl" />
+        <FxCompile Include="Shaders\LanczosFast24CS.hlsl" />
+        <FxCompile Include="Shaders\LanczosFast32CS.hlsl" />
+        <FxCompile Include="Shaders\LanczosHorizontalPS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\LanczosVerticalPS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\LinearizeDepthCS.hlsl" />
+        <FxCompile Include="Shaders\MagnifyPixelsPS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\MotionBlurFinalPassCS.hlsl" />
+        <FxCompile Include="Shaders\MotionBlurFinalPassPS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\MotionBlurPrePassCS.hlsl" />
+        <FxCompile Include="Shaders\FXAAResolveWorkQueueCS.hlsl" />
+        <FxCompile Include="Shaders\ParticleBinCullingCS.hlsl" />
+        <FxCompile Include="Shaders\ParticleDepthBoundsCS.hlsl" />
+        <FxCompile Include="Shaders\ParticleDispatchIndirectArgsCS.hlsl" />
+        <FxCompile Include="Shaders\ParticleFinalDispatchIndirectArgsCS.hlsl" />
+        <FxCompile Include="Shaders\ParticleLargeBinCullingCS.hlsl" />
+        <FxCompile Include="Shaders\ParticleNoSortVS.hlsl">
+            <ShaderType>Vertex</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\ParticlePreSortCS.hlsl" />
+        <FxCompile Include="Shaders\ParticlePS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\ParticleSortIndirectArgsCS.hlsl" />
+        <FxCompile Include="Shaders\ParticleSpawnCS.hlsl" />
+        <FxCompile Include="Shaders\ParticleTileCullingCS.hlsl" />
+        <FxCompile Include="Shaders\ParticleTileRender2CS.hlsl" />
+        <FxCompile Include="Shaders\ParticleTileRenderCS.hlsl" />
+        <FxCompile Include="Shaders\ParticleTileRenderFast2CS.hlsl" />
+        <FxCompile Include="Shaders\ParticleTileRenderFastCS.hlsl" />
+        <FxCompile Include="Shaders\ParticleTileRenderFastDynamic2CS.hlsl" />
+        <FxCompile Include="Shaders\ParticleTileRenderFastDynamicCS.hlsl" />
+        <FxCompile Include="Shaders\ParticleTileRenderFastLowRes2CS.hlsl" />
+        <FxCompile Include="Shaders\ParticleTileRenderFastLowResCS.hlsl" />
+        <FxCompile Include="Shaders\ParticleTileRenderSlowDynamic2CS.hlsl" />
+        <FxCompile Include="Shaders\ParticleTileRenderSlowDynamicCS.hlsl" />
+        <FxCompile Include="Shaders\ParticleTileRenderSlowLowRes2CS.hlsl" />
+        <FxCompile Include="Shaders\ParticleTileRenderSlowLowResCS.hlsl" />
+        <FxCompile Include="Shaders\ParticleUpdateCS.hlsl" />
+        <FxCompile Include="Shaders\ParticleVS.hlsl">
+            <ShaderType>Vertex</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\PerfGraphBackgroundVS.hlsl">
+            <ShaderType>Vertex</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\PerfGraphPS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\PerfGraphVS.hlsl">
+            <ShaderType>Vertex</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\PresentHDRPS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\PresentSDRPS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\ResolveTAACS.hlsl" />
+        <FxCompile Include="Shaders\ScaleAndCompositeHDRPS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\ScaleAndCompositeSDRPS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\ScreenQuadCommonVS.hlsl">
+            <ShaderType>Vertex</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\ScreenQuadPresentVS.hlsl">
+            <ShaderType>Vertex</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\SharpeningUpsampleGammaPS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\SharpeningUpsamplePS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\SharpenTAACS.hlsl" />
+        <FxCompile Include="Shaders\TemporalBlendCS.hlsl" />
+        <FxCompile Include="Shaders\TextAntialiasPS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\TextShadowPS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\TextVS.hlsl">
+            <ShaderType>Vertex</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\ToneMapHDR2CS.hlsl" />
+        <FxCompile Include="Shaders\ToneMapHDRCS.hlsl" />
+        <None Include="Math\Functions.inl" />
+        <None Include="packages.config" />
+        <None Include="Shaders\AoBlurAndUpsampleCS.hlsli" />
+        <None Include="Shaders\AoRenderCS.hlsli" />
+        <None Include="Shaders\BicubicFilterFunctions.hlsli" />
+        <None Include="Shaders\BitonicSortCommon.hlsli" />
+        <None Include="Shaders\ColorSpaceUtility.hlsli" />
+        <None Include="Shaders\CommonRS.hlsli" />
+        <None Include="Shaders\DoFCommon.hlsli" />
+        <None Include="Shaders\DoFRS.hlsli" />
+        <None Include="Shaders\FXAAPass1CS.hlsli" />
+        <None Include="Shaders\FXAAPass2CS.hlsli" />
+        <None Include="Shaders\FXAARootSignature.hlsli" />
+        <None Include="Shaders\GenerateMipsCS.hlsli" />
+        <None Include="Shaders\LanczosFunctions.hlsli" />
+        <None Include="Shaders\MotionBlurRS.hlsli" />
+        <None Include="Shaders\ParticleRS.hlsli" />
+        <None Include="Shaders\ParticleUpdateCommon.hlsli" />
+        <None Include="Shaders\ParticleUtility.hlsli" />
+        <None Include="Shaders\PerfGraphRS.hlsli" />
+        <None Include="Shaders\PixelPacking_R11G11B10.hlsli" />
+        <None Include="Shaders\PixelPacking_RGBE.hlsli" />
+        <None Include="Shaders\PixelPacking_RGBM.hlsli" />
+        <None Include="Shaders\PostEffectsRS.hlsli" />
+        <None Include="Shaders\PresentRS.hlsli" />
+        <None Include="Shaders\ShaderUtility.hlsli" />
+        <FxCompile Include="Shaders\ToneMap2CS.hlsl" />
+        <FxCompile Include="Shaders\ToneMapCS.hlsl" />
+        <FxCompile Include="Shaders\UpsampleAndBlurCS.hlsl" />
+        <None Include="Shaders\PixelPacking.hlsli" />
+        <None Include="Shaders\SSAORS.hlsli" />
+        <None Include="Shaders\TextRS.hlsli" />
+    </ItemGroup>
+    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+    <ItemDefinitionGroup>
+        <ClCompile>
+            <AdditionalIncludeDirectories>..\..\Packages\zlib-msvc-x64.1.2.11.8900\build\native\include;..\..\Packages\WinPixEventRuntime.1.0.210209001\Include\WinPixEventRuntime;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+            <PreprocessorDefinitions>_GAMING_DESKTOP;__WRL_NO_DEFAULT_LIB__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+        </ClCompile>
+    </ItemDefinitionGroup>
+    <ImportGroup Label="ExtensionTargets">
+        <Import Project="..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
+        <Import Project="..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets" Condition="Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" />
+    </ImportGroup>
+    <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+        <PropertyGroup>
+            <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+        </PropertyGroup>
+        <Error Condition="!Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
+        <Error Condition="!Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets'))" />
+    </Target>
 </Project>

--- a/Samples/BulkLoadDemo/Core/Core.vcxproj
+++ b/Samples/BulkLoadDemo/Core/Core.vcxproj
@@ -1,454 +1,454 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|x64">
-      <Configuration>Debug</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Profile|x64">
-      <Configuration>Profile</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|x64">
-      <Configuration>Release</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-  </ItemGroup>
-  <PropertyGroup Label="Globals">
-    <RootNamespace>Core</RootNamespace>
-    <ProjectGuid>{86A58508-0D6A-4786-A32F-01A301FDC6F3}</ProjectGuid>
-    <DefaultLanguage>en-US</DefaultLanguage>
-    <Keyword>Win32Proj</Keyword>
-    <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-    <TargetRuntime>Native</TargetRuntime>
-  </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-    <EmbedManifest>false</EmbedManifest>
-    <GenerateManifest>false</GenerateManifest>
-  </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <ImportGroup Label="ExtensionSettings" />
-  <ImportGroup Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\PropertySheets\Build.props" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Platform)'=='x64'" Label="PropertySheets">
-    <Import Project="..\PropertySheets\Desktop.props" />
-  </ImportGroup>
-  <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup>
-    <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <RuntimeTypeInfo>true</RuntimeTypeInfo>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
-    <Link>
-      <AdditionalDependencies>d3d11.lib;dxguid.lib;winmm.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <SubSystem>Windows</SubSystem>
-      <DataExecutionPrevention>true</DataExecutionPrevention>
-    </Link>
-    <Manifest>
-      <EnableDPIAwareness>true</EnableDPIAwareness>
-    </Manifest>
-  </ItemDefinitionGroup>
-  <ItemGroup>
-    <ClInclude Include="BitonicSort.h" />
-    <ClInclude Include="BuddyAllocator.h" />
-    <ClInclude Include="BufferManager.h" />
-    <ClInclude Include="Camera.h" />
-    <ClInclude Include="CameraController.h" />
-    <ClInclude Include="Color.h" />
-    <ClInclude Include="ColorBuffer.h" />
-    <ClInclude Include="CommandAllocatorPool.h" />
-    <ClInclude Include="CommandContext.h" />
-    <ClInclude Include="CommandListManager.h" />
-    <ClInclude Include="CommandSignature.h" />
-    <ClInclude Include="d3dx12.h" />
-    <ClInclude Include="dds.h" />
-    <ClInclude Include="DDSTextureLoader.h" />
-    <ClInclude Include="DepthBuffer.h" />
-    <ClInclude Include="DepthOfField.h" />
-    <ClInclude Include="DynamicDescriptorHeap.h" />
-    <ClInclude Include="DescriptorHeap.h" />
-    <ClInclude Include="GpuBuffer.h" />
-    <ClInclude Include="EngineProfiling.h" />
-    <ClInclude Include="EsramAllocator.h" />
-    <ClInclude Include="FileUtility.h" />
-    <ClInclude Include="FXAA.h" />
-    <ClInclude Include="GameInput.h" />
-    <ClInclude Include="GpuResource.h" />
-    <ClInclude Include="GpuTimeManager.h" />
-    <ClInclude Include="GameCore.h" />
-    <ClInclude Include="GraphicsCommon.h" />
-    <ClInclude Include="GraphicsCore.h" />
-    <ClInclude Include="GraphRenderer.h" />
-    <ClInclude Include="Hash.h" />
-    <ClInclude Include="ImageScaling.h" />
-    <ClInclude Include="LinearAllocator.h" />
-    <ClInclude Include="Math\BoundingBox.h" />
-    <ClInclude Include="Math\BoundingPlane.h" />
-    <ClInclude Include="Math\BoundingSphere.h" />
-    <ClInclude Include="Math\Common.h" />
-    <ClInclude Include="Math\Frustum.h" />
-    <ClInclude Include="Math\Matrix3.h" />
-    <ClInclude Include="Math\Matrix4.h" />
-    <ClInclude Include="Math\Quaternion.h" />
-    <ClInclude Include="Math\Random.h" />
-    <ClInclude Include="Math\Scalar.h" />
-    <ClInclude Include="Math\Transform.h" />
-    <ClInclude Include="Math\Vector.h" />
-    <ClInclude Include="MotionBlur.h" />
-    <ClInclude Include="ParticleEffect.h" />
-    <ClInclude Include="ParticleEffectManager.h" />
-    <ClInclude Include="ParticleEffectProperties.h" />
-    <ClInclude Include="ParticleShaderStructs.h" />
-    <ClInclude Include="pch.h" />
-    <ClInclude Include="PipelineState.h" />
-    <ClInclude Include="PixelBuffer.h" />
-    <ClInclude Include="PostEffects.h" />
-    <ClInclude Include="EngineTuning.h" />
-    <ClInclude Include="Display.h" />
-    <ClInclude Include="ReadbackBuffer.h" />
-    <ClInclude Include="RootSignature.h" />
-    <ClInclude Include="SamplerManager.h" />
-    <ClInclude Include="ShadowBuffer.h" />
-    <ClInclude Include="ShadowCamera.h" />
-    <ClInclude Include="SSAO.h" />
-    <ClInclude Include="SystemTime.h" />
-    <ClInclude Include="TemporalEffects.h" />
-    <ClInclude Include="TextRenderer.h" />
-    <ClInclude Include="Texture.h" />
-    <ClInclude Include="TextureManager.h" />
-    <ClInclude Include="UploadBuffer.h" />
-    <ClInclude Include="Utility.h" />
-    <ClInclude Include="Util\CommandLineArg.h" />
-    <ClInclude Include="VectorMath.h" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClCompile Include="BitonicSort.cpp" />
-    <ClCompile Include="BuddyAllocator.cpp" />
-    <ClCompile Include="BufferManager.cpp" />
-    <ClCompile Include="Camera.cpp" />
-    <ClCompile Include="CameraController.cpp" />
-    <ClCompile Include="Color.cpp" />
-    <ClCompile Include="ColorBuffer.cpp" />
-    <ClCompile Include="CommandAllocatorPool.cpp" />
-    <ClCompile Include="CommandContext.cpp" />
-    <ClCompile Include="CommandListManager.cpp" />
-    <ClCompile Include="CommandSignature.cpp" />
-    <ClCompile Include="DDSTextureLoader.cpp" />
-    <ClCompile Include="DepthBuffer.cpp" />
-    <ClCompile Include="DepthOfField.cpp" />
-    <ClCompile Include="DynamicDescriptorHeap.cpp" />
-    <ClCompile Include="DescriptorHeap.cpp" />
-    <ClCompile Include="EngineProfiling.cpp" />
-    <ClCompile Include="EngineTuning.cpp" />
-    <ClCompile Include="FileUtility.cpp" />
-    <ClCompile Include="FXAA.cpp" />
-    <ClCompile Include="Input.cpp" />
-    <ClCompile Include="GameCore.cpp" />
-    <ClCompile Include="GpuBuffer.cpp" />
-    <ClCompile Include="GpuTimeManager.cpp" />
-    <ClCompile Include="GraphicsCommon.cpp" />
-    <ClCompile Include="GraphicsCore.cpp" />
-    <ClCompile Include="GraphRenderer.cpp" />
-    <ClCompile Include="ImageScaling.cpp" />
-    <ClCompile Include="LinearAllocator.cpp" />
-    <ClCompile Include="Math\BoundingSphere.cpp" />
-    <ClCompile Include="Math\Frustum.cpp" />
-    <ClCompile Include="Math\Random.cpp" />
-    <ClCompile Include="MotionBlur.cpp" />
-    <ClCompile Include="ParticleEffect.cpp" />
-    <ClCompile Include="ParticleEffectManager.cpp" />
-    <ClCompile Include="ParticleEmissionProperties.cpp" />
-    <ClCompile Include="pch.cpp">
-      <PrecompiledHeader>Create</PrecompiledHeader>
-    </ClCompile>
-    <ClCompile Include="PipelineState.cpp" />
-    <ClCompile Include="PixelBuffer.cpp" />
-    <ClCompile Include="PostEffects.cpp" />
-    <ClCompile Include="Display.cpp" />
-    <ClCompile Include="ReadbackBuffer.cpp" />
-    <ClCompile Include="RootSignature.cpp" />
-    <ClCompile Include="SamplerManager.cpp" />
-    <ClCompile Include="ShadowBuffer.cpp" />
-    <ClCompile Include="ShadowCamera.cpp" />
-    <ClCompile Include="SSAO.cpp" />
-    <ClCompile Include="SystemTime.cpp" />
-    <ClCompile Include="TemporalEffects.cpp" />
-    <ClCompile Include="TextRenderer.cpp" />
-    <ClCompile Include="Texture.cpp" />
-    <ClCompile Include="TextureManager.cpp" />
-    <ClCompile Include="UploadBuffer.cpp" />
-    <ClCompile Include="Utility.cpp" />
-    <ClCompile Include="Util\CommandLineArg.cpp" />
-  </ItemGroup>
-  <ItemGroup>
-    <FxCompile Include="Shaders\AdaptExposureCS.hlsl" />
-    <FxCompile Include="Shaders\AoBlurUpsampleBlendOutCS.hlsl" />
-    <FxCompile Include="Shaders\AoBlurUpsampleCS.hlsl" />
-    <FxCompile Include="Shaders\AoBlurUpsamplePreMinBlendOutCS.hlsl" />
-    <FxCompile Include="Shaders\AoBlurUpsamplePreMinCS.hlsl" />
-    <FxCompile Include="Shaders\AoPrepareDepthBuffers1CS.hlsl" />
-    <FxCompile Include="Shaders\AoPrepareDepthBuffers2CS.hlsl" />
-    <FxCompile Include="Shaders\AoRender1CS.hlsl" />
-    <FxCompile Include="Shaders\AoRender2CS.hlsl" />
-    <FxCompile Include="Shaders\ApplyBloom2CS.hlsl" />
-    <FxCompile Include="Shaders\ApplyBloomCS.hlsl" />
-    <FxCompile Include="Shaders\AverageLumaCS.hlsl" />
-    <FxCompile Include="Shaders\BicubicHorizontalUpsamplePS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\BicubicUpsampleCS.hlsl" />
-    <FxCompile Include="Shaders\BicubicUpsampleFast16CS.hlsl" />
-    <FxCompile Include="Shaders\BicubicUpsampleFast24CS.hlsl" />
-    <FxCompile Include="Shaders\BicubicUpsampleFast32CS.hlsl" />
-    <FxCompile Include="Shaders\BicubicUpsampleGammaPS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\BicubicUpsamplePS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\BicubicVerticalUpsamplePS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\BilinearUpsamplePS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\Bitonic32InnerSortCS.hlsl" />
-    <FxCompile Include="Shaders\Bitonic32OuterSortCS.hlsl" />
-    <FxCompile Include="Shaders\Bitonic32PreSortCS.hlsl" />
-    <FxCompile Include="Shaders\Bitonic64InnerSortCS.hlsl" />
-    <FxCompile Include="Shaders\Bitonic64OuterSortCS.hlsl" />
-    <FxCompile Include="Shaders\Bitonic64PreSortCS.hlsl" />
-    <FxCompile Include="Shaders\BitonicIndirectArgsCS.hlsl" />
-    <FxCompile Include="Shaders\BlendUIHDRPS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\BloomExtractAndDownsampleHdrCS.hlsl" />
-    <FxCompile Include="Shaders\BloomExtractAndDownsampleLdrCS.hlsl" />
-    <FxCompile Include="Shaders\BlurCS.hlsl" />
-    <FxCompile Include="Shaders\BoundNeighborhoodCS.hlsl" />
-    <FxCompile Include="Shaders\BufferCopyPS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\CameraMotionBlurPrePassCS.hlsl" />
-    <FxCompile Include="Shaders\CameraMotionBlurPrePassLinearZCS.hlsl" />
-    <FxCompile Include="Shaders\CameraVelocityCS.hlsl" />
-    <FxCompile Include="Shaders\CompositeHDRPS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\CompositeSDRPS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\CopyBackPostBufferCS.hlsl" />
-    <FxCompile Include="Shaders\DebugDrawHistogramCS.hlsl" />
-    <FxCompile Include="Shaders\DebugLuminanceHdr2CS.hlsl" />
-    <FxCompile Include="Shaders\DebugLuminanceHdrCS.hlsl" />
-    <FxCompile Include="Shaders\DebugLuminanceLdr2CS.hlsl" />
-    <FxCompile Include="Shaders\DebugLuminanceLdrCS.hlsl" />
-    <FxCompile Include="Shaders\DebugSSAOCS.hlsl" />
-    <FxCompile Include="Shaders\DoFCombine2CS.hlsl" />
-    <FxCompile Include="Shaders\DoFCombineCS.hlsl" />
-    <FxCompile Include="Shaders\DoFCombineFast2CS.hlsl" />
-    <FxCompile Include="Shaders\DoFCombineFastCS.hlsl" />
-    <FxCompile Include="Shaders\DoFDebugBlueCS.hlsl" />
-    <FxCompile Include="Shaders\DoFDebugGreenCS.hlsl" />
-    <FxCompile Include="Shaders\DoFDebugRedCS.hlsl" />
-    <FxCompile Include="Shaders\DoFMedianFilterCS.hlsl" />
-    <FxCompile Include="Shaders\DoFMedianFilterFixupCS.hlsl" />
-    <FxCompile Include="Shaders\DoFMedianFilterSepAlphaCS.hlsl" />
-    <FxCompile Include="Shaders\DoFPass1CS.hlsl" />
-    <FxCompile Include="Shaders\DoFPass2CS.hlsl" />
-    <FxCompile Include="Shaders\DoFPass2DebugCS.hlsl" />
-    <FxCompile Include="Shaders\DoFPass2FastCS.hlsl" />
-    <FxCompile Include="Shaders\DoFPass2FixupCS.hlsl" />
-    <FxCompile Include="Shaders\DoFPreFilterCS.hlsl" />
-    <FxCompile Include="Shaders\DoFPreFilterFastCS.hlsl" />
-    <FxCompile Include="Shaders\DoFPreFilterFixupCS.hlsl" />
-    <FxCompile Include="Shaders\DoFTilePassCS.hlsl" />
-    <FxCompile Include="Shaders\DoFTilePassFixupCS.hlsl" />
-    <FxCompile Include="Shaders\DownsampleBloomAllCS.hlsl" />
-    <FxCompile Include="Shaders\DownsampleBloomCS.hlsl" />
-    <FxCompile Include="Shaders\DownsampleDepthPS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\ExtractLumaCS.hlsl" />
-    <FxCompile Include="Shaders\FXAAPass1_Luma2_CS.hlsl" />
-    <FxCompile Include="Shaders\FXAAPass1_Luma_CS.hlsl" />
-    <FxCompile Include="Shaders\FXAAPass1_RGB2_CS.hlsl" />
-    <FxCompile Include="Shaders\FXAAPass1_RGB_CS.hlsl" />
-    <FxCompile Include="Shaders\FXAAPass2H2CS.hlsl" />
-    <FxCompile Include="Shaders\FXAAPass2HDebug2CS.hlsl" />
-    <FxCompile Include="Shaders\FXAAPass2HDebugCS.hlsl" />
-    <FxCompile Include="Shaders\FXAAPass2V2CS.hlsl" />
-    <FxCompile Include="Shaders\FXAAPass2VDebug2CS.hlsl" />
-    <FxCompile Include="Shaders\FXAAPass2VDebugCS.hlsl" />
-    <FxCompile Include="Shaders\GenerateHistogramCS.hlsl" />
-    <FxCompile Include="Shaders\FXAAPass2HCS.hlsl" />
-    <FxCompile Include="Shaders\FXAAPass2VCS.hlsl" />
-    <FxCompile Include="Shaders\GenerateMipsGammaCS.hlsl" />
-    <FxCompile Include="Shaders\GenerateMipsGammaOddCS.hlsl" />
-    <FxCompile Include="Shaders\GenerateMipsGammaOddXCS.hlsl" />
-    <FxCompile Include="Shaders\GenerateMipsGammaOddYCS.hlsl" />
-    <FxCompile Include="Shaders\GenerateMipsLinearCS.hlsl" />
-    <FxCompile Include="Shaders\GenerateMipsLinearOddCS.hlsl" />
-    <FxCompile Include="Shaders\GenerateMipsLinearOddXCS.hlsl" />
-    <FxCompile Include="Shaders\GenerateMipsLinearOddYCS.hlsl" />
-    <FxCompile Include="Shaders\LanczosCS.hlsl" />
-    <FxCompile Include="Shaders\LanczosFast16CS.hlsl" />
-    <FxCompile Include="Shaders\LanczosFast24CS.hlsl" />
-    <FxCompile Include="Shaders\LanczosFast32CS.hlsl" />
-    <FxCompile Include="Shaders\LanczosHorizontalPS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\LanczosVerticalPS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\LinearizeDepthCS.hlsl" />
-    <FxCompile Include="Shaders\MagnifyPixelsPS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\MotionBlurFinalPassCS.hlsl" />
-    <FxCompile Include="Shaders\MotionBlurFinalPassPS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\MotionBlurPrePassCS.hlsl" />
-    <FxCompile Include="Shaders\FXAAResolveWorkQueueCS.hlsl" />
-    <FxCompile Include="Shaders\ParticleBinCullingCS.hlsl" />
-    <FxCompile Include="Shaders\ParticleDepthBoundsCS.hlsl" />
-    <FxCompile Include="Shaders\ParticleDispatchIndirectArgsCS.hlsl" />
-    <FxCompile Include="Shaders\ParticleFinalDispatchIndirectArgsCS.hlsl" />
-    <FxCompile Include="Shaders\ParticleLargeBinCullingCS.hlsl" />
-    <FxCompile Include="Shaders\ParticleNoSortVS.hlsl">
-      <ShaderType>Vertex</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\ParticlePreSortCS.hlsl" />
-    <FxCompile Include="Shaders\ParticlePS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\ParticleSortIndirectArgsCS.hlsl" />
-    <FxCompile Include="Shaders\ParticleSpawnCS.hlsl" />
-    <FxCompile Include="Shaders\ParticleTileCullingCS.hlsl" />
-    <FxCompile Include="Shaders\ParticleTileRender2CS.hlsl" />
-    <FxCompile Include="Shaders\ParticleTileRenderCS.hlsl" />
-    <FxCompile Include="Shaders\ParticleTileRenderFast2CS.hlsl" />
-    <FxCompile Include="Shaders\ParticleTileRenderFastCS.hlsl" />
-    <FxCompile Include="Shaders\ParticleTileRenderFastDynamic2CS.hlsl" />
-    <FxCompile Include="Shaders\ParticleTileRenderFastDynamicCS.hlsl" />
-    <FxCompile Include="Shaders\ParticleTileRenderFastLowRes2CS.hlsl" />
-    <FxCompile Include="Shaders\ParticleTileRenderFastLowResCS.hlsl" />
-    <FxCompile Include="Shaders\ParticleTileRenderSlowDynamic2CS.hlsl" />
-    <FxCompile Include="Shaders\ParticleTileRenderSlowDynamicCS.hlsl" />
-    <FxCompile Include="Shaders\ParticleTileRenderSlowLowRes2CS.hlsl" />
-    <FxCompile Include="Shaders\ParticleTileRenderSlowLowResCS.hlsl" />
-    <FxCompile Include="Shaders\ParticleUpdateCS.hlsl" />
-    <FxCompile Include="Shaders\ParticleVS.hlsl">
-      <ShaderType>Vertex</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\PerfGraphBackgroundVS.hlsl">
-      <ShaderType>Vertex</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\PerfGraphPS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\PerfGraphVS.hlsl">
-      <ShaderType>Vertex</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\PresentHDRPS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\PresentSDRPS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\ResolveTAACS.hlsl" />
-    <FxCompile Include="Shaders\ScaleAndCompositeHDRPS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\ScaleAndCompositeSDRPS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\ScreenQuadCommonVS.hlsl">
-      <ShaderType>Vertex</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\ScreenQuadPresentVS.hlsl">
-      <ShaderType>Vertex</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\SharpeningUpsampleGammaPS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\SharpeningUpsamplePS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\SharpenTAACS.hlsl" />
-    <FxCompile Include="Shaders\TemporalBlendCS.hlsl" />
-    <FxCompile Include="Shaders\TextAntialiasPS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\TextShadowPS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\TextVS.hlsl">
-      <ShaderType>Vertex</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\ToneMapHDR2CS.hlsl" />
-    <FxCompile Include="Shaders\ToneMapHDRCS.hlsl" />
-    <None Include="Math\Functions.inl" />
-    <None Include="packages.config" />
-    <None Include="Shaders\AoBlurAndUpsampleCS.hlsli" />
-    <None Include="Shaders\AoRenderCS.hlsli" />
-    <None Include="Shaders\BicubicFilterFunctions.hlsli" />
-    <None Include="Shaders\BitonicSortCommon.hlsli" />
-    <None Include="Shaders\ColorSpaceUtility.hlsli" />
-    <None Include="Shaders\CommonRS.hlsli" />
-    <None Include="Shaders\DoFCommon.hlsli" />
-    <None Include="Shaders\DoFRS.hlsli" />
-    <None Include="Shaders\FXAAPass1CS.hlsli" />
-    <None Include="Shaders\FXAAPass2CS.hlsli" />
-    <None Include="Shaders\FXAARootSignature.hlsli" />
-    <None Include="Shaders\GenerateMipsCS.hlsli" />
-    <None Include="Shaders\LanczosFunctions.hlsli" />
-    <None Include="Shaders\MotionBlurRS.hlsli" />
-    <None Include="Shaders\ParticleRS.hlsli" />
-    <None Include="Shaders\ParticleUpdateCommon.hlsli" />
-    <None Include="Shaders\ParticleUtility.hlsli" />
-    <None Include="Shaders\PerfGraphRS.hlsli" />
-    <None Include="Shaders\PixelPacking_R11G11B10.hlsli" />
-    <None Include="Shaders\PixelPacking_RGBE.hlsli" />
-    <None Include="Shaders\PixelPacking_RGBM.hlsli" />
-    <None Include="Shaders\PostEffectsRS.hlsli" />
-    <None Include="Shaders\PresentRS.hlsli" />
-    <None Include="Shaders\ShaderUtility.hlsli" />
-    <FxCompile Include="Shaders\ToneMap2CS.hlsl" />
-    <FxCompile Include="Shaders\ToneMapCS.hlsl" />
-    <FxCompile Include="Shaders\UpsampleAndBlurCS.hlsl" />
-    <None Include="Shaders\PixelPacking.hlsli" />
-    <None Include="Shaders\SSAORS.hlsli" />
-    <None Include="Shaders\TextRS.hlsli" />
-  </ItemGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ItemDefinitionGroup>
-    <ClCompile>
-      <AdditionalIncludeDirectories>..\..\Packages\zlib-msvc-x64.1.2.11.8900\build\native\include;..\..\Packages\WinPixEventRuntime.1.0.210209001\Include\WinPixEventRuntime;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_GAMING_DESKTOP;__WRL_NO_DEFAULT_LIB__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
-    <Import Project="..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets" Condition="Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" />
-  </ImportGroup>
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
-    <Error Condition="!Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets'))" />
-  </Target>
+	<ItemGroup Label="ProjectConfigurations">
+		<ProjectConfiguration Include="Debug|x64">
+			<Configuration>Debug</Configuration>
+			<Platform>x64</Platform>
+		</ProjectConfiguration>
+		<ProjectConfiguration Include="Profile|x64">
+			<Configuration>Profile</Configuration>
+			<Platform>x64</Platform>
+		</ProjectConfiguration>
+		<ProjectConfiguration Include="Release|x64">
+			<Configuration>Release</Configuration>
+			<Platform>x64</Platform>
+		</ProjectConfiguration>
+	</ItemGroup>
+	<PropertyGroup Label="Globals">
+		<RootNamespace>Core</RootNamespace>
+		<ProjectGuid>{86A58508-0D6A-4786-A32F-01A301FDC6F3}</ProjectGuid>
+		<DefaultLanguage>en-US</DefaultLanguage>
+		<Keyword>Win32Proj</Keyword>
+		<MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
+		<WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+		<TargetRuntime>Native</TargetRuntime>
+	</PropertyGroup>
+	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+	<PropertyGroup Label="Configuration">
+		<ConfigurationType>StaticLibrary</ConfigurationType>
+		<PlatformToolset>v142</PlatformToolset>
+		<CharacterSet>Unicode</CharacterSet>
+		<EmbedManifest>false</EmbedManifest>
+		<GenerateManifest>false</GenerateManifest>
+	</PropertyGroup>
+	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+	<ImportGroup Label="ExtensionSettings" />
+	<ImportGroup Label="PropertySheets">
+		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+		<Import Project="..\PropertySheets\Build.props" />
+	</ImportGroup>
+	<ImportGroup Condition="'$(Platform)'=='x64'" Label="PropertySheets">
+		<Import Project="..\PropertySheets\Desktop.props" />
+	</ImportGroup>
+	<PropertyGroup Label="UserMacros" />
+	<ItemDefinitionGroup>
+		<ClCompile>
+			<PrecompiledHeader>Use</PrecompiledHeader>
+			<PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+			<RuntimeTypeInfo>true</RuntimeTypeInfo>
+		</ClCompile>
+	</ItemDefinitionGroup>
+	<ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
+		<Link>
+			<AdditionalDependencies>d3d11.lib;dxguid.lib;winmm.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+			<SubSystem>Windows</SubSystem>
+			<DataExecutionPrevention>true</DataExecutionPrevention>
+		</Link>
+		<Manifest>
+			<EnableDPIAwareness>true</EnableDPIAwareness>
+		</Manifest>
+	</ItemDefinitionGroup>
+	<ItemGroup>
+		<ClInclude Include="BitonicSort.h" />
+		<ClInclude Include="BuddyAllocator.h" />
+		<ClInclude Include="BufferManager.h" />
+		<ClInclude Include="Camera.h" />
+		<ClInclude Include="CameraController.h" />
+		<ClInclude Include="Color.h" />
+		<ClInclude Include="ColorBuffer.h" />
+		<ClInclude Include="CommandAllocatorPool.h" />
+		<ClInclude Include="CommandContext.h" />
+		<ClInclude Include="CommandListManager.h" />
+		<ClInclude Include="CommandSignature.h" />
+		<ClInclude Include="d3dx12.h" />
+		<ClInclude Include="dds.h" />
+		<ClInclude Include="DDSTextureLoader.h" />
+		<ClInclude Include="DepthBuffer.h" />
+		<ClInclude Include="DepthOfField.h" />
+		<ClInclude Include="DynamicDescriptorHeap.h" />
+		<ClInclude Include="DescriptorHeap.h" />
+		<ClInclude Include="GpuBuffer.h" />
+		<ClInclude Include="EngineProfiling.h" />
+		<ClInclude Include="EsramAllocator.h" />
+		<ClInclude Include="FileUtility.h" />
+		<ClInclude Include="FXAA.h" />
+		<ClInclude Include="GameInput.h" />
+		<ClInclude Include="GpuResource.h" />
+		<ClInclude Include="GpuTimeManager.h" />
+		<ClInclude Include="GameCore.h" />
+		<ClInclude Include="GraphicsCommon.h" />
+		<ClInclude Include="GraphicsCore.h" />
+		<ClInclude Include="GraphRenderer.h" />
+		<ClInclude Include="Hash.h" />
+		<ClInclude Include="ImageScaling.h" />
+		<ClInclude Include="LinearAllocator.h" />
+		<ClInclude Include="Math\BoundingBox.h" />
+		<ClInclude Include="Math\BoundingPlane.h" />
+		<ClInclude Include="Math\BoundingSphere.h" />
+		<ClInclude Include="Math\Common.h" />
+		<ClInclude Include="Math\Frustum.h" />
+		<ClInclude Include="Math\Matrix3.h" />
+		<ClInclude Include="Math\Matrix4.h" />
+		<ClInclude Include="Math\Quaternion.h" />
+		<ClInclude Include="Math\Random.h" />
+		<ClInclude Include="Math\Scalar.h" />
+		<ClInclude Include="Math\Transform.h" />
+		<ClInclude Include="Math\Vector.h" />
+		<ClInclude Include="MotionBlur.h" />
+		<ClInclude Include="ParticleEffect.h" />
+		<ClInclude Include="ParticleEffectManager.h" />
+		<ClInclude Include="ParticleEffectProperties.h" />
+		<ClInclude Include="ParticleShaderStructs.h" />
+		<ClInclude Include="pch.h" />
+		<ClInclude Include="PipelineState.h" />
+		<ClInclude Include="PixelBuffer.h" />
+		<ClInclude Include="PostEffects.h" />
+		<ClInclude Include="EngineTuning.h" />
+		<ClInclude Include="Display.h" />
+		<ClInclude Include="ReadbackBuffer.h" />
+		<ClInclude Include="RootSignature.h" />
+		<ClInclude Include="SamplerManager.h" />
+		<ClInclude Include="ShadowBuffer.h" />
+		<ClInclude Include="ShadowCamera.h" />
+		<ClInclude Include="SSAO.h" />
+		<ClInclude Include="SystemTime.h" />
+		<ClInclude Include="TemporalEffects.h" />
+		<ClInclude Include="TextRenderer.h" />
+		<ClInclude Include="Texture.h" />
+		<ClInclude Include="TextureManager.h" />
+		<ClInclude Include="UploadBuffer.h" />
+		<ClInclude Include="Utility.h" />
+		<ClInclude Include="Util\CommandLineArg.h" />
+		<ClInclude Include="VectorMath.h" />
+	</ItemGroup>
+	<ItemGroup>
+		<ClCompile Include="BitonicSort.cpp" />
+		<ClCompile Include="BuddyAllocator.cpp" />
+		<ClCompile Include="BufferManager.cpp" />
+		<ClCompile Include="Camera.cpp" />
+		<ClCompile Include="CameraController.cpp" />
+		<ClCompile Include="Color.cpp" />
+		<ClCompile Include="ColorBuffer.cpp" />
+		<ClCompile Include="CommandAllocatorPool.cpp" />
+		<ClCompile Include="CommandContext.cpp" />
+		<ClCompile Include="CommandListManager.cpp" />
+		<ClCompile Include="CommandSignature.cpp" />
+		<ClCompile Include="DDSTextureLoader.cpp" />
+		<ClCompile Include="DepthBuffer.cpp" />
+		<ClCompile Include="DepthOfField.cpp" />
+		<ClCompile Include="DynamicDescriptorHeap.cpp" />
+		<ClCompile Include="DescriptorHeap.cpp" />
+		<ClCompile Include="EngineProfiling.cpp" />
+		<ClCompile Include="EngineTuning.cpp" />
+		<ClCompile Include="FileUtility.cpp" />
+		<ClCompile Include="FXAA.cpp" />
+		<ClCompile Include="Input.cpp" />
+		<ClCompile Include="GameCore.cpp" />
+		<ClCompile Include="GpuBuffer.cpp" />
+		<ClCompile Include="GpuTimeManager.cpp" />
+		<ClCompile Include="GraphicsCommon.cpp" />
+		<ClCompile Include="GraphicsCore.cpp" />
+		<ClCompile Include="GraphRenderer.cpp" />
+		<ClCompile Include="ImageScaling.cpp" />
+		<ClCompile Include="LinearAllocator.cpp" />
+		<ClCompile Include="Math\BoundingSphere.cpp" />
+		<ClCompile Include="Math\Frustum.cpp" />
+		<ClCompile Include="Math\Random.cpp" />
+		<ClCompile Include="MotionBlur.cpp" />
+		<ClCompile Include="ParticleEffect.cpp" />
+		<ClCompile Include="ParticleEffectManager.cpp" />
+		<ClCompile Include="ParticleEmissionProperties.cpp" />
+		<ClCompile Include="pch.cpp">
+			<PrecompiledHeader>Create</PrecompiledHeader>
+		</ClCompile>
+		<ClCompile Include="PipelineState.cpp" />
+		<ClCompile Include="PixelBuffer.cpp" />
+		<ClCompile Include="PostEffects.cpp" />
+		<ClCompile Include="Display.cpp" />
+		<ClCompile Include="ReadbackBuffer.cpp" />
+		<ClCompile Include="RootSignature.cpp" />
+		<ClCompile Include="SamplerManager.cpp" />
+		<ClCompile Include="ShadowBuffer.cpp" />
+		<ClCompile Include="ShadowCamera.cpp" />
+		<ClCompile Include="SSAO.cpp" />
+		<ClCompile Include="SystemTime.cpp" />
+		<ClCompile Include="TemporalEffects.cpp" />
+		<ClCompile Include="TextRenderer.cpp" />
+		<ClCompile Include="Texture.cpp" />
+		<ClCompile Include="TextureManager.cpp" />
+		<ClCompile Include="UploadBuffer.cpp" />
+		<ClCompile Include="Utility.cpp" />
+		<ClCompile Include="Util\CommandLineArg.cpp" />
+	</ItemGroup>
+	<ItemGroup>
+		<FxCompile Include="Shaders\AdaptExposureCS.hlsl" />
+		<FxCompile Include="Shaders\AoBlurUpsampleBlendOutCS.hlsl" />
+		<FxCompile Include="Shaders\AoBlurUpsampleCS.hlsl" />
+		<FxCompile Include="Shaders\AoBlurUpsamplePreMinBlendOutCS.hlsl" />
+		<FxCompile Include="Shaders\AoBlurUpsamplePreMinCS.hlsl" />
+		<FxCompile Include="Shaders\AoPrepareDepthBuffers1CS.hlsl" />
+		<FxCompile Include="Shaders\AoPrepareDepthBuffers2CS.hlsl" />
+		<FxCompile Include="Shaders\AoRender1CS.hlsl" />
+		<FxCompile Include="Shaders\AoRender2CS.hlsl" />
+		<FxCompile Include="Shaders\ApplyBloom2CS.hlsl" />
+		<FxCompile Include="Shaders\ApplyBloomCS.hlsl" />
+		<FxCompile Include="Shaders\AverageLumaCS.hlsl" />
+		<FxCompile Include="Shaders\BicubicHorizontalUpsamplePS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\BicubicUpsampleCS.hlsl" />
+		<FxCompile Include="Shaders\BicubicUpsampleFast16CS.hlsl" />
+		<FxCompile Include="Shaders\BicubicUpsampleFast24CS.hlsl" />
+		<FxCompile Include="Shaders\BicubicUpsampleFast32CS.hlsl" />
+		<FxCompile Include="Shaders\BicubicUpsampleGammaPS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\BicubicUpsamplePS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\BicubicVerticalUpsamplePS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\BilinearUpsamplePS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\Bitonic32InnerSortCS.hlsl" />
+		<FxCompile Include="Shaders\Bitonic32OuterSortCS.hlsl" />
+		<FxCompile Include="Shaders\Bitonic32PreSortCS.hlsl" />
+		<FxCompile Include="Shaders\Bitonic64InnerSortCS.hlsl" />
+		<FxCompile Include="Shaders\Bitonic64OuterSortCS.hlsl" />
+		<FxCompile Include="Shaders\Bitonic64PreSortCS.hlsl" />
+		<FxCompile Include="Shaders\BitonicIndirectArgsCS.hlsl" />
+		<FxCompile Include="Shaders\BlendUIHDRPS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\BloomExtractAndDownsampleHdrCS.hlsl" />
+		<FxCompile Include="Shaders\BloomExtractAndDownsampleLdrCS.hlsl" />
+		<FxCompile Include="Shaders\BlurCS.hlsl" />
+		<FxCompile Include="Shaders\BoundNeighborhoodCS.hlsl" />
+		<FxCompile Include="Shaders\BufferCopyPS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\CameraMotionBlurPrePassCS.hlsl" />
+		<FxCompile Include="Shaders\CameraMotionBlurPrePassLinearZCS.hlsl" />
+		<FxCompile Include="Shaders\CameraVelocityCS.hlsl" />
+		<FxCompile Include="Shaders\CompositeHDRPS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\CompositeSDRPS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\CopyBackPostBufferCS.hlsl" />
+		<FxCompile Include="Shaders\DebugDrawHistogramCS.hlsl" />
+		<FxCompile Include="Shaders\DebugLuminanceHdr2CS.hlsl" />
+		<FxCompile Include="Shaders\DebugLuminanceHdrCS.hlsl" />
+		<FxCompile Include="Shaders\DebugLuminanceLdr2CS.hlsl" />
+		<FxCompile Include="Shaders\DebugLuminanceLdrCS.hlsl" />
+		<FxCompile Include="Shaders\DebugSSAOCS.hlsl" />
+		<FxCompile Include="Shaders\DoFCombine2CS.hlsl" />
+		<FxCompile Include="Shaders\DoFCombineCS.hlsl" />
+		<FxCompile Include="Shaders\DoFCombineFast2CS.hlsl" />
+		<FxCompile Include="Shaders\DoFCombineFastCS.hlsl" />
+		<FxCompile Include="Shaders\DoFDebugBlueCS.hlsl" />
+		<FxCompile Include="Shaders\DoFDebugGreenCS.hlsl" />
+		<FxCompile Include="Shaders\DoFDebugRedCS.hlsl" />
+		<FxCompile Include="Shaders\DoFMedianFilterCS.hlsl" />
+		<FxCompile Include="Shaders\DoFMedianFilterFixupCS.hlsl" />
+		<FxCompile Include="Shaders\DoFMedianFilterSepAlphaCS.hlsl" />
+		<FxCompile Include="Shaders\DoFPass1CS.hlsl" />
+		<FxCompile Include="Shaders\DoFPass2CS.hlsl" />
+		<FxCompile Include="Shaders\DoFPass2DebugCS.hlsl" />
+		<FxCompile Include="Shaders\DoFPass2FastCS.hlsl" />
+		<FxCompile Include="Shaders\DoFPass2FixupCS.hlsl" />
+		<FxCompile Include="Shaders\DoFPreFilterCS.hlsl" />
+		<FxCompile Include="Shaders\DoFPreFilterFastCS.hlsl" />
+		<FxCompile Include="Shaders\DoFPreFilterFixupCS.hlsl" />
+		<FxCompile Include="Shaders\DoFTilePassCS.hlsl" />
+		<FxCompile Include="Shaders\DoFTilePassFixupCS.hlsl" />
+		<FxCompile Include="Shaders\DownsampleBloomAllCS.hlsl" />
+		<FxCompile Include="Shaders\DownsampleBloomCS.hlsl" />
+		<FxCompile Include="Shaders\DownsampleDepthPS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\ExtractLumaCS.hlsl" />
+		<FxCompile Include="Shaders\FXAAPass1_Luma2_CS.hlsl" />
+		<FxCompile Include="Shaders\FXAAPass1_Luma_CS.hlsl" />
+		<FxCompile Include="Shaders\FXAAPass1_RGB2_CS.hlsl" />
+		<FxCompile Include="Shaders\FXAAPass1_RGB_CS.hlsl" />
+		<FxCompile Include="Shaders\FXAAPass2H2CS.hlsl" />
+		<FxCompile Include="Shaders\FXAAPass2HDebug2CS.hlsl" />
+		<FxCompile Include="Shaders\FXAAPass2HDebugCS.hlsl" />
+		<FxCompile Include="Shaders\FXAAPass2V2CS.hlsl" />
+		<FxCompile Include="Shaders\FXAAPass2VDebug2CS.hlsl" />
+		<FxCompile Include="Shaders\FXAAPass2VDebugCS.hlsl" />
+		<FxCompile Include="Shaders\GenerateHistogramCS.hlsl" />
+		<FxCompile Include="Shaders\FXAAPass2HCS.hlsl" />
+		<FxCompile Include="Shaders\FXAAPass2VCS.hlsl" />
+		<FxCompile Include="Shaders\GenerateMipsGammaCS.hlsl" />
+		<FxCompile Include="Shaders\GenerateMipsGammaOddCS.hlsl" />
+		<FxCompile Include="Shaders\GenerateMipsGammaOddXCS.hlsl" />
+		<FxCompile Include="Shaders\GenerateMipsGammaOddYCS.hlsl" />
+		<FxCompile Include="Shaders\GenerateMipsLinearCS.hlsl" />
+		<FxCompile Include="Shaders\GenerateMipsLinearOddCS.hlsl" />
+		<FxCompile Include="Shaders\GenerateMipsLinearOddXCS.hlsl" />
+		<FxCompile Include="Shaders\GenerateMipsLinearOddYCS.hlsl" />
+		<FxCompile Include="Shaders\LanczosCS.hlsl" />
+		<FxCompile Include="Shaders\LanczosFast16CS.hlsl" />
+		<FxCompile Include="Shaders\LanczosFast24CS.hlsl" />
+		<FxCompile Include="Shaders\LanczosFast32CS.hlsl" />
+		<FxCompile Include="Shaders\LanczosHorizontalPS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\LanczosVerticalPS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\LinearizeDepthCS.hlsl" />
+		<FxCompile Include="Shaders\MagnifyPixelsPS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\MotionBlurFinalPassCS.hlsl" />
+		<FxCompile Include="Shaders\MotionBlurFinalPassPS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\MotionBlurPrePassCS.hlsl" />
+		<FxCompile Include="Shaders\FXAAResolveWorkQueueCS.hlsl" />
+		<FxCompile Include="Shaders\ParticleBinCullingCS.hlsl" />
+		<FxCompile Include="Shaders\ParticleDepthBoundsCS.hlsl" />
+		<FxCompile Include="Shaders\ParticleDispatchIndirectArgsCS.hlsl" />
+		<FxCompile Include="Shaders\ParticleFinalDispatchIndirectArgsCS.hlsl" />
+		<FxCompile Include="Shaders\ParticleLargeBinCullingCS.hlsl" />
+		<FxCompile Include="Shaders\ParticleNoSortVS.hlsl">
+			<ShaderType>Vertex</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\ParticlePreSortCS.hlsl" />
+		<FxCompile Include="Shaders\ParticlePS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\ParticleSortIndirectArgsCS.hlsl" />
+		<FxCompile Include="Shaders\ParticleSpawnCS.hlsl" />
+		<FxCompile Include="Shaders\ParticleTileCullingCS.hlsl" />
+		<FxCompile Include="Shaders\ParticleTileRender2CS.hlsl" />
+		<FxCompile Include="Shaders\ParticleTileRenderCS.hlsl" />
+		<FxCompile Include="Shaders\ParticleTileRenderFast2CS.hlsl" />
+		<FxCompile Include="Shaders\ParticleTileRenderFastCS.hlsl" />
+		<FxCompile Include="Shaders\ParticleTileRenderFastDynamic2CS.hlsl" />
+		<FxCompile Include="Shaders\ParticleTileRenderFastDynamicCS.hlsl" />
+		<FxCompile Include="Shaders\ParticleTileRenderFastLowRes2CS.hlsl" />
+		<FxCompile Include="Shaders\ParticleTileRenderFastLowResCS.hlsl" />
+		<FxCompile Include="Shaders\ParticleTileRenderSlowDynamic2CS.hlsl" />
+		<FxCompile Include="Shaders\ParticleTileRenderSlowDynamicCS.hlsl" />
+		<FxCompile Include="Shaders\ParticleTileRenderSlowLowRes2CS.hlsl" />
+		<FxCompile Include="Shaders\ParticleTileRenderSlowLowResCS.hlsl" />
+		<FxCompile Include="Shaders\ParticleUpdateCS.hlsl" />
+		<FxCompile Include="Shaders\ParticleVS.hlsl">
+			<ShaderType>Vertex</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\PerfGraphBackgroundVS.hlsl">
+			<ShaderType>Vertex</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\PerfGraphPS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\PerfGraphVS.hlsl">
+			<ShaderType>Vertex</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\PresentHDRPS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\PresentSDRPS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\ResolveTAACS.hlsl" />
+		<FxCompile Include="Shaders\ScaleAndCompositeHDRPS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\ScaleAndCompositeSDRPS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\ScreenQuadCommonVS.hlsl">
+			<ShaderType>Vertex</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\ScreenQuadPresentVS.hlsl">
+			<ShaderType>Vertex</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\SharpeningUpsampleGammaPS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\SharpeningUpsamplePS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\SharpenTAACS.hlsl" />
+		<FxCompile Include="Shaders\TemporalBlendCS.hlsl" />
+		<FxCompile Include="Shaders\TextAntialiasPS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\TextShadowPS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\TextVS.hlsl">
+			<ShaderType>Vertex</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\ToneMapHDR2CS.hlsl" />
+		<FxCompile Include="Shaders\ToneMapHDRCS.hlsl" />
+		<None Include="Math\Functions.inl" />
+		<None Include="packages.config" />
+		<None Include="Shaders\AoBlurAndUpsampleCS.hlsli" />
+		<None Include="Shaders\AoRenderCS.hlsli" />
+		<None Include="Shaders\BicubicFilterFunctions.hlsli" />
+		<None Include="Shaders\BitonicSortCommon.hlsli" />
+		<None Include="Shaders\ColorSpaceUtility.hlsli" />
+		<None Include="Shaders\CommonRS.hlsli" />
+		<None Include="Shaders\DoFCommon.hlsli" />
+		<None Include="Shaders\DoFRS.hlsli" />
+		<None Include="Shaders\FXAAPass1CS.hlsli" />
+		<None Include="Shaders\FXAAPass2CS.hlsli" />
+		<None Include="Shaders\FXAARootSignature.hlsli" />
+		<None Include="Shaders\GenerateMipsCS.hlsli" />
+		<None Include="Shaders\LanczosFunctions.hlsli" />
+		<None Include="Shaders\MotionBlurRS.hlsli" />
+		<None Include="Shaders\ParticleRS.hlsli" />
+		<None Include="Shaders\ParticleUpdateCommon.hlsli" />
+		<None Include="Shaders\ParticleUtility.hlsli" />
+		<None Include="Shaders\PerfGraphRS.hlsli" />
+		<None Include="Shaders\PixelPacking_R11G11B10.hlsli" />
+		<None Include="Shaders\PixelPacking_RGBE.hlsli" />
+		<None Include="Shaders\PixelPacking_RGBM.hlsli" />
+		<None Include="Shaders\PostEffectsRS.hlsli" />
+		<None Include="Shaders\PresentRS.hlsli" />
+		<None Include="Shaders\ShaderUtility.hlsli" />
+		<FxCompile Include="Shaders\ToneMap2CS.hlsl" />
+		<FxCompile Include="Shaders\ToneMapCS.hlsl" />
+		<FxCompile Include="Shaders\UpsampleAndBlurCS.hlsl" />
+		<None Include="Shaders\PixelPacking.hlsli" />
+		<None Include="Shaders\SSAORS.hlsli" />
+		<None Include="Shaders\TextRS.hlsli" />
+	</ItemGroup>
+	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+	<ItemDefinitionGroup>
+		<ClCompile>
+			<AdditionalIncludeDirectories>..\..\Packages\zlib-msvc-x64.1.2.11.8900\build\native\include;..\..\Packages\WinPixEventRuntime.1.0.210209001\Include\WinPixEventRuntime;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+			<PreprocessorDefinitions>_GAMING_DESKTOP;__WRL_NO_DEFAULT_LIB__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+		</ClCompile>
+	</ItemDefinitionGroup>
+	<ImportGroup Label="ExtensionTargets">
+		<Import Project="..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
+		<Import Project="..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets" Condition="Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" />
+	</ImportGroup>
+	<Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+		<PropertyGroup>
+			<ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+		</PropertyGroup>
+		<Error Condition="!Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
+		<Error Condition="!Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets'))" />
+	</Target>
 </Project>

--- a/Samples/BulkLoadDemo/Core/Shaders/BicubicFilterFunctions.hlsli
+++ b/Samples/BulkLoadDemo/Core/Shaders/BicubicFilterFunctions.hlsli
@@ -31,7 +31,7 @@ float4 GetBicubicFilterWeights(float offset, float A)
     //return ComputeWeights(offset, A);
 
     // Precompute weights for 16 discrete offsets
-    static const float4 FilterWeights[16] =
+    const float4 FilterWeights[16] =
     {
         ComputeWeights( 0.5 / 16.0, -0.5),
         ComputeWeights( 1.5 / 16.0, -0.5),

--- a/Samples/BulkLoadDemo/Core/Shaders/BicubicHorizontalUpsamplePS.hlsl
+++ b/Samples/BulkLoadDemo/Core/Shaders/BicubicHorizontalUpsamplePS.hlsl
@@ -41,7 +41,7 @@ float3 GetColor(uint s, uint t)
 }
 
 [RootSignature(Present_RootSig)]
-float4 main(float4 position : SV_Position, float2 uv : TexCoord0) : SV_Target0
+float3 main(float4 position : SV_Position, float2 uv : TexCoord0) : SV_Target0
 {
     float2 t = uv * TextureSize + 0.5;
     float2 f = frac(t);
@@ -61,5 +61,5 @@ float4 main(float4 position : SV_Position, float2 uv : TexCoord0) : SV_Target0
         W.z * GetColor(s2, st.y) +
         W.w * GetColor(s3, st.y);
 
-    return float4(Color, 1);
+    return Color;
 }

--- a/Samples/BulkLoadDemo/Core/Shaders/BicubicUpsamplePS.hlsl
+++ b/Samples/BulkLoadDemo/Core/Shaders/BicubicUpsamplePS.hlsl
@@ -61,7 +61,7 @@ float3 GetColor(uint s, uint t)
 }
 
 [RootSignature(Present_RootSig)]
-float4 main(float4 position : SV_Position, float2 uv : TexCoord0) : SV_Target0
+float3 main(float4 position : SV_Position, float2 uv : TexCoord0) : SV_Target0
 {
     float2 t = uv * TextureSize + 0.5;
     float2 f = frac(t);
@@ -88,8 +88,8 @@ float4 main(float4 position : SV_Position, float2 uv : TexCoord0) : SV_Target0
     float3 Color = Cubic(GetWeights(f.y), c0, c1, c2, c3);
 
 #ifdef GAMMA_SPACE
-    return float4(Color, 1);
+    return Color;
 #else
-    return float4(ApplyDisplayProfile(Color, DISPLAY_PLANE_FORMAT), 1);
+    return ApplyDisplayProfile(Color, DISPLAY_PLANE_FORMAT);
 #endif
 }

--- a/Samples/BulkLoadDemo/Core/Shaders/BicubicVerticalUpsamplePS.hlsl
+++ b/Samples/BulkLoadDemo/Core/Shaders/BicubicVerticalUpsamplePS.hlsl
@@ -37,7 +37,7 @@ float3 GetColor(uint s, uint t)
 }
 
 [RootSignature(Present_RootSig)]
-float4 main(float4 position : SV_Position, float2 uv : TexCoord0) : SV_Target0
+float3 main(float4 position : SV_Position, float2 uv : TexCoord0) : SV_Target0
 {
     float2 t = uv * TextureSize + 0.5;
     float2 f = frac(t);
@@ -58,8 +58,8 @@ float4 main(float4 position : SV_Position, float2 uv : TexCoord0) : SV_Target0
         W.w * GetColor(st.x, t3);
 
 #ifdef GAMMA_SPACE
-        return float4(Color,1);
+        return Color;
 #else
-        return float4(ApplyDisplayProfile(Color, DISPLAY_PLANE_FORMAT), 1);
+        return ApplyDisplayProfile(Color, DISPLAY_PLANE_FORMAT);
 #endif
 }

--- a/Samples/BulkLoadDemo/Core/Shaders/BilinearUpsamplePS.hlsl
+++ b/Samples/BulkLoadDemo/Core/Shaders/BilinearUpsamplePS.hlsl
@@ -18,8 +18,8 @@ Texture2D<float3> ColorTex : register(t0);
 SamplerState BilinearFilter : register(s0);
 
 [RootSignature(Present_RootSig)]
-float4 main( float4 position : SV_Position, float2 uv : TexCoord0 ) : SV_Target0
+float3 main( float4 position : SV_Position, float2 uv : TexCoord0 ) : SV_Target0
 {
     float3 LinearRGB = RemoveDisplayProfile(ColorTex.SampleLevel(BilinearFilter, uv, 0), LDR_COLOR_FORMAT);
-    return float4(ApplyDisplayProfile(LinearRGB, DISPLAY_PLANE_FORMAT), 1);
+    return ApplyDisplayProfile(LinearRGB, DISPLAY_PLANE_FORMAT);
 }

--- a/Samples/BulkLoadDemo/Core/Shaders/ColorSpaceUtility.hlsli
+++ b/Samples/BulkLoadDemo/Core/Shaders/ColorSpaceUtility.hlsli
@@ -34,25 +34,25 @@
 // are--the sRGB curve needs to be removed before involving the colors in linear mathematics such
 // as physically based lighting.
 
-float3 ApplySRGBCurve(float3 x)
+float3 ApplySRGBCurve( float3 x )
 {
     // Approximately pow(x, 1.0 / 2.2)
     return select(x < 0.0031308, 12.92 * x, 1.055 * pow(x, 1.0 / 2.4) - 0.055);
 }
 
-float3 RemoveSRGBCurve(float3 x)
+float3 RemoveSRGBCurve( float3 x )
 {
     // Approximately pow(x, 2.2)
-    return select(x < 0.04045, x / 12.92, pow((x + 0.055) / 1.055, 2.4));
+    return select(x < 0.04045, x / 12.92, pow( (x + 0.055) / 1.055, 2.4 ));
 }
 
 // These functions avoid pow() to efficiently approximate sRGB with an error < 0.4%.
-float3 ApplySRGBCurve_Fast(float3 x)
+float3 ApplySRGBCurve_Fast( float3 x )
 {
     return select(x < 0.0031308, 12.92 * x, 1.13005 * sqrt(x - 0.00228) - 0.13448 * x + 0.005719);
 }
 
-float3 RemoveSRGBCurve_Fast(float3 x)
+float3 RemoveSRGBCurve_Fast( float3 x )
 {
     return select(x < 0.04045, x / 12.92, -7.43605 * x - 31.24297 * sqrt(-0.53792 * x + 1.279924) + 35.34864);
 }
@@ -60,12 +60,12 @@ float3 RemoveSRGBCurve_Fast(float3 x)
 // The OETF recommended for content shown on HDTVs.  This "gamma ramp" may increase contrast as
 // appropriate for viewing in a dark environment.  Always use this curve with Limited RGB as it is
 // used in conjunction with HDTVs.
-float3 ApplyREC709Curve(float3 x)
+float3 ApplyREC709Curve( float3 x )
 {
     return select(x < 0.0181, 4.5 * x, 1.0993 * pow(x, 0.45) - 0.0993);
 }
 
-float3 RemoveREC709Curve(float3 x)
+float3 RemoveREC709Curve( float3 x )
 {
     return select(x < 0.08145, x / 4.5, pow((x + 0.0993) / 1.0993, 1.0 / 0.45));
 }
@@ -117,7 +117,7 @@ float3 RemoveREC2084Curve(float3 N)
 // Note:  Rec.709 and sRGB share the same color primaries and white point.  Their only difference
 // is the transfer curve used.
 
-float3 REC709toREC2020(float3 RGB709)
+float3 REC709toREC2020( float3 RGB709 )
 {
     static const float3x3 ConvMat =
     {
@@ -139,7 +139,7 @@ float3 REC2020toREC709(float3 RGB2020)
     return mul(ConvMat, RGB2020);
 }
 
-float3 REC709toDCIP3(float3 RGB709)
+float3 REC709toDCIP3( float3 RGB709 )
 {
     static const float3x3 ConvMat =
     {
@@ -150,7 +150,7 @@ float3 REC709toDCIP3(float3 RGB709)
     return mul(ConvMat, RGB709);
 }
 
-float3 DCIP3toREC709(float3 RGBP3)
+float3 DCIP3toREC709( float3 RGBP3 )
 {
     static const float3x3 ConvMat =
     {

--- a/Samples/BulkLoadDemo/Core/Shaders/ColorSpaceUtility.hlsli
+++ b/Samples/BulkLoadDemo/Core/Shaders/ColorSpaceUtility.hlsli
@@ -34,40 +34,40 @@
 // are--the sRGB curve needs to be removed before involving the colors in linear mathematics such
 // as physically based lighting.
 
-float3 ApplySRGBCurve( float3 x )
+float3 ApplySRGBCurve(float3 x)
 {
     // Approximately pow(x, 1.0 / 2.2)
-    return x < 0.0031308 ? 12.92 * x : 1.055 * pow(x, 1.0 / 2.4) - 0.055;
+    return select(x < 0.0031308, 12.92 * x, 1.055 * pow(x, 1.0 / 2.4) - 0.055);
 }
 
-float3 RemoveSRGBCurve( float3 x )
+float3 RemoveSRGBCurve(float3 x)
 {
     // Approximately pow(x, 2.2)
-    return x < 0.04045 ? x / 12.92 : pow( (x + 0.055) / 1.055, 2.4 );
+    return select(x < 0.04045, x / 12.92, pow((x + 0.055) / 1.055, 2.4));
 }
 
 // These functions avoid pow() to efficiently approximate sRGB with an error < 0.4%.
-float3 ApplySRGBCurve_Fast( float3 x )
+float3 ApplySRGBCurve_Fast(float3 x)
 {
-    return x < 0.0031308 ? 12.92 * x : 1.13005 * sqrt(x - 0.00228) - 0.13448 * x + 0.005719;
+    return select(x < 0.0031308, 12.92 * x, 1.13005 * sqrt(x - 0.00228) - 0.13448 * x + 0.005719);
 }
 
-float3 RemoveSRGBCurve_Fast( float3 x )
+float3 RemoveSRGBCurve_Fast(float3 x)
 {
-    return x < 0.04045 ? x / 12.92 : -7.43605 * x - 31.24297 * sqrt(-0.53792 * x + 1.279924) + 35.34864;
+    return select(x < 0.04045, x / 12.92, -7.43605 * x - 31.24297 * sqrt(-0.53792 * x + 1.279924) + 35.34864);
 }
 
 // The OETF recommended for content shown on HDTVs.  This "gamma ramp" may increase contrast as
 // appropriate for viewing in a dark environment.  Always use this curve with Limited RGB as it is
 // used in conjunction with HDTVs.
-float3 ApplyREC709Curve( float3 x )
+float3 ApplyREC709Curve(float3 x)
 {
-    return x < 0.0181 ? 4.5 * x : 1.0993 * pow(x, 0.45) - 0.0993;
+    return select(x < 0.0181, 4.5 * x, 1.0993 * pow(x, 0.45) - 0.0993);
 }
 
-float3 RemoveREC709Curve( float3 x )
+float3 RemoveREC709Curve(float3 x)
 {
-    return x < 0.08145 ? x / 4.5 : pow((x + 0.0993) / 1.0993, 1.0 / 0.45);
+    return select(x < 0.08145, x / 4.5, pow((x + 0.0993) / 1.0993, 1.0 / 0.45));
 }
 
 // This is the new HDR transfer function, also called "PQ" for perceptual quantizer.  Note that REC2084
@@ -117,7 +117,7 @@ float3 RemoveREC2084Curve(float3 N)
 // Note:  Rec.709 and sRGB share the same color primaries and white point.  Their only difference
 // is the transfer curve used.
 
-float3 REC709toREC2020( float3 RGB709 )
+float3 REC709toREC2020(float3 RGB709)
 {
     static const float3x3 ConvMat =
     {
@@ -139,7 +139,7 @@ float3 REC2020toREC709(float3 RGB2020)
     return mul(ConvMat, RGB2020);
 }
 
-float3 REC709toDCIP3( float3 RGB709 )
+float3 REC709toDCIP3(float3 RGB709)
 {
     static const float3x3 ConvMat =
     {
@@ -150,7 +150,7 @@ float3 REC709toDCIP3( float3 RGB709 )
     return mul(ConvMat, RGB709);
 }
 
-float3 DCIP3toREC709( float3 RGBP3 )
+float3 DCIP3toREC709(float3 RGBP3)
 {
     static const float3x3 ConvMat =
     {

--- a/Samples/BulkLoadDemo/Core/Shaders/CompositeHDRPS.hlsl
+++ b/Samples/BulkLoadDemo/Core/Shaders/CompositeHDRPS.hlsl
@@ -24,7 +24,7 @@ cbuffer CB0 : register(b0)
 }
 
 [RootSignature(Present_RootSig)]
-float4 main( float4 position : SV_Position, float2 uv : TexCoord0 ) : SV_Target0
+float3 main( float4 position : SV_Position, float2 uv : TexCoord0 ) : SV_Target0
 {
     int2 ST = (int2)position.xy;
 
@@ -36,5 +36,5 @@ float4 main( float4 position : SV_Position, float2 uv : TexCoord0 ) : SV_Target0
     OverlayColor.rgb = REC709toREC2020(OverlayColor.rgb / (OverlayColor.a == 0.0 ? 1.0 : OverlayColor.a));
     OverlayColor.rgb = ApplyREC2084Curve(OverlayColor.rgb * PaperWhiteRatio);
 
-    return float4(lerp(MainColor, OverlayColor.rgb, OverlayColor.a), 1);
+    return lerp(MainColor, OverlayColor.rgb, OverlayColor.a);
 }

--- a/Samples/BulkLoadDemo/Core/Shaders/CompositeSDRPS.hlsl
+++ b/Samples/BulkLoadDemo/Core/Shaders/CompositeSDRPS.hlsl
@@ -18,9 +18,9 @@ Texture2D<float3> MainBuffer : register(t0);
 Texture2D<float4> OverlayBuffer : register(t1);
 
 [RootSignature(Present_RootSig)]
-float4 main( float4 position : SV_Position ) : SV_Target0
+float3 main( float4 position : SV_Position ) : SV_Target0
 {
     float3 MainColor = ApplyDisplayProfile(MainBuffer[(int2)position.xy], DISPLAY_PLANE_FORMAT);
     float4 OverlayColor = OverlayBuffer[(int2)position.xy];
-    return float4(OverlayColor.rgb + MainColor.rgb * (1.0 - OverlayColor.a), 1);
+    return OverlayColor.rgb + MainColor.rgb * (1.0 - OverlayColor.a);
 }

--- a/Samples/BulkLoadDemo/Core/Shaders/GenerateMipsCS.hlsli
+++ b/Samples/BulkLoadDemo/Core/Shaders/GenerateMipsCS.hlsli
@@ -26,9 +26,9 @@ SamplerState BilinearClamp : register(s0);
 
 cbuffer CB0 : register(b0)
 {
-    uint SrcMipLevel; // Texture level of source mip
-    uint NumMipLevels; // Number of OutMips to write: [1, 4]
-    float2 TexelSize; // 1.0 / OutMip1.Dimensions
+    uint SrcMipLevel;	// Texture level of source mip
+    uint NumMipLevels;	// Number of OutMips to write: [1, 4]
+    float2 TexelSize;	// 1.0 / OutMip1.Dimensions
 }
 
 // The reason for separating channels is to reduce bank conflicts in the
@@ -39,7 +39,7 @@ groupshared float gs_G[64];
 groupshared float gs_B[64];
 groupshared float gs_A[64];
 
-void StoreColor(uint Index, float4 Color)
+void StoreColor( uint Index, float4 Color )
 {
     gs_R[Index] = Color.r;
     gs_G[Index] = Color.g;
@@ -47,9 +47,9 @@ void StoreColor(uint Index, float4 Color)
     gs_A[Index] = Color.a;
 }
 
-float4 LoadColor(uint Index)
+float4 LoadColor( uint Index )
 {
-    return float4(gs_R[Index], gs_G[Index], gs_B[Index], gs_A[Index]);
+    return float4( gs_R[Index], gs_G[Index], gs_B[Index], gs_A[Index]);
 }
 
 float3 ApplySRGBCurve(float3 x)
@@ -71,8 +71,8 @@ float4 PackColor(float4 Linear)
 }
 
 [RootSignature(Common_RootSig)]
-[numthreads(8, 8, 1)]
-void main(uint GI : SV_GroupIndex, uint3 DTid : SV_DispatchThreadID)
+[numthreads( 8, 8, 1 )]
+void main( uint GI : SV_GroupIndex, uint3 DTid : SV_DispatchThreadID )
 {
     // One bilinear sample is insufficient when scaling down by more than 2x.
     // You will slightly undersample in the case where the source dimension

--- a/Samples/BulkLoadDemo/Core/Shaders/GenerateMipsCS.hlsli
+++ b/Samples/BulkLoadDemo/Core/Shaders/GenerateMipsCS.hlsli
@@ -26,9 +26,9 @@ SamplerState BilinearClamp : register(s0);
 
 cbuffer CB0 : register(b0)
 {
-    uint SrcMipLevel;	// Texture level of source mip
-    uint NumMipLevels;	// Number of OutMips to write: [1, 4]
-    float2 TexelSize;	// 1.0 / OutMip1.Dimensions
+    uint SrcMipLevel; // Texture level of source mip
+    uint NumMipLevels; // Number of OutMips to write: [1, 4]
+    float2 TexelSize; // 1.0 / OutMip1.Dimensions
 }
 
 // The reason for separating channels is to reduce bank conflicts in the
@@ -39,7 +39,7 @@ groupshared float gs_G[64];
 groupshared float gs_B[64];
 groupshared float gs_A[64];
 
-void StoreColor( uint Index, float4 Color )
+void StoreColor(uint Index, float4 Color)
 {
     gs_R[Index] = Color.r;
     gs_G[Index] = Color.g;
@@ -47,18 +47,18 @@ void StoreColor( uint Index, float4 Color )
     gs_A[Index] = Color.a;
 }
 
-float4 LoadColor( uint Index )
+float4 LoadColor(uint Index)
 {
-    return float4( gs_R[Index], gs_G[Index], gs_B[Index], gs_A[Index]);
+    return float4(gs_R[Index], gs_G[Index], gs_B[Index], gs_A[Index]);
 }
 
 float3 ApplySRGBCurve(float3 x)
 {
     // This is exactly the sRGB curve
-    //return x < 0.0031308 ? 12.92 * x : 1.055 * pow(abs(x), 1.0 / 2.4) - 0.055;
+    //return select(x < 0.0031308, 12.92 * x, 1.055 * pow(abs(x), 1.0 / 2.4) - 0.055);
      
     // This is cheaper but nearly equivalent
-    return x < 0.0031308 ? 12.92 * x : 1.13005 * sqrt(abs(x - 0.00228)) - 0.13448 * x + 0.005719;
+    return select(x < 0.0031308, 12.92 * x, 1.13005 * sqrt(abs(x - 0.00228)) - 0.13448 * x + 0.005719);
 }
 
 float4 PackColor(float4 Linear)
@@ -71,8 +71,8 @@ float4 PackColor(float4 Linear)
 }
 
 [RootSignature(Common_RootSig)]
-[numthreads( 8, 8, 1 )]
-void main( uint GI : SV_GroupIndex, uint3 DTid : SV_DispatchThreadID )
+[numthreads(8, 8, 1)]
+void main(uint GI : SV_GroupIndex, uint3 DTid : SV_DispatchThreadID)
 {
     // One bilinear sample is insufficient when scaling down by more than 2x.
     // You will slightly undersample in the case where the source dimension

--- a/Samples/BulkLoadDemo/Core/Shaders/LanczosFunctions.hlsli
+++ b/Samples/BulkLoadDemo/Core/Shaders/LanczosFunctions.hlsli
@@ -41,7 +41,7 @@ float4 GetUpscaleFilterWeights(float offset)
     //return ComputeWeights(offset);
 
     // Precompute weights for 16 discrete offsets
-    static const float4 FilterWeights[16] =
+    const float4 FilterWeights[16] =
     {
         ComputeWeights( 0.5 / 16.0),
         ComputeWeights( 1.5 / 16.0),

--- a/Samples/BulkLoadDemo/Core/Shaders/LanczosHorizontalPS.hlsl
+++ b/Samples/BulkLoadDemo/Core/Shaders/LanczosHorizontalPS.hlsl
@@ -30,7 +30,7 @@ float4x3 LoadSamples(int2 ST, uint2 Stride)
 }
 
 [RootSignature(Present_RootSig)]
-float4 main(float4 Pos : SV_Position, float2 UV : TexCoord0) : SV_Target0
+float3 main(float4 Pos : SV_Position, float2 UV : TexCoord0) : SV_Target0
 {
     // We subtract 0.5 because that represents the center of the pixel.  We need to know where
     // we lie between two pixel centers, and we will use frac() for that.  We subtract another
@@ -53,5 +53,5 @@ float4 main(float4 Pos : SV_Position, float2 UV : TexCoord0) : SV_Target0
     Result = ApplyDisplayProfile(Result, DISPLAY_PLANE_FORMAT);
 #endif
 
-    return float4(Result, 1);
+    return Result;
 }

--- a/Samples/BulkLoadDemo/Core/Shaders/MagnifyPixelsPS.hlsl
+++ b/Samples/BulkLoadDemo/Core/Shaders/MagnifyPixelsPS.hlsl
@@ -23,8 +23,8 @@ cbuffer Constants : register(b0)
 }
 
 [RootSignature(Present_RootSig)]
-float4 main( float4 position : SV_Position, float2 uv : TexCoord0 ) : SV_Target0
+float3 main( float4 position : SV_Position, float2 uv : TexCoord0 ) : SV_Target0
 {
     float2 ScaledUV = ScaleFactor * (uv - 0.5) + 0.5;
-    return float4(ColorTex.SampleLevel(PointSampler, ScaledUV, 0), 1);
+    return ColorTex.SampleLevel(PointSampler, ScaledUV, 0);
 }

--- a/Samples/BulkLoadDemo/Core/Shaders/ParticleTileCullingCS.hlsl
+++ b/Samples/BulkLoadDemo/Core/Shaders/ParticleTileCullingCS.hlsl
@@ -106,7 +106,7 @@ void main( uint3 Gid : SV_GroupID, uint GI : SV_GroupIndex, uint3 GTid : SV_Grou
     ParticleCountInBin = min(MAX_PARTICLES_PER_BIN, ParticleCountInBin);
 
     // Compute the next power of two for the bitonic sort
-    uint NextPow2 = countbits(ParticleCountInBin) <= 1u ? ParticleCountInBin : (2u << firstbithigh(ParticleCountInBin));
+    uint NextPow2 = countbits(ParticleCountInBin) <= 1 ? ParticleCountInBin : (2u << firstbithigh(ParticleCountInBin));
 
     // Fill in the sort key array.  Each sort key has passenger data (in the least signficant
     // bits, so that as the sort keys are moved around, they retain a pointer to the particle

--- a/Samples/BulkLoadDemo/Core/Shaders/PresentHDRPS.hlsl
+++ b/Samples/BulkLoadDemo/Core/Shaders/PresentHDRPS.hlsl
@@ -17,7 +17,7 @@
 Texture2D<float3> MainBuffer : register(t0);
 
 [RootSignature(Present_RootSig)]
-float4 main( float4 position : SV_Position, float2 uv : TexCoord0 ) : SV_Target0
+float3 main( float4 position : SV_Position, float2 uv : TexCoord0 ) : SV_Target0
 {
-    return float4(ApplyREC2084Curve(MainBuffer[(int2)position.xy] / 10000.0), 1);
+    return ApplyREC2084Curve(MainBuffer[(int2)position.xy] / 10000.0);
 }

--- a/Samples/BulkLoadDemo/Core/Shaders/PresentSDRPS.hlsl
+++ b/Samples/BulkLoadDemo/Core/Shaders/PresentSDRPS.hlsl
@@ -17,8 +17,8 @@
 Texture2D<float3> ColorTex : register(t0);
 
 [RootSignature(Present_RootSig)]
-float4 main( float4 position : SV_Position ) : SV_Target0
+float3 main( float4 position : SV_Position ) : SV_Target0
 {
     float3 LinearRGB = ColorTex[(int2)position.xy];
-    return float4(ApplyDisplayProfile(LinearRGB, DISPLAY_PLANE_FORMAT), 1);
+    return ApplyDisplayProfile(LinearRGB, DISPLAY_PLANE_FORMAT);
 }

--- a/Samples/BulkLoadDemo/Core/Shaders/ScaleAndCompositeHDRPS.hlsl
+++ b/Samples/BulkLoadDemo/Core/Shaders/ScaleAndCompositeHDRPS.hlsl
@@ -42,14 +42,14 @@ float3 ScaleBuffer(float2 uv)
 }
 
 [RootSignature(Present_RootSig)]
-float4 main( float4 position : SV_Position, float2 uv : TexCoord0 ) : SV_Target0
+float3 main( float4 position : SV_Position, float2 uv : TexCoord0 ) : SV_Target0
 {
-    float3 MainColor = ApplyREC2084Curve(ScaleBuffer(uv) / 10000.0);
+    float3 MainColor = ApplyREC2084Curve( saturate(ScaleBuffer(uv) / 10000.0) );
 
     float4 OverlayColor = OverlayBuffer[(int2)position.xy];
     OverlayColor.rgb = RemoveSRGBCurve(OverlayColor.rgb);
     OverlayColor.rgb = REC709toREC2020(OverlayColor.rgb / (OverlayColor.a == 0.0 ? 1.0 : OverlayColor.a));
     OverlayColor.rgb = ApplyREC2084Curve(OverlayColor.rgb * PaperWhiteRatio);
 
-    return float4(lerp(MainColor, OverlayColor.rgb, OverlayColor.a), 1);
+    return lerp(MainColor, OverlayColor.rgb, OverlayColor.a);
 }

--- a/Samples/BulkLoadDemo/Core/Shaders/ScaleAndCompositeSDRPS.hlsl
+++ b/Samples/BulkLoadDemo/Core/Shaders/ScaleAndCompositeSDRPS.hlsl
@@ -40,9 +40,9 @@ float3 ScaleBuffer(float2 uv)
 }
 
 [RootSignature(Present_RootSig)]
-float4 main( float4 position : SV_Position, float2 uv : TexCoord0 ) : SV_Target0
+float3 main( float4 position : SV_Position, float2 uv : TexCoord0 ) : SV_Target0
 {
     float3 MainColor = ApplyDisplayProfile(ScaleBuffer(uv), DISPLAY_PLANE_FORMAT);
     float4 OverlayColor = OverlayBuffer[(int2)position.xy];
-    return float4(OverlayColor.rgb + MainColor.rgb * (1.0 - OverlayColor.a), 1);
+    return OverlayColor.rgb + MainColor.rgb * (1.0 - OverlayColor.a);
 }

--- a/Samples/BulkLoadDemo/Core/Shaders/SharpeningUpsamplePS.hlsl
+++ b/Samples/BulkLoadDemo/Core/Shaders/SharpeningUpsamplePS.hlsl
@@ -37,15 +37,15 @@ float3 GetColor(float2 UV)
 }
 
 [RootSignature(Present_RootSig)]
-float4 main(float4 position : SV_Position, float2 uv : TexCoord0) : SV_Target0
+float3 main(float4 position : SV_Position, float2 uv : TexCoord0) : SV_Target0
 {
     float3 Color = WB * GetColor(uv) - WA * (
         GetColor(uv + UVOffset0) + GetColor(uv - UVOffset0) +
         GetColor(uv + UVOffset1) + GetColor(uv - UVOffset1));
 
 #ifdef GAMMA_SPACE
-    return float4(Color, 1);
+    return Color;
 #else
-    return float4(ApplyDisplayProfile(Color, DISPLAY_PLANE_FORMAT), 1);
+    return ApplyDisplayProfile(Color, DISPLAY_PLANE_FORMAT);
 #endif
 }

--- a/Samples/BulkLoadDemo/Core/Shaders/TemporalBlendCS.hlsl
+++ b/Samples/BulkLoadDemo/Core/Shaders/TemporalBlendCS.hlsl
@@ -194,8 +194,6 @@ void main(uint3 DTid : SV_DispatchThreadID, uint GI : SV_GroupIndex, uint3 GTid 
     uint Idx0 = GTid.x * 2 + GTid.y * kLdsPitch + kLdsPitch + 1;
     uint Idx1 = Idx0 + 1;
 
-    GroupMemoryBarrierWithGroupSync();
-
     float3 BoxMin, BoxMax;
     GetBBoxForPair(Idx0, Idx1, BoxMin, BoxMax);
 

--- a/Samples/BulkLoadDemo/Core/Shaders/ToneMappingUtility.hlsli
+++ b/Samples/BulkLoadDemo/Core/Shaders/ToneMappingUtility.hlsli
@@ -30,7 +30,7 @@ float3 TM_Reinhard(float3 hdr, float k = 1.0)
 // The inverse of Reinhard
 float3 ITM_Reinhard(float3 sdr, float k = 1.0)
 {
-    return k * sdr / (k - sdr);
+    return k * sdr / (1.0 - sdr);
 }
 
 //

--- a/Samples/BulkLoadDemo/MiniArchive/MiniArchive.vcxproj
+++ b/Samples/BulkLoadDemo/MiniArchive/MiniArchive.vcxproj
@@ -20,7 +20,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <Keyword>Win32Proj</Keyword>
     <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <TargetRuntime>Native</TargetRuntime>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/Samples/BulkLoadDemo/MiniArchive/MiniArchive.vcxproj
+++ b/Samples/BulkLoadDemo/MiniArchive/MiniArchive.vcxproj
@@ -1,98 +1,98 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="Debug|x64">
-			<Configuration>Debug</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="Profile|x64">
-			<Configuration>Profile</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="Release|x64">
-			<Configuration>Release</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-	</ItemGroup>
-	<PropertyGroup Label="Globals">
-		<RootNamespace>Core</RootNamespace>
-		<ProjectGuid>{a2631beb-8f09-4d0f-a729-f4470d765fc6}</ProjectGuid>
-		<DefaultLanguage>en-US</DefaultLanguage>
-		<Keyword>Win32Proj</Keyword>
-		<MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
-		<WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
-		<TargetRuntime>Native</TargetRuntime>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-	<PropertyGroup Label="Configuration">
-		<ConfigurationType>Application</ConfigurationType>
-		<PlatformToolset>v142</PlatformToolset>
-		<CharacterSet>Unicode</CharacterSet>
-		<EmbedManifest>false</EmbedManifest>
-		<GenerateManifest>false</GenerateManifest>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-	<ImportGroup Label="ExtensionSettings" />
-	<ImportGroup Label="PropertySheets">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-		<Import Project="..\PropertySheets\Build.props" />
-		<Import Project="..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
-		<Import Project="..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets" Condition="Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" />
-		<Import Project="..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets" Condition="Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" />
-		<Import Project="..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets" Condition="Exists('..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" />
-	</ImportGroup>
-	<ImportGroup Condition="'$(Platform)'=='x64'" Label="PropertySheets">
-		<Import Project="..\PropertySheets\Desktop.props" />
-	</ImportGroup>
-	<PropertyGroup Label="UserMacros" />
-	<ItemDefinitionGroup>
-		<ClCompile>
-			<PrecompiledHeader>Use</PrecompiledHeader>
-			<PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-			<RuntimeTypeInfo>true</RuntimeTypeInfo>
-		</ClCompile>
-	</ItemDefinitionGroup>
-	<ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
-		<Link>
-			<AdditionalDependencies>d3d12.lib;dxguid.lib;winmm.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<SubSystem>Console</SubSystem>
-			<DataExecutionPrevention>true</DataExecutionPrevention>
-		</Link>
-		<Manifest>
-			<EnableDPIAwareness>true</EnableDPIAwareness>
-		</Manifest>
-	</ItemDefinitionGroup>
-	<ItemGroup>
-		<None Include="packages.config" />
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="main.cpp" />
-		<ClCompile Include="pch.cpp">
-			<PrecompiledHeader>Create</PrecompiledHeader>
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="..\Core\Core.vcxproj">
-			<Project>{86a58508-0d6a-4786-a32f-01a301fdc6f3}</Project>
-		</ProjectReference>
-		<ProjectReference Include="..\Model\Model.vcxproj">
-			<Project>{5d3aeefb-8789-48e5-9bd9-09c667052d09}</Project>
-		</ProjectReference>
-	</ItemGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-	<ItemDefinitionGroup>
-		<ClCompile>
-			<PreprocessorDefinitions>_GAMING_DESKTOP;__WRL_NO_DEFAULT_LIB__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<LanguageStandard>stdcpp17</LanguageStandard>
-		</ClCompile>
-	</ItemDefinitionGroup>
-	<Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-		<PropertyGroup>
-			<ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-		</PropertyGroup>
-		<Error Condition="!Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
-		<Error Condition="!Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets'))" />
-		<Error Condition="!Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets'))" />
-		<Error Condition="!Exists('..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets'))" />
-	</Target>
+    <ItemGroup Label="ProjectConfigurations">
+        <ProjectConfiguration Include="Debug|x64">
+            <Configuration>Debug</Configuration>
+            <Platform>x64</Platform>
+        </ProjectConfiguration>
+        <ProjectConfiguration Include="Profile|x64">
+            <Configuration>Profile</Configuration>
+            <Platform>x64</Platform>
+        </ProjectConfiguration>
+        <ProjectConfiguration Include="Release|x64">
+            <Configuration>Release</Configuration>
+            <Platform>x64</Platform>
+        </ProjectConfiguration>
+    </ItemGroup>
+    <PropertyGroup Label="Globals">
+        <RootNamespace>Core</RootNamespace>
+        <ProjectGuid>{a2631beb-8f09-4d0f-a729-f4470d765fc6}</ProjectGuid>
+        <DefaultLanguage>en-US</DefaultLanguage>
+        <Keyword>Win32Proj</Keyword>
+        <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
+        <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+        <TargetRuntime>Native</TargetRuntime>
+    </PropertyGroup>
+    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+    <PropertyGroup Label="Configuration">
+        <ConfigurationType>Application</ConfigurationType>
+        <PlatformToolset>v142</PlatformToolset>
+        <CharacterSet>Unicode</CharacterSet>
+        <EmbedManifest>false</EmbedManifest>
+        <GenerateManifest>false</GenerateManifest>
+    </PropertyGroup>
+    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+    <ImportGroup Label="ExtensionSettings" />
+    <ImportGroup Label="PropertySheets">
+        <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+        <Import Project="..\PropertySheets\Build.props" />
+        <Import Project="..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
+        <Import Project="..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets" Condition="Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" />
+        <Import Project="..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets" Condition="Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" />
+        <Import Project="..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets" Condition="Exists('..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" />
+    </ImportGroup>
+    <ImportGroup Condition="'$(Platform)'=='x64'" Label="PropertySheets">
+        <Import Project="..\PropertySheets\Desktop.props" />
+    </ImportGroup>
+    <PropertyGroup Label="UserMacros" />
+    <ItemDefinitionGroup>
+        <ClCompile>
+            <PrecompiledHeader>Use</PrecompiledHeader>
+            <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+            <RuntimeTypeInfo>true</RuntimeTypeInfo>
+        </ClCompile>
+    </ItemDefinitionGroup>
+    <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
+        <Link>
+            <AdditionalDependencies>d3d12.lib;dxguid.lib;winmm.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+            <SubSystem>Console</SubSystem>
+            <DataExecutionPrevention>true</DataExecutionPrevention>
+        </Link>
+        <Manifest>
+            <EnableDPIAwareness>true</EnableDPIAwareness>
+        </Manifest>
+    </ItemDefinitionGroup>
+    <ItemGroup>
+        <None Include="packages.config" />
+    </ItemGroup>
+    <ItemGroup>
+        <ClCompile Include="main.cpp" />
+        <ClCompile Include="pch.cpp">
+            <PrecompiledHeader>Create</PrecompiledHeader>
+        </ClCompile>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Core\Core.vcxproj">
+            <Project>{86a58508-0d6a-4786-a32f-01a301fdc6f3}</Project>
+        </ProjectReference>
+        <ProjectReference Include="..\Model\Model.vcxproj">
+            <Project>{5d3aeefb-8789-48e5-9bd9-09c667052d09}</Project>
+        </ProjectReference>
+    </ItemGroup>
+    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+    <ItemDefinitionGroup>
+        <ClCompile>
+            <PreprocessorDefinitions>_GAMING_DESKTOP;__WRL_NO_DEFAULT_LIB__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+            <LanguageStandard>stdcpp17</LanguageStandard>
+        </ClCompile>
+    </ItemDefinitionGroup>
+    <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+        <PropertyGroup>
+            <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+        </PropertyGroup>
+        <Error Condition="!Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
+        <Error Condition="!Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets'))" />
+        <Error Condition="!Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets'))" />
+        <Error Condition="!Exists('..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets'))" />
+    </Target>
 </Project>

--- a/Samples/BulkLoadDemo/MiniArchive/MiniArchive.vcxproj
+++ b/Samples/BulkLoadDemo/MiniArchive/MiniArchive.vcxproj
@@ -1,98 +1,98 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|x64">
-      <Configuration>Debug</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Profile|x64">
-      <Configuration>Profile</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|x64">
-      <Configuration>Release</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-  </ItemGroup>
-  <PropertyGroup Label="Globals">
-    <RootNamespace>Core</RootNamespace>
-    <ProjectGuid>{a2631beb-8f09-4d0f-a729-f4470d765fc6}</ProjectGuid>
-    <DefaultLanguage>en-US</DefaultLanguage>
-    <Keyword>Win32Proj</Keyword>
-    <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-    <TargetRuntime>Native</TargetRuntime>
-  </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-    <EmbedManifest>false</EmbedManifest>
-    <GenerateManifest>false</GenerateManifest>
-  </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <ImportGroup Label="ExtensionSettings" />
-  <ImportGroup Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\PropertySheets\Build.props" />
-    <Import Project="..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
-    <Import Project="..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets" Condition="Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" />
-    <Import Project="..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets" Condition="Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" />
-    <Import Project="..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets" Condition="Exists('..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Platform)'=='x64'" Label="PropertySheets">
-    <Import Project="..\PropertySheets\Desktop.props" />
-  </ImportGroup>
-  <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup>
-    <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <RuntimeTypeInfo>true</RuntimeTypeInfo>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
-    <Link>
-      <AdditionalDependencies>d3d12.lib;dxguid.lib;winmm.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <SubSystem>Console</SubSystem>
-      <DataExecutionPrevention>true</DataExecutionPrevention>
-    </Link>
-    <Manifest>
-      <EnableDPIAwareness>true</EnableDPIAwareness>
-    </Manifest>
-  </ItemDefinitionGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClCompile Include="main.cpp" />
-    <ClCompile Include="pch.cpp">
-      <PrecompiledHeader>Create</PrecompiledHeader>
-    </ClCompile>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Core\Core.vcxproj">
-      <Project>{86a58508-0d6a-4786-a32f-01a301fdc6f3}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\Model\Model.vcxproj">
-      <Project>{5d3aeefb-8789-48e5-9bd9-09c667052d09}</Project>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ItemDefinitionGroup>
-    <ClCompile>
-      <PreprocessorDefinitions>_GAMING_DESKTOP;__WRL_NO_DEFAULT_LIB__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
-    <Error Condition="!Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets'))" />
-    <Error Condition="!Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets'))" />
-  </Target>
+	<ItemGroup Label="ProjectConfigurations">
+		<ProjectConfiguration Include="Debug|x64">
+			<Configuration>Debug</Configuration>
+			<Platform>x64</Platform>
+		</ProjectConfiguration>
+		<ProjectConfiguration Include="Profile|x64">
+			<Configuration>Profile</Configuration>
+			<Platform>x64</Platform>
+		</ProjectConfiguration>
+		<ProjectConfiguration Include="Release|x64">
+			<Configuration>Release</Configuration>
+			<Platform>x64</Platform>
+		</ProjectConfiguration>
+	</ItemGroup>
+	<PropertyGroup Label="Globals">
+		<RootNamespace>Core</RootNamespace>
+		<ProjectGuid>{a2631beb-8f09-4d0f-a729-f4470d765fc6}</ProjectGuid>
+		<DefaultLanguage>en-US</DefaultLanguage>
+		<Keyword>Win32Proj</Keyword>
+		<MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
+		<WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+		<TargetRuntime>Native</TargetRuntime>
+	</PropertyGroup>
+	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+	<PropertyGroup Label="Configuration">
+		<ConfigurationType>Application</ConfigurationType>
+		<PlatformToolset>v142</PlatformToolset>
+		<CharacterSet>Unicode</CharacterSet>
+		<EmbedManifest>false</EmbedManifest>
+		<GenerateManifest>false</GenerateManifest>
+	</PropertyGroup>
+	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+	<ImportGroup Label="ExtensionSettings" />
+	<ImportGroup Label="PropertySheets">
+		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+		<Import Project="..\PropertySheets\Build.props" />
+		<Import Project="..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
+		<Import Project="..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets" Condition="Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" />
+		<Import Project="..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets" Condition="Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" />
+		<Import Project="..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets" Condition="Exists('..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" />
+	</ImportGroup>
+	<ImportGroup Condition="'$(Platform)'=='x64'" Label="PropertySheets">
+		<Import Project="..\PropertySheets\Desktop.props" />
+	</ImportGroup>
+	<PropertyGroup Label="UserMacros" />
+	<ItemDefinitionGroup>
+		<ClCompile>
+			<PrecompiledHeader>Use</PrecompiledHeader>
+			<PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+			<RuntimeTypeInfo>true</RuntimeTypeInfo>
+		</ClCompile>
+	</ItemDefinitionGroup>
+	<ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
+		<Link>
+			<AdditionalDependencies>d3d12.lib;dxguid.lib;winmm.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+			<SubSystem>Console</SubSystem>
+			<DataExecutionPrevention>true</DataExecutionPrevention>
+		</Link>
+		<Manifest>
+			<EnableDPIAwareness>true</EnableDPIAwareness>
+		</Manifest>
+	</ItemDefinitionGroup>
+	<ItemGroup>
+		<None Include="packages.config" />
+	</ItemGroup>
+	<ItemGroup>
+		<ClCompile Include="main.cpp" />
+		<ClCompile Include="pch.cpp">
+			<PrecompiledHeader>Create</PrecompiledHeader>
+		</ClCompile>
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Core\Core.vcxproj">
+			<Project>{86a58508-0d6a-4786-a32f-01a301fdc6f3}</Project>
+		</ProjectReference>
+		<ProjectReference Include="..\Model\Model.vcxproj">
+			<Project>{5d3aeefb-8789-48e5-9bd9-09c667052d09}</Project>
+		</ProjectReference>
+	</ItemGroup>
+	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+	<ItemDefinitionGroup>
+		<ClCompile>
+			<PreprocessorDefinitions>_GAMING_DESKTOP;__WRL_NO_DEFAULT_LIB__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+			<LanguageStandard>stdcpp17</LanguageStandard>
+		</ClCompile>
+	</ItemDefinitionGroup>
+	<Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+		<PropertyGroup>
+			<ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+		</PropertyGroup>
+		<Error Condition="!Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
+		<Error Condition="!Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets'))" />
+		<Error Condition="!Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets'))" />
+		<Error Condition="!Exists('..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets'))" />
+	</Target>
 </Project>

--- a/Samples/BulkLoadDemo/MiniArchive/MiniArchive.vcxproj
+++ b/Samples/BulkLoadDemo/MiniArchive/MiniArchive.vcxproj
@@ -1,98 +1,98 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <ItemGroup Label="ProjectConfigurations">
-        <ProjectConfiguration Include="Debug|x64">
-            <Configuration>Debug</Configuration>
-            <Platform>x64</Platform>
-        </ProjectConfiguration>
-        <ProjectConfiguration Include="Profile|x64">
-            <Configuration>Profile</Configuration>
-            <Platform>x64</Platform>
-        </ProjectConfiguration>
-        <ProjectConfiguration Include="Release|x64">
-            <Configuration>Release</Configuration>
-            <Platform>x64</Platform>
-        </ProjectConfiguration>
-    </ItemGroup>
-    <PropertyGroup Label="Globals">
-        <RootNamespace>Core</RootNamespace>
-        <ProjectGuid>{a2631beb-8f09-4d0f-a729-f4470d765fc6}</ProjectGuid>
-        <DefaultLanguage>en-US</DefaultLanguage>
-        <Keyword>Win32Proj</Keyword>
-        <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
-        <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-        <TargetRuntime>Native</TargetRuntime>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Profile|x64">
+      <Configuration>Profile</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <RootNamespace>Core</RootNamespace>
+    <ProjectGuid>{a2631beb-8f09-4d0f-a729-f4470d765fc6}</ProjectGuid>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <Keyword>Win32Proj</Keyword>
+    <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <TargetRuntime>Native</TargetRuntime>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <EmbedManifest>false</EmbedManifest>
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\PropertySheets\Build.props" />
+    <Import Project="..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
+    <Import Project="..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets" Condition="Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" />
+    <Import Project="..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets" Condition="Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" />
+    <Import Project="..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets" Condition="Exists('..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Platform)'=='x64'" Label="PropertySheets">
+    <Import Project="..\PropertySheets\Desktop.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
+    <Link>
+      <AdditionalDependencies>d3d12.lib;dxguid.lib;winmm.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Console</SubSystem>
+      <DataExecutionPrevention>true</DataExecutionPrevention>
+    </Link>
+    <Manifest>
+      <EnableDPIAwareness>true</EnableDPIAwareness>
+    </Manifest>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Core.vcxproj">
+      <Project>{86a58508-0d6a-4786-a32f-01a301fdc6f3}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\Model\Model.vcxproj">
+      <Project>{5d3aeefb-8789-48e5-9bd9-09c667052d09}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>_GAMING_DESKTOP;__WRL_NO_DEFAULT_LIB__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-    <PropertyGroup Label="Configuration">
-        <ConfigurationType>Application</ConfigurationType>
-        <PlatformToolset>v142</PlatformToolset>
-        <CharacterSet>Unicode</CharacterSet>
-        <EmbedManifest>false</EmbedManifest>
-        <GenerateManifest>false</GenerateManifest>
-    </PropertyGroup>
-    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-    <ImportGroup Label="ExtensionSettings" />
-    <ImportGroup Label="PropertySheets">
-        <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-        <Import Project="..\PropertySheets\Build.props" />
-        <Import Project="..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
-        <Import Project="..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets" Condition="Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" />
-        <Import Project="..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets" Condition="Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" />
-        <Import Project="..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets" Condition="Exists('..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" />
-    </ImportGroup>
-    <ImportGroup Condition="'$(Platform)'=='x64'" Label="PropertySheets">
-        <Import Project="..\PropertySheets\Desktop.props" />
-    </ImportGroup>
-    <PropertyGroup Label="UserMacros" />
-    <ItemDefinitionGroup>
-        <ClCompile>
-            <PrecompiledHeader>Use</PrecompiledHeader>
-            <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-            <RuntimeTypeInfo>true</RuntimeTypeInfo>
-        </ClCompile>
-    </ItemDefinitionGroup>
-    <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
-        <Link>
-            <AdditionalDependencies>d3d12.lib;dxguid.lib;winmm.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-            <SubSystem>Console</SubSystem>
-            <DataExecutionPrevention>true</DataExecutionPrevention>
-        </Link>
-        <Manifest>
-            <EnableDPIAwareness>true</EnableDPIAwareness>
-        </Manifest>
-    </ItemDefinitionGroup>
-    <ItemGroup>
-        <None Include="packages.config" />
-    </ItemGroup>
-    <ItemGroup>
-        <ClCompile Include="main.cpp" />
-        <ClCompile Include="pch.cpp">
-            <PrecompiledHeader>Create</PrecompiledHeader>
-        </ClCompile>
-    </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="..\Core\Core.vcxproj">
-            <Project>{86a58508-0d6a-4786-a32f-01a301fdc6f3}</Project>
-        </ProjectReference>
-        <ProjectReference Include="..\Model\Model.vcxproj">
-            <Project>{5d3aeefb-8789-48e5-9bd9-09c667052d09}</Project>
-        </ProjectReference>
-    </ItemGroup>
-    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-    <ItemDefinitionGroup>
-        <ClCompile>
-            <PreprocessorDefinitions>_GAMING_DESKTOP;__WRL_NO_DEFAULT_LIB__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-            <LanguageStandard>stdcpp17</LanguageStandard>
-        </ClCompile>
-    </ItemDefinitionGroup>
-    <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-        <PropertyGroup>
-            <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-        </PropertyGroup>
-        <Error Condition="!Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
-        <Error Condition="!Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets'))" />
-        <Error Condition="!Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets'))" />
-        <Error Condition="!Exists('..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets'))" />
-    </Target>
+    <Error Condition="!Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
+    <Error Condition="!Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets'))" />
+    <Error Condition="!Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Direct3D.DirectStorage.1.3.0\build\native\targets\Microsoft.Direct3D.DirectStorage.targets'))" />
+  </Target>
 </Project>

--- a/Samples/BulkLoadDemo/MiniArchive/MiniArchive.vcxproj
+++ b/Samples/BulkLoadDemo/MiniArchive/MiniArchive.vcxproj
@@ -26,7 +26,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <EmbedManifest>false</EmbedManifest>
     <GenerateManifest>false</GenerateManifest>

--- a/Samples/BulkLoadDemo/MiniArchive/MiniArchive.vcxproj
+++ b/Samples/BulkLoadDemo/MiniArchive/MiniArchive.vcxproj
@@ -20,13 +20,13 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <Keyword>Win32Proj</Keyword>
     <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <TargetRuntime>Native</TargetRuntime>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <EmbedManifest>false</EmbedManifest>
     <GenerateManifest>false</GenerateManifest>

--- a/Samples/BulkLoadDemo/Model/Model.vcxproj
+++ b/Samples/BulkLoadDemo/Model/Model.vcxproj
@@ -20,7 +20,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <Keyword>Win32Proj</Keyword>
     <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <TargetRuntime>Native</TargetRuntime>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/Samples/BulkLoadDemo/Model/Model.vcxproj
+++ b/Samples/BulkLoadDemo/Model/Model.vcxproj
@@ -20,13 +20,13 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <Keyword>Win32Proj</Keyword>
     <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <TargetRuntime>Native</TargetRuntime>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <EmbedManifest>false</EmbedManifest>
     <GenerateManifest>false</GenerateManifest>

--- a/Samples/BulkLoadDemo/Model/Model.vcxproj
+++ b/Samples/BulkLoadDemo/Model/Model.vcxproj
@@ -26,7 +26,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <EmbedManifest>false</EmbedManifest>
     <GenerateManifest>false</GenerateManifest>

--- a/Samples/BulkLoadDemo/Model/Model.vcxproj
+++ b/Samples/BulkLoadDemo/Model/Model.vcxproj
@@ -1,191 +1,191 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <ItemGroup Label="ProjectConfigurations">
-        <ProjectConfiguration Include="Debug|x64">
-            <Configuration>Debug</Configuration>
-            <Platform>x64</Platform>
-        </ProjectConfiguration>
-        <ProjectConfiguration Include="Profile|x64">
-            <Configuration>Profile</Configuration>
-            <Platform>x64</Platform>
-        </ProjectConfiguration>
-        <ProjectConfiguration Include="Release|x64">
-            <Configuration>Release</Configuration>
-            <Platform>x64</Platform>
-        </ProjectConfiguration>
-    </ItemGroup>
-    <PropertyGroup Label="Globals">
-        <RootNamespace>Model</RootNamespace>
-        <ProjectGuid>{5D3AEEFB-8789-48E5-9BD9-09C667052D09}</ProjectGuid>
-        <DefaultLanguage>en-US</DefaultLanguage>
-        <Keyword>Win32Proj</Keyword>
-        <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
-        <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-        <TargetRuntime>Native</TargetRuntime>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Profile|x64">
+      <Configuration>Profile</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <RootNamespace>Model</RootNamespace>
+    <ProjectGuid>{5D3AEEFB-8789-48E5-9BD9-09C667052D09}</ProjectGuid>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <Keyword>Win32Proj</Keyword>
+    <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <TargetRuntime>Native</TargetRuntime>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <EmbedManifest>false</EmbedManifest>
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\PropertySheets\Build.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Platform)'=='x64'" Label="PropertySheets">
+    <Import Project="..\PropertySheets\Desktop.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile />
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
+    <Link>
+      <AdditionalDependencies>d3d11.lib;dxguid.lib;winmm.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Windows</SubSystem>
+      <DataExecutionPrevention>true</DataExecutionPrevention>
+    </Link>
+    <Manifest>
+      <EnableDPIAwareness>true</EnableDPIAwareness>
+    </Manifest>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="Animation.h" />
+    <ClInclude Include="ConstantBuffers.h" />
+    <ClInclude Include="glTF.h" />
+    <ClInclude Include="IndexOptimizePostTransform.h" />
+    <ClInclude Include="json.hpp" />
+    <ClInclude Include="LightManager.h" />
+    <ClInclude Include="MeshConvert.h" />
+    <ClInclude Include="Model.h" />
+    <ClInclude Include="ModelLoader.h" />
+    <ClInclude Include="ModelH3D.h" />
+    <ClInclude Include="ParticleEffects.h" />
+    <ClInclude Include="Renderer.h" />
+    <ClInclude Include="SponzaRenderer.h" />
+    <ClInclude Include="TextureConvert.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Animation.cpp" />
+    <ClCompile Include="BuildH3D.cpp" />
+    <ClCompile Include="glTF.cpp" />
+    <ClCompile Include="IndexOptimizePostTransform.cpp" />
+    <ClCompile Include="LightManager.cpp" />
+    <ClCompile Include="MeshConvert.cpp" />
+    <ClCompile Include="Model.cpp" />
+    <ClCompile Include="ModelConvert.cpp" />
+    <ClCompile Include="ModelH3D.cpp" />
+    <ClCompile Include="ModelLoader.cpp" />
+    <ClCompile Include="ParticleEffects.cpp" />
+    <ClCompile Include="Renderer.cpp" />
+    <ClCompile Include="SponzaRenderer.cpp" />
+    <ClCompile Include="TextureConvert.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="Shaders\Common.hlsli" />
+    <None Include="Shaders\FillLightGridCS.hlsli" />
+    <None Include="Shaders\LightGrid.hlsli" />
+    <None Include="Shaders\Lighting.hlsli" />
+  </ItemGroup>
+  <ItemGroup>
+    <FxCompile Include="Shaders\CutoutDepthPS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\CutoutDepthSkinVS.hlsl">
+      <ShaderType>Vertex</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\CutoutDepthVS.hlsl">
+      <ShaderType>Vertex</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\DefaultNoTangentNoUV1PS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\DefaultNoTangentNoUV1SkinVS.hlsl">
+      <ShaderType>Vertex</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\DefaultNoTangentNoUV1VS.hlsl">
+      <ShaderType>Vertex</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\DefaultNoTangentPS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\DefaultNoTangentSkinVS.hlsl">
+      <ShaderType>Vertex</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\DefaultNoTangentVS.hlsl">
+      <ShaderType>Vertex</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\DefaultNoUV1PS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\DefaultNoUV1SkinVS.hlsl">
+      <ShaderType>Vertex</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\DefaultNoUV1VS.hlsl">
+      <ShaderType>Vertex</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\DefaultSkinVS.hlsl">
+      <ShaderType>Vertex</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\DefaultVS.hlsl">
+      <ShaderType>Vertex</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\DepthOnlySkinVS.hlsl">
+      <ShaderType>Vertex</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\DepthOnlyVS.hlsl">
+      <ShaderType>Vertex</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\DepthViewerPS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\DepthViewerVS.hlsl">
+      <ShaderType>Vertex</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\FillLightGridCS_16.hlsl" />
+    <FxCompile Include="Shaders\FillLightGridCS_24.hlsl" />
+    <FxCompile Include="Shaders\FillLightGridCS_32.hlsl" />
+    <FxCompile Include="Shaders\FillLightGridCS_8.hlsl" />
+    <FxCompile Include="Shaders\DefaultPS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\ModelViewerPS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\ModelViewerVS.hlsl">
+      <ShaderType>Vertex</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\SkyboxPS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="Shaders\SkyboxVS.hlsl">
+      <ShaderType>Vertex</ShaderType>
+    </FxCompile>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
+    <Import Project="..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets" Condition="Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" />
+    <Import Project="..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets" Condition="Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" />
+    <Import Project="..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets" Condition="Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-    <PropertyGroup Label="Configuration">
-        <ConfigurationType>StaticLibrary</ConfigurationType>
-        <PlatformToolset>v142</PlatformToolset>
-        <CharacterSet>Unicode</CharacterSet>
-        <EmbedManifest>false</EmbedManifest>
-        <GenerateManifest>false</GenerateManifest>
-    </PropertyGroup>
-    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-    <ImportGroup Label="ExtensionSettings" />
-    <ImportGroup Label="PropertySheets">
-        <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-        <Import Project="..\PropertySheets\Build.props" />
-    </ImportGroup>
-    <ImportGroup Condition="'$(Platform)'=='x64'" Label="PropertySheets">
-        <Import Project="..\PropertySheets\Desktop.props" />
-    </ImportGroup>
-    <PropertyGroup Label="UserMacros" />
-    <ItemDefinitionGroup>
-        <ClCompile>
-            <PrecompiledHeader>NotUsing</PrecompiledHeader>
-            <PrecompiledHeaderFile />
-            <RuntimeTypeInfo>true</RuntimeTypeInfo>
-        </ClCompile>
-    </ItemDefinitionGroup>
-    <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
-        <Link>
-            <AdditionalDependencies>d3d11.lib;dxguid.lib;winmm.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-            <SubSystem>Windows</SubSystem>
-            <DataExecutionPrevention>true</DataExecutionPrevention>
-        </Link>
-        <Manifest>
-            <EnableDPIAwareness>true</EnableDPIAwareness>
-        </Manifest>
-    </ItemDefinitionGroup>
-    <ItemGroup>
-        <ClInclude Include="Animation.h" />
-        <ClInclude Include="ConstantBuffers.h" />
-        <ClInclude Include="glTF.h" />
-        <ClInclude Include="IndexOptimizePostTransform.h" />
-        <ClInclude Include="json.hpp" />
-        <ClInclude Include="LightManager.h" />
-        <ClInclude Include="MeshConvert.h" />
-        <ClInclude Include="Model.h" />
-        <ClInclude Include="ModelLoader.h" />
-        <ClInclude Include="ModelH3D.h" />
-        <ClInclude Include="ParticleEffects.h" />
-        <ClInclude Include="Renderer.h" />
-        <ClInclude Include="SponzaRenderer.h" />
-        <ClInclude Include="TextureConvert.h" />
-    </ItemGroup>
-    <ItemGroup>
-        <ClCompile Include="Animation.cpp" />
-        <ClCompile Include="BuildH3D.cpp" />
-        <ClCompile Include="glTF.cpp" />
-        <ClCompile Include="IndexOptimizePostTransform.cpp" />
-        <ClCompile Include="LightManager.cpp" />
-        <ClCompile Include="MeshConvert.cpp" />
-        <ClCompile Include="Model.cpp" />
-        <ClCompile Include="ModelConvert.cpp" />
-        <ClCompile Include="ModelH3D.cpp" />
-        <ClCompile Include="ModelLoader.cpp" />
-        <ClCompile Include="ParticleEffects.cpp" />
-        <ClCompile Include="Renderer.cpp" />
-        <ClCompile Include="SponzaRenderer.cpp" />
-        <ClCompile Include="TextureConvert.cpp" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="packages.config" />
-        <None Include="Shaders\Common.hlsli" />
-        <None Include="Shaders\FillLightGridCS.hlsli" />
-        <None Include="Shaders\LightGrid.hlsli" />
-        <None Include="Shaders\Lighting.hlsli" />
-    </ItemGroup>
-    <ItemGroup>
-        <FxCompile Include="Shaders\CutoutDepthPS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\CutoutDepthSkinVS.hlsl">
-            <ShaderType>Vertex</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\CutoutDepthVS.hlsl">
-            <ShaderType>Vertex</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\DefaultNoTangentNoUV1PS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\DefaultNoTangentNoUV1SkinVS.hlsl">
-            <ShaderType>Vertex</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\DefaultNoTangentNoUV1VS.hlsl">
-            <ShaderType>Vertex</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\DefaultNoTangentPS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\DefaultNoTangentSkinVS.hlsl">
-            <ShaderType>Vertex</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\DefaultNoTangentVS.hlsl">
-            <ShaderType>Vertex</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\DefaultNoUV1PS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\DefaultNoUV1SkinVS.hlsl">
-            <ShaderType>Vertex</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\DefaultNoUV1VS.hlsl">
-            <ShaderType>Vertex</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\DefaultSkinVS.hlsl">
-            <ShaderType>Vertex</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\DefaultVS.hlsl">
-            <ShaderType>Vertex</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\DepthOnlySkinVS.hlsl">
-            <ShaderType>Vertex</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\DepthOnlyVS.hlsl">
-            <ShaderType>Vertex</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\DepthViewerPS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\DepthViewerVS.hlsl">
-            <ShaderType>Vertex</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\FillLightGridCS_16.hlsl" />
-        <FxCompile Include="Shaders\FillLightGridCS_24.hlsl" />
-        <FxCompile Include="Shaders\FillLightGridCS_32.hlsl" />
-        <FxCompile Include="Shaders\FillLightGridCS_8.hlsl" />
-        <FxCompile Include="Shaders\DefaultPS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\ModelViewerPS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\ModelViewerVS.hlsl">
-            <ShaderType>Vertex</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\SkyboxPS.hlsl">
-            <ShaderType>Pixel</ShaderType>
-        </FxCompile>
-        <FxCompile Include="Shaders\SkyboxVS.hlsl">
-            <ShaderType>Vertex</ShaderType>
-        </FxCompile>
-    </ItemGroup>
-    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-    <ImportGroup Label="ExtensionTargets">
-        <Import Project="..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
-        <Import Project="..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets" Condition="Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" />
-        <Import Project="..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets" Condition="Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" />
-        <Import Project="..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets" Condition="Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" />
-    </ImportGroup>
-    <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-        <PropertyGroup>
-            <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-        </PropertyGroup>
-        <Error Condition="!Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
-        <Error Condition="!Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets'))" />
-        <Error Condition="!Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets'))" />
-        <Error Condition="!Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets'))" />
-    </Target>
+    <Error Condition="!Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
+    <Error Condition="!Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets'))" />
+    <Error Condition="!Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets'))" />
+    <Error Condition="!Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets'))" />
+  </Target>
 </Project>

--- a/Samples/BulkLoadDemo/Model/Model.vcxproj
+++ b/Samples/BulkLoadDemo/Model/Model.vcxproj
@@ -1,191 +1,191 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="Debug|x64">
-			<Configuration>Debug</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="Profile|x64">
-			<Configuration>Profile</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="Release|x64">
-			<Configuration>Release</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-	</ItemGroup>
-	<PropertyGroup Label="Globals">
-		<RootNamespace>Model</RootNamespace>
-		<ProjectGuid>{5D3AEEFB-8789-48E5-9BD9-09C667052D09}</ProjectGuid>
-		<DefaultLanguage>en-US</DefaultLanguage>
-		<Keyword>Win32Proj</Keyword>
-		<MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
-		<WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
-		<TargetRuntime>Native</TargetRuntime>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-	<PropertyGroup Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v142</PlatformToolset>
-		<CharacterSet>Unicode</CharacterSet>
-		<EmbedManifest>false</EmbedManifest>
-		<GenerateManifest>false</GenerateManifest>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-	<ImportGroup Label="ExtensionSettings" />
-	<ImportGroup Label="PropertySheets">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-		<Import Project="..\PropertySheets\Build.props" />
-	</ImportGroup>
-	<ImportGroup Condition="'$(Platform)'=='x64'" Label="PropertySheets">
-		<Import Project="..\PropertySheets\Desktop.props" />
-	</ImportGroup>
-	<PropertyGroup Label="UserMacros" />
-	<ItemDefinitionGroup>
-		<ClCompile>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile />
-			<RuntimeTypeInfo>true</RuntimeTypeInfo>
-		</ClCompile>
-	</ItemDefinitionGroup>
-	<ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
-		<Link>
-			<AdditionalDependencies>d3d11.lib;dxguid.lib;winmm.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<SubSystem>Windows</SubSystem>
-			<DataExecutionPrevention>true</DataExecutionPrevention>
-		</Link>
-		<Manifest>
-			<EnableDPIAwareness>true</EnableDPIAwareness>
-		</Manifest>
-	</ItemDefinitionGroup>
-	<ItemGroup>
-		<ClInclude Include="Animation.h" />
-		<ClInclude Include="ConstantBuffers.h" />
-		<ClInclude Include="glTF.h" />
-		<ClInclude Include="IndexOptimizePostTransform.h" />
-		<ClInclude Include="json.hpp" />
-		<ClInclude Include="LightManager.h" />
-		<ClInclude Include="MeshConvert.h" />
-		<ClInclude Include="Model.h" />
-		<ClInclude Include="ModelLoader.h" />
-		<ClInclude Include="ModelH3D.h" />
-		<ClInclude Include="ParticleEffects.h" />
-		<ClInclude Include="Renderer.h" />
-		<ClInclude Include="SponzaRenderer.h" />
-		<ClInclude Include="TextureConvert.h" />
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="Animation.cpp" />
-		<ClCompile Include="BuildH3D.cpp" />
-		<ClCompile Include="glTF.cpp" />
-		<ClCompile Include="IndexOptimizePostTransform.cpp" />
-		<ClCompile Include="LightManager.cpp" />
-		<ClCompile Include="MeshConvert.cpp" />
-		<ClCompile Include="Model.cpp" />
-		<ClCompile Include="ModelConvert.cpp" />
-		<ClCompile Include="ModelH3D.cpp" />
-		<ClCompile Include="ModelLoader.cpp" />
-		<ClCompile Include="ParticleEffects.cpp" />
-		<ClCompile Include="Renderer.cpp" />
-		<ClCompile Include="SponzaRenderer.cpp" />
-		<ClCompile Include="TextureConvert.cpp" />
-	</ItemGroup>
-	<ItemGroup>
-		<None Include="packages.config" />
-		<None Include="Shaders\Common.hlsli" />
-		<None Include="Shaders\FillLightGridCS.hlsli" />
-		<None Include="Shaders\LightGrid.hlsli" />
-		<None Include="Shaders\Lighting.hlsli" />
-	</ItemGroup>
-	<ItemGroup>
-		<FxCompile Include="Shaders\CutoutDepthPS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\CutoutDepthSkinVS.hlsl">
-			<ShaderType>Vertex</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\CutoutDepthVS.hlsl">
-			<ShaderType>Vertex</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\DefaultNoTangentNoUV1PS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\DefaultNoTangentNoUV1SkinVS.hlsl">
-			<ShaderType>Vertex</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\DefaultNoTangentNoUV1VS.hlsl">
-			<ShaderType>Vertex</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\DefaultNoTangentPS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\DefaultNoTangentSkinVS.hlsl">
-			<ShaderType>Vertex</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\DefaultNoTangentVS.hlsl">
-			<ShaderType>Vertex</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\DefaultNoUV1PS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\DefaultNoUV1SkinVS.hlsl">
-			<ShaderType>Vertex</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\DefaultNoUV1VS.hlsl">
-			<ShaderType>Vertex</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\DefaultSkinVS.hlsl">
-			<ShaderType>Vertex</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\DefaultVS.hlsl">
-			<ShaderType>Vertex</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\DepthOnlySkinVS.hlsl">
-			<ShaderType>Vertex</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\DepthOnlyVS.hlsl">
-			<ShaderType>Vertex</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\DepthViewerPS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\DepthViewerVS.hlsl">
-			<ShaderType>Vertex</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\FillLightGridCS_16.hlsl" />
-		<FxCompile Include="Shaders\FillLightGridCS_24.hlsl" />
-		<FxCompile Include="Shaders\FillLightGridCS_32.hlsl" />
-		<FxCompile Include="Shaders\FillLightGridCS_8.hlsl" />
-		<FxCompile Include="Shaders\DefaultPS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\ModelViewerPS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\ModelViewerVS.hlsl">
-			<ShaderType>Vertex</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\SkyboxPS.hlsl">
-			<ShaderType>Pixel</ShaderType>
-		</FxCompile>
-		<FxCompile Include="Shaders\SkyboxVS.hlsl">
-			<ShaderType>Vertex</ShaderType>
-		</FxCompile>
-	</ItemGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-	<ImportGroup Label="ExtensionTargets">
-		<Import Project="..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
-		<Import Project="..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets" Condition="Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" />
-		<Import Project="..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets" Condition="Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" />
-		<Import Project="..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets" Condition="Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" />
-	</ImportGroup>
-	<Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-		<PropertyGroup>
-			<ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-		</PropertyGroup>
-		<Error Condition="!Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
-		<Error Condition="!Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets'))" />
-		<Error Condition="!Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets'))" />
-		<Error Condition="!Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets'))" />
-	</Target>
+    <ItemGroup Label="ProjectConfigurations">
+        <ProjectConfiguration Include="Debug|x64">
+            <Configuration>Debug</Configuration>
+            <Platform>x64</Platform>
+        </ProjectConfiguration>
+        <ProjectConfiguration Include="Profile|x64">
+            <Configuration>Profile</Configuration>
+            <Platform>x64</Platform>
+        </ProjectConfiguration>
+        <ProjectConfiguration Include="Release|x64">
+            <Configuration>Release</Configuration>
+            <Platform>x64</Platform>
+        </ProjectConfiguration>
+    </ItemGroup>
+    <PropertyGroup Label="Globals">
+        <RootNamespace>Model</RootNamespace>
+        <ProjectGuid>{5D3AEEFB-8789-48E5-9BD9-09C667052D09}</ProjectGuid>
+        <DefaultLanguage>en-US</DefaultLanguage>
+        <Keyword>Win32Proj</Keyword>
+        <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
+        <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+        <TargetRuntime>Native</TargetRuntime>
+    </PropertyGroup>
+    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+    <PropertyGroup Label="Configuration">
+        <ConfigurationType>StaticLibrary</ConfigurationType>
+        <PlatformToolset>v142</PlatformToolset>
+        <CharacterSet>Unicode</CharacterSet>
+        <EmbedManifest>false</EmbedManifest>
+        <GenerateManifest>false</GenerateManifest>
+    </PropertyGroup>
+    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+    <ImportGroup Label="ExtensionSettings" />
+    <ImportGroup Label="PropertySheets">
+        <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+        <Import Project="..\PropertySheets\Build.props" />
+    </ImportGroup>
+    <ImportGroup Condition="'$(Platform)'=='x64'" Label="PropertySheets">
+        <Import Project="..\PropertySheets\Desktop.props" />
+    </ImportGroup>
+    <PropertyGroup Label="UserMacros" />
+    <ItemDefinitionGroup>
+        <ClCompile>
+            <PrecompiledHeader>NotUsing</PrecompiledHeader>
+            <PrecompiledHeaderFile />
+            <RuntimeTypeInfo>true</RuntimeTypeInfo>
+        </ClCompile>
+    </ItemDefinitionGroup>
+    <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
+        <Link>
+            <AdditionalDependencies>d3d11.lib;dxguid.lib;winmm.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+            <SubSystem>Windows</SubSystem>
+            <DataExecutionPrevention>true</DataExecutionPrevention>
+        </Link>
+        <Manifest>
+            <EnableDPIAwareness>true</EnableDPIAwareness>
+        </Manifest>
+    </ItemDefinitionGroup>
+    <ItemGroup>
+        <ClInclude Include="Animation.h" />
+        <ClInclude Include="ConstantBuffers.h" />
+        <ClInclude Include="glTF.h" />
+        <ClInclude Include="IndexOptimizePostTransform.h" />
+        <ClInclude Include="json.hpp" />
+        <ClInclude Include="LightManager.h" />
+        <ClInclude Include="MeshConvert.h" />
+        <ClInclude Include="Model.h" />
+        <ClInclude Include="ModelLoader.h" />
+        <ClInclude Include="ModelH3D.h" />
+        <ClInclude Include="ParticleEffects.h" />
+        <ClInclude Include="Renderer.h" />
+        <ClInclude Include="SponzaRenderer.h" />
+        <ClInclude Include="TextureConvert.h" />
+    </ItemGroup>
+    <ItemGroup>
+        <ClCompile Include="Animation.cpp" />
+        <ClCompile Include="BuildH3D.cpp" />
+        <ClCompile Include="glTF.cpp" />
+        <ClCompile Include="IndexOptimizePostTransform.cpp" />
+        <ClCompile Include="LightManager.cpp" />
+        <ClCompile Include="MeshConvert.cpp" />
+        <ClCompile Include="Model.cpp" />
+        <ClCompile Include="ModelConvert.cpp" />
+        <ClCompile Include="ModelH3D.cpp" />
+        <ClCompile Include="ModelLoader.cpp" />
+        <ClCompile Include="ParticleEffects.cpp" />
+        <ClCompile Include="Renderer.cpp" />
+        <ClCompile Include="SponzaRenderer.cpp" />
+        <ClCompile Include="TextureConvert.cpp" />
+    </ItemGroup>
+    <ItemGroup>
+        <None Include="packages.config" />
+        <None Include="Shaders\Common.hlsli" />
+        <None Include="Shaders\FillLightGridCS.hlsli" />
+        <None Include="Shaders\LightGrid.hlsli" />
+        <None Include="Shaders\Lighting.hlsli" />
+    </ItemGroup>
+    <ItemGroup>
+        <FxCompile Include="Shaders\CutoutDepthPS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\CutoutDepthSkinVS.hlsl">
+            <ShaderType>Vertex</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\CutoutDepthVS.hlsl">
+            <ShaderType>Vertex</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\DefaultNoTangentNoUV1PS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\DefaultNoTangentNoUV1SkinVS.hlsl">
+            <ShaderType>Vertex</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\DefaultNoTangentNoUV1VS.hlsl">
+            <ShaderType>Vertex</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\DefaultNoTangentPS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\DefaultNoTangentSkinVS.hlsl">
+            <ShaderType>Vertex</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\DefaultNoTangentVS.hlsl">
+            <ShaderType>Vertex</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\DefaultNoUV1PS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\DefaultNoUV1SkinVS.hlsl">
+            <ShaderType>Vertex</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\DefaultNoUV1VS.hlsl">
+            <ShaderType>Vertex</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\DefaultSkinVS.hlsl">
+            <ShaderType>Vertex</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\DefaultVS.hlsl">
+            <ShaderType>Vertex</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\DepthOnlySkinVS.hlsl">
+            <ShaderType>Vertex</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\DepthOnlyVS.hlsl">
+            <ShaderType>Vertex</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\DepthViewerPS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\DepthViewerVS.hlsl">
+            <ShaderType>Vertex</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\FillLightGridCS_16.hlsl" />
+        <FxCompile Include="Shaders\FillLightGridCS_24.hlsl" />
+        <FxCompile Include="Shaders\FillLightGridCS_32.hlsl" />
+        <FxCompile Include="Shaders\FillLightGridCS_8.hlsl" />
+        <FxCompile Include="Shaders\DefaultPS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\ModelViewerPS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\ModelViewerVS.hlsl">
+            <ShaderType>Vertex</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\SkyboxPS.hlsl">
+            <ShaderType>Pixel</ShaderType>
+        </FxCompile>
+        <FxCompile Include="Shaders\SkyboxVS.hlsl">
+            <ShaderType>Vertex</ShaderType>
+        </FxCompile>
+    </ItemGroup>
+    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+    <ImportGroup Label="ExtensionTargets">
+        <Import Project="..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
+        <Import Project="..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets" Condition="Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" />
+        <Import Project="..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets" Condition="Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" />
+        <Import Project="..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets" Condition="Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" />
+    </ImportGroup>
+    <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+        <PropertyGroup>
+            <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+        </PropertyGroup>
+        <Error Condition="!Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
+        <Error Condition="!Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets'))" />
+        <Error Condition="!Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets'))" />
+        <Error Condition="!Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets'))" />
+    </Target>
 </Project>

--- a/Samples/BulkLoadDemo/Model/Model.vcxproj
+++ b/Samples/BulkLoadDemo/Model/Model.vcxproj
@@ -1,191 +1,191 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|x64">
-      <Configuration>Debug</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Profile|x64">
-      <Configuration>Profile</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|x64">
-      <Configuration>Release</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-  </ItemGroup>
-  <PropertyGroup Label="Globals">
-    <RootNamespace>Model</RootNamespace>
-    <ProjectGuid>{5D3AEEFB-8789-48E5-9BD9-09C667052D09}</ProjectGuid>
-    <DefaultLanguage>en-US</DefaultLanguage>
-    <Keyword>Win32Proj</Keyword>
-    <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-    <TargetRuntime>Native</TargetRuntime>
-  </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-    <EmbedManifest>false</EmbedManifest>
-    <GenerateManifest>false</GenerateManifest>
-  </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <ImportGroup Label="ExtensionSettings" />
-  <ImportGroup Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\PropertySheets\Build.props" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Platform)'=='x64'" Label="PropertySheets">
-    <Import Project="..\PropertySheets\Desktop.props" />
-  </ImportGroup>
-  <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup>
-    <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <PrecompiledHeaderFile />
-      <RuntimeTypeInfo>true</RuntimeTypeInfo>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
-    <Link>
-      <AdditionalDependencies>d3d11.lib;dxguid.lib;winmm.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <SubSystem>Windows</SubSystem>
-      <DataExecutionPrevention>true</DataExecutionPrevention>
-    </Link>
-    <Manifest>
-      <EnableDPIAwareness>true</EnableDPIAwareness>
-    </Manifest>
-  </ItemDefinitionGroup>
-  <ItemGroup>
-    <ClInclude Include="Animation.h" />
-    <ClInclude Include="ConstantBuffers.h" />
-    <ClInclude Include="glTF.h" />
-    <ClInclude Include="IndexOptimizePostTransform.h" />
-    <ClInclude Include="json.hpp" />
-    <ClInclude Include="LightManager.h" />
-    <ClInclude Include="MeshConvert.h" />
-    <ClInclude Include="Model.h" />
-    <ClInclude Include="ModelLoader.h" />
-    <ClInclude Include="ModelH3D.h" />
-    <ClInclude Include="ParticleEffects.h" />
-    <ClInclude Include="Renderer.h" />
-    <ClInclude Include="SponzaRenderer.h" />
-    <ClInclude Include="TextureConvert.h" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClCompile Include="Animation.cpp" />
-    <ClCompile Include="BuildH3D.cpp" />
-    <ClCompile Include="glTF.cpp" />
-    <ClCompile Include="IndexOptimizePostTransform.cpp" />
-    <ClCompile Include="LightManager.cpp" />
-    <ClCompile Include="MeshConvert.cpp" />
-    <ClCompile Include="Model.cpp" />
-    <ClCompile Include="ModelConvert.cpp" />
-    <ClCompile Include="ModelH3D.cpp" />
-    <ClCompile Include="ModelLoader.cpp" />
-    <ClCompile Include="ParticleEffects.cpp" />
-    <ClCompile Include="Renderer.cpp" />
-    <ClCompile Include="SponzaRenderer.cpp" />
-    <ClCompile Include="TextureConvert.cpp" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-    <None Include="Shaders\Common.hlsli" />
-    <None Include="Shaders\FillLightGridCS.hlsli" />
-    <None Include="Shaders\LightGrid.hlsli" />
-    <None Include="Shaders\Lighting.hlsli" />
-  </ItemGroup>
-  <ItemGroup>
-    <FxCompile Include="Shaders\CutoutDepthPS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\CutoutDepthSkinVS.hlsl">
-      <ShaderType>Vertex</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\CutoutDepthVS.hlsl">
-      <ShaderType>Vertex</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\DefaultNoTangentNoUV1PS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\DefaultNoTangentNoUV1SkinVS.hlsl">
-      <ShaderType>Vertex</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\DefaultNoTangentNoUV1VS.hlsl">
-      <ShaderType>Vertex</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\DefaultNoTangentPS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\DefaultNoTangentSkinVS.hlsl">
-      <ShaderType>Vertex</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\DefaultNoTangentVS.hlsl">
-      <ShaderType>Vertex</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\DefaultNoUV1PS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\DefaultNoUV1SkinVS.hlsl">
-      <ShaderType>Vertex</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\DefaultNoUV1VS.hlsl">
-      <ShaderType>Vertex</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\DefaultSkinVS.hlsl">
-      <ShaderType>Vertex</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\DefaultVS.hlsl">
-      <ShaderType>Vertex</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\DepthOnlySkinVS.hlsl">
-      <ShaderType>Vertex</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\DepthOnlyVS.hlsl">
-      <ShaderType>Vertex</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\DepthViewerPS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\DepthViewerVS.hlsl">
-      <ShaderType>Vertex</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\FillLightGridCS_16.hlsl" />
-    <FxCompile Include="Shaders\FillLightGridCS_24.hlsl" />
-    <FxCompile Include="Shaders\FillLightGridCS_32.hlsl" />
-    <FxCompile Include="Shaders\FillLightGridCS_8.hlsl" />
-    <FxCompile Include="Shaders\DefaultPS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\ModelViewerPS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\ModelViewerVS.hlsl">
-      <ShaderType>Vertex</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\SkyboxPS.hlsl">
-      <ShaderType>Pixel</ShaderType>
-    </FxCompile>
-    <FxCompile Include="Shaders\SkyboxVS.hlsl">
-      <ShaderType>Vertex</ShaderType>
-    </FxCompile>
-  </ItemGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
-    <Import Project="..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets" Condition="Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" />
-    <Import Project="..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets" Condition="Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" />
-    <Import Project="..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets" Condition="Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" />
-  </ImportGroup>
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
-    <Error Condition="!Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets'))" />
-    <Error Condition="!Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets'))" />
-    <Error Condition="!Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets'))" />
-  </Target>
+	<ItemGroup Label="ProjectConfigurations">
+		<ProjectConfiguration Include="Debug|x64">
+			<Configuration>Debug</Configuration>
+			<Platform>x64</Platform>
+		</ProjectConfiguration>
+		<ProjectConfiguration Include="Profile|x64">
+			<Configuration>Profile</Configuration>
+			<Platform>x64</Platform>
+		</ProjectConfiguration>
+		<ProjectConfiguration Include="Release|x64">
+			<Configuration>Release</Configuration>
+			<Platform>x64</Platform>
+		</ProjectConfiguration>
+	</ItemGroup>
+	<PropertyGroup Label="Globals">
+		<RootNamespace>Model</RootNamespace>
+		<ProjectGuid>{5D3AEEFB-8789-48E5-9BD9-09C667052D09}</ProjectGuid>
+		<DefaultLanguage>en-US</DefaultLanguage>
+		<Keyword>Win32Proj</Keyword>
+		<MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
+		<WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+		<TargetRuntime>Native</TargetRuntime>
+	</PropertyGroup>
+	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+	<PropertyGroup Label="Configuration">
+		<ConfigurationType>StaticLibrary</ConfigurationType>
+		<PlatformToolset>v142</PlatformToolset>
+		<CharacterSet>Unicode</CharacterSet>
+		<EmbedManifest>false</EmbedManifest>
+		<GenerateManifest>false</GenerateManifest>
+	</PropertyGroup>
+	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+	<ImportGroup Label="ExtensionSettings" />
+	<ImportGroup Label="PropertySheets">
+		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+		<Import Project="..\PropertySheets\Build.props" />
+	</ImportGroup>
+	<ImportGroup Condition="'$(Platform)'=='x64'" Label="PropertySheets">
+		<Import Project="..\PropertySheets\Desktop.props" />
+	</ImportGroup>
+	<PropertyGroup Label="UserMacros" />
+	<ItemDefinitionGroup>
+		<ClCompile>
+			<PrecompiledHeader>NotUsing</PrecompiledHeader>
+			<PrecompiledHeaderFile />
+			<RuntimeTypeInfo>true</RuntimeTypeInfo>
+		</ClCompile>
+	</ItemDefinitionGroup>
+	<ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
+		<Link>
+			<AdditionalDependencies>d3d11.lib;dxguid.lib;winmm.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+			<SubSystem>Windows</SubSystem>
+			<DataExecutionPrevention>true</DataExecutionPrevention>
+		</Link>
+		<Manifest>
+			<EnableDPIAwareness>true</EnableDPIAwareness>
+		</Manifest>
+	</ItemDefinitionGroup>
+	<ItemGroup>
+		<ClInclude Include="Animation.h" />
+		<ClInclude Include="ConstantBuffers.h" />
+		<ClInclude Include="glTF.h" />
+		<ClInclude Include="IndexOptimizePostTransform.h" />
+		<ClInclude Include="json.hpp" />
+		<ClInclude Include="LightManager.h" />
+		<ClInclude Include="MeshConvert.h" />
+		<ClInclude Include="Model.h" />
+		<ClInclude Include="ModelLoader.h" />
+		<ClInclude Include="ModelH3D.h" />
+		<ClInclude Include="ParticleEffects.h" />
+		<ClInclude Include="Renderer.h" />
+		<ClInclude Include="SponzaRenderer.h" />
+		<ClInclude Include="TextureConvert.h" />
+	</ItemGroup>
+	<ItemGroup>
+		<ClCompile Include="Animation.cpp" />
+		<ClCompile Include="BuildH3D.cpp" />
+		<ClCompile Include="glTF.cpp" />
+		<ClCompile Include="IndexOptimizePostTransform.cpp" />
+		<ClCompile Include="LightManager.cpp" />
+		<ClCompile Include="MeshConvert.cpp" />
+		<ClCompile Include="Model.cpp" />
+		<ClCompile Include="ModelConvert.cpp" />
+		<ClCompile Include="ModelH3D.cpp" />
+		<ClCompile Include="ModelLoader.cpp" />
+		<ClCompile Include="ParticleEffects.cpp" />
+		<ClCompile Include="Renderer.cpp" />
+		<ClCompile Include="SponzaRenderer.cpp" />
+		<ClCompile Include="TextureConvert.cpp" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Include="packages.config" />
+		<None Include="Shaders\Common.hlsli" />
+		<None Include="Shaders\FillLightGridCS.hlsli" />
+		<None Include="Shaders\LightGrid.hlsli" />
+		<None Include="Shaders\Lighting.hlsli" />
+	</ItemGroup>
+	<ItemGroup>
+		<FxCompile Include="Shaders\CutoutDepthPS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\CutoutDepthSkinVS.hlsl">
+			<ShaderType>Vertex</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\CutoutDepthVS.hlsl">
+			<ShaderType>Vertex</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\DefaultNoTangentNoUV1PS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\DefaultNoTangentNoUV1SkinVS.hlsl">
+			<ShaderType>Vertex</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\DefaultNoTangentNoUV1VS.hlsl">
+			<ShaderType>Vertex</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\DefaultNoTangentPS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\DefaultNoTangentSkinVS.hlsl">
+			<ShaderType>Vertex</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\DefaultNoTangentVS.hlsl">
+			<ShaderType>Vertex</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\DefaultNoUV1PS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\DefaultNoUV1SkinVS.hlsl">
+			<ShaderType>Vertex</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\DefaultNoUV1VS.hlsl">
+			<ShaderType>Vertex</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\DefaultSkinVS.hlsl">
+			<ShaderType>Vertex</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\DefaultVS.hlsl">
+			<ShaderType>Vertex</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\DepthOnlySkinVS.hlsl">
+			<ShaderType>Vertex</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\DepthOnlyVS.hlsl">
+			<ShaderType>Vertex</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\DepthViewerPS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\DepthViewerVS.hlsl">
+			<ShaderType>Vertex</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\FillLightGridCS_16.hlsl" />
+		<FxCompile Include="Shaders\FillLightGridCS_24.hlsl" />
+		<FxCompile Include="Shaders\FillLightGridCS_32.hlsl" />
+		<FxCompile Include="Shaders\FillLightGridCS_8.hlsl" />
+		<FxCompile Include="Shaders\DefaultPS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\ModelViewerPS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\ModelViewerVS.hlsl">
+			<ShaderType>Vertex</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\SkyboxPS.hlsl">
+			<ShaderType>Pixel</ShaderType>
+		</FxCompile>
+		<FxCompile Include="Shaders\SkyboxVS.hlsl">
+			<ShaderType>Vertex</ShaderType>
+		</FxCompile>
+	</ItemGroup>
+	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+	<ImportGroup Label="ExtensionTargets">
+		<Import Project="..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
+		<Import Project="..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets" Condition="Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" />
+		<Import Project="..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets" Condition="Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" />
+		<Import Project="..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets" Condition="Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" />
+	</ImportGroup>
+	<Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+		<PropertyGroup>
+			<ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+		</PropertyGroup>
+		<Error Condition="!Exists('..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
+		<Error Condition="!Exists('..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets'))" />
+		<Error Condition="!Exists('..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxtex_desktop_win10.2023.1.31.1\build\native\directxtex_desktop_win10.targets'))" />
+		<Error Condition="!Exists('..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\directxmesh_desktop_win10.2022.10.18.1\build\native\directxmesh_desktop_win10.targets'))" />
+	</Target>
 </Project>

--- a/Samples/BulkLoadDemo/PropertySheets/Build.props
+++ b/Samples/BulkLoadDemo/PropertySheets/Build.props
@@ -64,6 +64,7 @@
 	  <ObjectFileOutput />
 	  <EnableDebuggingInformation Condition="'$(Configuration)'=='Debug'">true</EnableDebuggingInformation>
       <AdditionalOptions Condition="'$(Configuration)'=='Debug'">-Qembed_debug %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>-HV 2021 %(AdditionalOptions)</AdditionalOptions>
     </FxCompile>
   </ItemDefinitionGroup>
 </Project>

--- a/Samples/BulkLoadDemo/PropertySheets/Desktop.props
+++ b/Samples/BulkLoadDemo/PropertySheets/Desktop.props
@@ -15,7 +15,7 @@
     </ClCompile>
     <FxCompile>
       <PreprocessorDefinitions>_GAMING_DESKTOP=1</PreprocessorDefinitions>
-      <ShaderModel>6.1</ShaderModel>
+      <ShaderModel>6.2</ShaderModel>
     </FxCompile>
   </ItemDefinitionGroup>
   <ItemGroup />


### PR DESCRIPTION
Fixing compatibility issue with Visual C++ version 143.  Updating shaders to match those in https://github.com/microsoft/DirectX-Graphics-Samples/tree/master/MiniEngine/Core/Shaders, and updating project files as required.  