### PR TITLE
zstd/ExecuteSequences: Reduce DeviceMemoryBarrierWithGroupSync calls.

### DIFF
--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -3890,6 +3890,8 @@ static void zstdgpu_ShaderEntry_ExecuteSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_Exe
 
     const zstdgpu_OffsetAndSize dstFrameOffsAndSize = srt.inUnCompressedFramesRefs[frameIdx];
 
+    uint32_t readableOutputGlobalEnd = 0;
+
     for (uint32_t cmpBlockIdx = cmpBlockBeg; cmpBlockIdx < cmpBlockEnd; ++cmpBlockIdx)
     {
         const uint32_t blockIdx = srt.inGlobalBlockIndexPerCmpBlock[cmpBlockIdx];
@@ -3905,7 +3907,6 @@ static void zstdgpu_ShaderEntry_ExecuteSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_Exe
         const uint32_t blockByteBeg = dstFrameOffsAndSize.offs + (blockOfs - firstFrameBlockOfs);
         const uint32_t blockByteEnd = dstFrameOffsAndSize.offs + (srt.inBlockSizePrefix[blockIdx] - firstFrameBlockOfs);
 
-        uint32_t readableOutputGlobalEnd = blockByteBeg;
 #if 0
         for (uint32_t blockByteIdx = blockByteBeg + i; blockByteIdx < blockByteEnd; blockByteIdx += maxCopySize)
         {
@@ -4042,8 +4043,8 @@ static void zstdgpu_ShaderEntry_ExecuteSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_Exe
             }
         }
 #endif
-        // We don't have to worry about doing DeviceMemoryBarrierWithGroupSync() across blocks.
-    } // end loop over compressed blocks
+
+    }
 }
 
 #ifdef _MSC_VER

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -8,7 +8,7 @@
  *
  * Advanced Technology Group (ATG)
  * Author(s):   Pavel Martishevsky (pamartis@microsoft.com)
- * 
+ *
  * Contains definitions of various routines shared between CPU and GPU.
  */
 
@@ -3813,13 +3813,20 @@ static void zstdgpu_ShaderEntry_FinaliseSequenceOffsets(ZSTDGPU_PARAM_INOUT(zstd
     srt.inoutDecompressedSequenceOffs[seqIdx] = offset;
 }
 
-static uint32_t zstdgpu_MatchLengthCopy(ZSTDGPU_RW_TYPED_BUFFER(uint32_t, uint8_t) outData, uint32_t outByteIdx, uint32_t outByteEnd, uint32_t seqOffs, uint32_t seqMLen, uint32_t i, uint32_t seqIdx, uint32_t maxCopySize)
+static uint32_t zstdgpu_MatchLengthCopy(ZSTDGPU_RW_TYPED_BUFFER(uint32_t, uint8_t) outData, uint32_t outByteIdx, uint32_t outByteEnd, uint32_t seqOffs, uint32_t seqMLen, uint32_t i, uint32_t seqIdx, uint32_t maxCopySize, ZSTDGPU_PARAM_INOUT(uint32_t) readableOutputGlobalEnd)
 {
     ZSTDGPU_UNUSED(i);
     ZSTDGPU_UNUSED(seqIdx);
     ZSTDGPU_UNUSED(maxCopySize); //< NOTE(pamartis): Unused only on CPP side.
 
-    DeviceMemoryBarrierWithGroupSync();
+    // NOTE(jweinste): Avoid waits on UAV stores when llen and mlen are small and match offset is large.
+    // This check may be inaccurate, but it should be conservative.
+    const uint32_t toReadNowGlobalEnd = (outByteIdx - seqOffs) + seqMLen;
+    if (readableOutputGlobalEnd < toReadNowGlobalEnd) // these values should be workgroup-uniform
+    {
+        DeviceMemoryBarrierWithGroupSync();
+        readableOutputGlobalEnd = outByteIdx;
+    }
 
     // NOTE(pamartis): when offset is large enough to fit the entire length, we do as wide copy as possible
     if (seqOffs >= seqMLen)
@@ -3853,6 +3860,7 @@ static uint32_t zstdgpu_MatchLengthCopy(ZSTDGPU_RW_TYPED_BUFFER(uint32_t, uint8_
             len += copyLen;
         }
         while (len < seqMLen);
+        readableOutputGlobalEnd = outByteIdx; // see barrier in do...while
     }
 
     return outByteIdx;
@@ -3897,6 +3905,7 @@ static void zstdgpu_ShaderEntry_ExecuteSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_Exe
         const uint32_t blockByteBeg = dstFrameOffsAndSize.offs + (blockOfs - firstFrameBlockOfs);
         const uint32_t blockByteEnd = dstFrameOffsAndSize.offs + (srt.inBlockSizePrefix[blockIdx] - firstFrameBlockOfs);
 
+        uint32_t readableOutputGlobalEnd = blockByteBeg;
 #if 0
         for (uint32_t blockByteIdx = blockByteBeg + i; blockByteIdx < blockByteEnd; blockByteIdx += maxCopySize)
         {
@@ -3953,7 +3962,7 @@ static void zstdgpu_ShaderEntry_ExecuteSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_Exe
                     blockByteCur += copyLen;
                     litCur += copyLen;
 
-                    blockByteCur = zstdgpu_MatchLengthCopy(srt.inoutUnCompressedFramesData, blockByteCur, blockByteEnd, offs, mlen, i, seqIdx, maxCopySize);
+                    blockByteCur = zstdgpu_MatchLengthCopy(srt.inoutUnCompressedFramesData, blockByteCur, blockByteEnd, offs, mlen, i, seqIdx, maxCopySize, readableOutputGlobalEnd);
                 }
 
             // NOTE(pamartis): copy remaining literals. If above condtion `seqStreamIdx == ~0u` is true,
@@ -3986,7 +3995,7 @@ static void zstdgpu_ShaderEntry_ExecuteSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_Exe
                     blockByteCur += copyLen;
                     litCur += copyLen;
 
-                    blockByteCur = zstdgpu_MatchLengthCopy(srt.inoutUnCompressedFramesData, blockByteCur, blockByteEnd, offs, mlen, i, seqIdx, maxCopySize);
+                    blockByteCur = zstdgpu_MatchLengthCopy(srt.inoutUnCompressedFramesData, blockByteCur, blockByteEnd, offs, mlen, i, seqIdx, maxCopySize, readableOutputGlobalEnd);
                 }
 
             // NOTE(pamartis): copy remaining literals. If above condtion `seqStreamIdx == ~0u` is true,
@@ -4021,7 +4030,7 @@ static void zstdgpu_ShaderEntry_ExecuteSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_Exe
                     blockByteCur += copyLen;
                     litCur += copyLen;
 
-                    blockByteCur = zstdgpu_MatchLengthCopy(srt.inoutUnCompressedFramesData, blockByteCur, blockByteEnd, offs, mlen, i, seqIdx, maxCopySize);
+                    blockByteCur = zstdgpu_MatchLengthCopy(srt.inoutUnCompressedFramesData, blockByteCur, blockByteEnd, offs, mlen, i, seqIdx, maxCopySize, readableOutputGlobalEnd);
                 }
 
             // NOTE(pamartis): copy remaining literals. If above condtion `seqStreamIdx == ~0u` is true,

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -3819,6 +3819,8 @@ static uint32_t zstdgpu_MatchLengthCopy(ZSTDGPU_RW_TYPED_BUFFER(uint32_t, uint8_
     ZSTDGPU_UNUSED(seqIdx);
     ZSTDGPU_UNUSED(maxCopySize); //< NOTE(pamartis): Unused only on CPP side.
 
+    DeviceMemoryBarrierWithGroupSync();
+
     // NOTE(pamartis): when offset is large enough to fit the entire length, we do as wide copy as possible
     if (seqOffs >= seqMLen)
     {
@@ -3852,7 +3854,6 @@ static uint32_t zstdgpu_MatchLengthCopy(ZSTDGPU_RW_TYPED_BUFFER(uint32_t, uint8_
         }
         while (len < seqMLen);
     }
-    DeviceMemoryBarrierWithGroupSync();
 
     return outByteIdx;
 }
@@ -3949,7 +3950,6 @@ static void zstdgpu_ShaderEntry_ExecuteSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_Exe
                     {
                         srt.inoutUnCompressedFramesData[blockByteCur + byteIdx] = srt.inDecompressedLiterals[litCur + byteIdx];
                     }
-                    DeviceMemoryBarrierWithGroupSync();
                     blockByteCur += copyLen;
                     litCur += copyLen;
 
@@ -3983,7 +3983,6 @@ static void zstdgpu_ShaderEntry_ExecuteSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_Exe
                         const uint32_t byteOfs = litCur + byteIdx;
                         srt.inoutUnCompressedFramesData[blockByteCur + byteIdx] = (srt.inCompressedData[byteOfs >> 2] >> ((byteOfs & 3u) << 3u)) & 0xffu;
                     }
-                    DeviceMemoryBarrierWithGroupSync();
                     blockByteCur += copyLen;
                     litCur += copyLen;
 
@@ -4019,7 +4018,6 @@ static void zstdgpu_ShaderEntry_ExecuteSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_Exe
                     {
                         zstdgpu_TypedStoreU8(srt.inoutUnCompressedFramesData, blockByteCur + byteIdx, symbol);
                     }
-                    DeviceMemoryBarrierWithGroupSync();
                     blockByteCur += copyLen;
                     litCur += copyLen;
 
@@ -4035,8 +4033,8 @@ static void zstdgpu_ShaderEntry_ExecuteSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_Exe
             }
         }
 #endif
-
-    }
+        // We don't have to worry about doing DeviceMemoryBarrierWithGroupSync() across blocks.
+    } // end loop over compressed blocks
 }
 
 #ifdef _MSC_VER


### PR DESCRIPTION
Hello! Apologies if a change like this is premature; I know the zstd shader is still quite in development and I haven't tested on a lot of (realistic) data, but these changes seem decently helpful for how simple they might be, and could still be relevant to the future shape the code takes.

These are two changes (each in a PR commit) that reduce the number of `DeviceMemoryBarrierWithGroupSync`s executed across `zstdgpu_ShaderEntry_ExecuteSequences` and `zstdgpu_MatchLengthCopy`:

**First Optimization** (remove unnecessary barrier without adding extra logic/state)
The main operations can occur like this:

1. copy literals (reads from constant literals, does UAV stores to output)
2. DeviceMemoryBarrierWithGroupSync (in zstdgpu_ShaderEntry_ExecuteSequences)
3. do match-copies (reads/writes from/to UAV output)
4. DeviceMemoryBarrierWithGroupSync (at the end of zstdgpu_MatchLengthCopy)
5. copy literals (next sequence)
6. DeviceMemoryBarrierWithGroupSync

The DeviceMemoryBarrierWithGroupSync at operation 4 is unnecessary since the copy literals at operation 5 read from constant data, and there is a DeviceMemoryBarrierWithGroupSync right after it at operation 6. NOTE: the DeviceMemoryBarrierWithGroupSync at 4 is actually costly because its after operation 3, meaning there would be UAV stores in flight.

Avoid this by moving DeviceMemoryBarrierWithGroupSync just before doing match copies.

The DeviceMemoryBarrierWithGroupSync in the "weird memmove" path (mlen > offset) is left alone now. That path doesn't seem common for the data I'm using.

**Second Optimization** ("watermark", builds of prior optimization)
Consider this example sequence-command:
llen: 7
mlen: 8
offs: 1360

The match-copy for this sequence-command will not touch data written earlier by its literal-copy, thus there is no need to wait for the literal-copy. Avoid the barrier by keeping track of whats called "`readableOutputGlobalEnd`" and checking against it. This optimization also applies across sequence-commands and additionally avoids waiting for prior match-copies. It reduces a decent amount of memory barriers in the data I'm using.

**Testing**
I wanted to get something up and going quick, so I just grabbed one 4096x4096 BC7_SRGB texture from a game as a DDS and then compressed that with zstd directly. I realize that's probably not realistic (I assume BCn data is best processed before going through a general compressor like zstd) and more should be tested, but maybe you have advice for that or are able to give these changes a spin.

According to PIX timing with **StablePowerState** on an RX 7900 XTX, [Execute Sequences] completely dominates the time taken for this input. Its duration goes from 835 ms -> 630 ms -> 530 ms (original, first optimization, +second optimization).