### PR TITLE
MINOR: Adds support for several specialised ExecuteSequence kernel sizes

### DIFF
--- a/zstd/zstdgpu/Shaders/ZstdGpuExecuteSequences.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuExecuteSequences.hlsl
@@ -28,7 +28,9 @@ ZSTDGPU_EXECUTE_SEQUENCES_SRT()
 #undef ZSTDGPU_RW_BUFFER_DECL
 #undef ZSTDGPU_RO_BUFFER_DECL
 
-#define MAX_COPY_SIZE 1024
+#ifndef MAX_COPY_SIZE
+#define MAX_COPY_SIZE 32
+#endif
 
 [RootSignature("DescriptorTable(SRV(t0, numDescriptors=13), UAV(u0, numDescriptors=1))")]
 [numthreads(MAX_COPY_SIZE, 1, 1)]

--- a/zstd/zstdgpu/Shaders/ZstdGpuExecuteSequences128.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuExecuteSequences128.hlsl
@@ -1,0 +1,18 @@
+/**
+ * ZstdGpuExecuteSequences128.hlsl
+ *
+ * A specialisation for the compute shader that executes sequences.
+ *
+ * Copyright (c) Microsoft. All rights reserved.
+ * This code is licensed under the MIT License (MIT).
+ * THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+ * ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+ * IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+ *
+ * Advanced Technology Group (ATG)
+ * Author(s):   Pavel Martishevsky (pamartis@microsoft.com)
+ */
+
+#define MAX_COPY_SIZE 128
+#include "ZstdGpuExecuteSequences.hlsl"

--- a/zstd/zstdgpu/Shaders/ZstdGpuExecuteSequences32.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuExecuteSequences32.hlsl
@@ -1,0 +1,18 @@
+/**
+ * ZstdGpuExecuteSequences32.hlsl
+ *
+ * A specialisation for the compute shader that executes sequences.
+ *
+ * Copyright (c) Microsoft. All rights reserved.
+ * This code is licensed under the MIT License (MIT).
+ * THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+ * ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+ * IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+ *
+ * Advanced Technology Group (ATG)
+ * Author(s):   Pavel Martishevsky (pamartis@microsoft.com)
+ */
+
+#define MAX_COPY_SIZE 32
+#include "ZstdGpuExecuteSequences.hlsl"

--- a/zstd/zstdgpu/Shaders/ZstdGpuExecuteSequences64.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuExecuteSequences64.hlsl
@@ -1,0 +1,18 @@
+/**
+ * ZstdGpuExecuteSequences64.hlsl
+ *
+ * A specialisation for the compute shader that executes sequences.
+ *
+ * Copyright (c) Microsoft. All rights reserved.
+ * This code is licensed under the MIT License (MIT).
+ * THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+ * ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+ * IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+ *
+ * Advanced Technology Group (ATG)
+ * Author(s):   Pavel Martishevsky (pamartis@microsoft.com)
+ */
+
+#define MAX_COPY_SIZE 64
+#include "ZstdGpuExecuteSequences.hlsl"

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -39,7 +39,9 @@
 #include "ZstdGpuDecodeHuffmanWeights.h"
 #include "ZstdGpuDecompressHuffmanWeights.h"
 #include "ZstdGpuDecompressSequences.h"
-#include "ZstdGpuExecuteSequences.h"
+#include "ZstdGpuExecuteSequences128.h"
+#include "ZstdGpuExecuteSequences64.h"
+#include "ZstdGpuExecuteSequences32.h"
 #include "ZstdGpuFinaliseSequenceOffsets.h"
 #include "ZstdGpuGroupCompressedLiterals.h"
 #include "ZstdGpuInitFseTable.h"
@@ -278,7 +280,9 @@ static void zstdgpu_ReCreate_SRTs(zstdgpu_SRTs & srts, ID3D12Device *device, con
     ZSTDGPU_KERNEL(DecodeHuffmanWeights                     , L"Decode (from nibbles) Uncompressed Huffman Weights")                \
     ZSTDGPU_KERNEL(DecompressHuffmanWeights                 , L"Decompress FSE-compressed Huffman Weights")                         \
     ZSTDGPU_KERNEL(DecompressSequences                      , L"Decompress Sequences")                                              \
-    ZSTDGPU_KERNEL(ExecuteSequences                         , L"Execute Sequences")                                                 \
+    ZSTDGPU_KERNEL(ExecuteSequences128                      , L"Execute Sequences 128")                                             \
+    ZSTDGPU_KERNEL(ExecuteSequences64                       , L"Execute Sequences 64")                                              \
+    ZSTDGPU_KERNEL(ExecuteSequences32                       , L"Execute Sequences 32")                                              \
     ZSTDGPU_KERNEL(FinaliseSequenceOffsets                  , L"Finalise Sequence Offsets")                                         \
     ZSTDGPU_KERNEL(GroupCompressedLiterals                  , L"Group Huffman-compressed Literals")                                 \
     ZSTDGPU_KERNEL(InitFseTable                             , L"Init Fse Table")                                                    \
@@ -321,6 +325,7 @@ struct zstdgpu_PerRequestContextImpl
     #define ZSTDGPU_KERNEL(name, desc) d3d12aid_ComputeRsPs name;
         ZSTDGPU_KERNEL_LIST()
     #undef ZSTDGPU_KERNEL
+    d3d12aid_ComputeRsPs    ExecuteSequences;
 
     zstdgpu_SRTs            srts;
     zstdgpu_ResourceDataGpu resData;
@@ -473,6 +478,24 @@ zstdgpu_Status zstdgpu_CreatePerRequestContext(zstdgpu_PerRequestContext *outPer
             context->name.ps->AddRef();
             ZSTDGPU_KERNEL_LIST()
         #undef ZSTDGPU_KERNEL
+#ifdef _GAMING_XBOX_SCARLETT
+        context->ExecuteSequences = context->ExecuteSequences64;
+#else
+        if (persistentContext->maxLaneCount == 128)
+        {
+            context->ExecuteSequences = context->ExecuteSequences128;
+        }
+        else if (persistentContext->maxLaneCount == 64)
+        {
+            context->ExecuteSequences = context->ExecuteSequences64;
+        }
+        else
+        {
+            context->ExecuteSequences = context->ExecuteSequences32;
+        }
+#endif
+        context->ExecuteSequences.rs->AddRef();
+        context->ExecuteSequences.ps->AddRef();
 
         context->srts.heap = NULL;
         context->srts.heapOffset = 0;
@@ -528,6 +551,7 @@ zstdgpu_Status zstdgpu_DestroyPerRequestContext(void **outMemoryBlock, uint32_t 
 
         D3D12AID_SAFE_RELEASE(inPerRequestContext->srts.heap);
 
+        d3d12aid_ComputeRsPs_Release(&inPerRequestContext->ExecuteSequences);
         #define ZSTDGPU_KERNEL(name, desc) d3d12aid_ComputeRsPs_Release(&inPerRequestContext->name);
             ZSTDGPU_KERNEL_LIST()
         #undef ZSTDGPU_KERNEL


### PR DESCRIPTION
This PR adds support for specialised "Execute Sequences" kernel sizes: `32`, `64` and `128`. Those specialised kernels are chosen based on the device's maximal supported wave size, so the size of the chosen threadgroup is never larger than the widest support wave (if device supports multiple wave sizes).

The change from larger `1024`-wide threadgroup was mainly motivated by preferring more parallelism on datasets with many zstd frames over handling sequences with very wide copies faster.

