### PR TITLE
Addresses several correctness issue

### DIFF
--- a/zstd/zstdgpu/Shaders/ZstdGpuPrefixSequenceOffsets.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuPrefixSequenceOffsets.hlsl
@@ -80,7 +80,8 @@ void main(uint i : SV_DispatchThreadId)
 
     // NOTE(pamartis): for every first in zstd frame compressed block that contains non-zero sequence count, convert "final" offsets
     // into "non-repeat" offsets (if they're re-encoded "repeat" offsets)
-    if (seqStreamIdxFirstInFrame != ~0u && seqStreamIdxFirstInFrame == i)
+    const bool isFirstSequenceStreamInFrame = seqStreamIdxFirstInFrame != ~0u && seqStreamIdxFirstInFrame == i;
+    if (isFirstSequenceStreamInFrame)
     {
         const uint32_t3 b = uint32_t3(1, 4, 8) + 3;
 
@@ -283,5 +284,16 @@ void main(uint i : SV_DispatchThreadId)
         ZstdPerSeqStreamFinalOffset1[i] = p.x;
         ZstdPerSeqStreamFinalOffset2[i] = p.y;
         ZstdPerSeqStreamFinalOffset3[i] = p.z;
+    }
+    // NOTE(pamartis): Added this condition to make sure the first sequence stream ('i') in the frame
+    // always updates its "final" offsets even if 'needsPropagationAfterLookback' is set to 'false'.
+    // 'needsPropagationAfterLookback' can be set to 'false' by the condition at the top of the shader entry
+    // checking that all offsets are "non-encoded", but at the same time offsets of the first sequence stream ('i')
+    // in the frame could have been modified from "encoded" to "non-encoded", so they have to be stored back
+    else if (isFirstSequenceStreamInFrame)
+    {
+        ZstdPerSeqStreamFinalOffset1[i] = o.x;
+        ZstdPerSeqStreamFinalOffset2[i] = o.y;
+        ZstdPerSeqStreamFinalOffset3[i] = o.z;
     }
 }

--- a/zstd/zstdgpu/zstdgpu_reference_store.cpp
+++ b/zstd/zstdgpu/zstdgpu_reference_store.cpp
@@ -703,9 +703,9 @@ void zstdgpu_ReferenceStore_Report_DecompressedSequences(const uint32_t *sequenc
     ZSTDGPU_ASSERT(zstdgpu_DecodeSeqRepeatOffsetEncoded(recent3) == 0);
 
     // on GPU these offsets are available after cross-block propagation
-    GZstd.PerSeqStreamFinalOffset1[GBlockIndexCMP - 1u] = recent1;
-    GZstd.PerSeqStreamFinalOffset2[GBlockIndexCMP - 1u] = recent2;
-    GZstd.PerSeqStreamFinalOffset3[GBlockIndexCMP - 1u] = recent3;
+    GZstd.PerSeqStreamFinalOffset1[i] = recent1;
+    GZstd.PerSeqStreamFinalOffset2[i] = recent2;
+    GZstd.PerSeqStreamFinalOffset3[i] = recent3;
 
     GSequenceCount += sequenceCount;
 

--- a/zstd/zstdgpu/zstdgpu_reference_store.cpp
+++ b/zstd/zstdgpu/zstdgpu_reference_store.cpp
@@ -99,7 +99,7 @@ void zstdgpu_ReferenceStore_FreeMemory(void)
     zstdgpu_ResourceDataCpu_Term(&GZstd);
 }
 
-static uint32_t zstdgpu_SetLastBlockSize(uint32_t size)
+static uint32_t zstdgpu_GetLastBlockIndex(void)
 {
     const uint32_t allBlockCount = GBlockIndexRAW
                                  + GBlockIndexRLE
@@ -107,7 +107,12 @@ static uint32_t zstdgpu_SetLastBlockSize(uint32_t size)
 
     ZSTDGPU_ASSERT(allBlockCount >= 1u);
 
-    const uint32_t lastBlockIndex = allBlockCount - 1u;
+    return allBlockCount - 1u;
+}
+
+static uint32_t zstdgpu_SetLastBlockSize(uint32_t size)
+{
+    const uint32_t lastBlockIndex = zstdgpu_GetLastBlockIndex();
     GZstd.BlockSizePrefix[lastBlockIndex] = size;
 
     if (lastBlockIndex >= 1)
@@ -119,12 +124,7 @@ static uint32_t zstdgpu_SetLastBlockSize(uint32_t size)
 
 static void zstdgpu_AppendLastBlockSize(uint32_t size)
 {
-    const uint32_t allBlockCount = GBlockIndexRAW
-                                 + GBlockIndexRLE
-                                 + GBlockIndexCMP;
-    ZSTDGPU_ASSERT(allBlockCount >= 1u);
-
-    GZstd.BlockSizePrefix[allBlockCount - 1u] += size;
+    GZstd.BlockSizePrefix[zstdgpu_GetLastBlockIndex()] += size;
 }
 
 
@@ -490,10 +490,13 @@ void zstdgpu_ReferenceStore_Report_CompressedSequences(const void *base, uint32_
 
     GZstd.PerSeqStreamSeqStart[i] = GSequenceCount;
 
-    GZstd.SeqRefs[i].fseLLen = GZstd.CompressedBlocks[GBlockIndexCMP - 1].fseTableIndexLLen;
-    GZstd.SeqRefs[i].fseOffs = GZstd.CompressedBlocks[GBlockIndexCMP - 1].fseTableIndexOffs;
-    GZstd.SeqRefs[i].fseMLen = GZstd.CompressedBlocks[GBlockIndexCMP - 1].fseTableIndexMLen;
-    GZstd.CompressedBlocks[GBlockIndexCMP - 1].seqStreamIndex = i;
+    const uint32_t blockId = zstdgpu_GetLastBlockIndex();
+    const uint32_t cmpBlockId = GBlockIndexCMP - 1;
+    GZstd.SeqRefs[i].fseLLen = GZstd.CompressedBlocks[cmpBlockId].fseTableIndexLLen;
+    GZstd.SeqRefs[i].fseOffs = GZstd.CompressedBlocks[cmpBlockId].fseTableIndexOffs;
+    GZstd.SeqRefs[i].fseMLen = GZstd.CompressedBlocks[cmpBlockId].fseTableIndexMLen;
+    GZstd.SeqRefs[i].blockId = blockId;
+    GZstd.CompressedBlocks[cmpBlockId].seqStreamIndex = i;
 }
 
 __pragma(warning(push))

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -398,7 +398,7 @@ static inline void zstdgpu_ShaderEntry_ParseFrames(ZSTDGPU_PARAM_INOUT(zstdgpu_P
                 frameInfo.cmpBlockStart = srt.inoutPerFrameBlockCountCMP[threadId];
 
                 frameInfo.rawBlockBytesStart = srt.inoutPerFrameBlockSizesRAW[threadId];
-                frameInfo.rleBlockBytesStart = srt.inoutPerFrameBlockCountRLE[threadId];
+                frameInfo.rleBlockBytesStart = srt.inoutPerFrameBlockSizesRLE[threadId];
             }
 
             zstdgpu_ShaderEntry_ParseFrame(


### PR DESCRIPTION
This PR adds several fixes:
- A fix for the incorrect index being used to store "final" offsets in validation layer which caused some tests to fail
- A fix for a typo producing wrong results in some cases
- A backward block index reference was not properly initialised in sequence descriptors
- In certain cases "final" (or resolved) offsets were not stored back (after being computed) correctly for the first compressed block with sequences in each frame.