### PR TITLE
Restores profiling capabilities of internal 'zstdgpu' passes through D3D12 Fences 

### DIFF
--- a/zstd/ThirdParty/d3d12aid.h
+++ b/zstd/ThirdParty/d3d12aid.h
@@ -1029,7 +1029,7 @@ D3D12AID_API uint64_t d3d12aid_CmdQueue_SubmitMultiCmdLists(d3d12aid_CmdQueue *q
         allocReuseFenceValues[allocatorIdx] = submitFenceValue;
 
         /** 2. choose next available allocator index */
-        allocIndices[i] = (allocatorIdx + D3D12AID_CMD_QUEUE_LIST_MAX_COUNT_PER_FRAME) % D3D12AID_CMD_QUEUE_ALLOC_MAX_COUNT;
+        allocIndices[i] = (allocatorIdx + queue->cmdListCount) % queue->cmdAllocCount;
     }
     return submitFenceValue;
 }

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -295,6 +295,42 @@ static void zstdgpu_ReCreate_SRTs(zstdgpu_SRTs & srts, ID3D12Device *device, con
     ZSTDGPU_KERNEL(PrefixSum                                , L"Prefix Sum")                                                        \
     ZSTDGPU_KERNEL(UpdateDispatchArgs                       , L"Update Dispatch Args")
 
+#define ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_0() \
+    ZSTDGPU_KERNEL_SCOPE_X(InitResources_CountBlocks            , L"Init Resources"             )   \
+    ZSTDGPU_KERNEL_SCOPE_X(ParseFrames_CountBlocks              , L"Parse Frames"               )   \
+    ZSTDGPU_KERNEL_SCOPE_X(PrefixSum                            , L"Prefix Sums"                )
+
+#define ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1() \
+    ZSTDGPU_KERNEL_SCOPE_X(InitResources                        , L"Init Resources"             )   \
+    ZSTDGPU_KERNEL_SCOPE_X(ParseFrames                          , L"Parse Frames"               )   \
+    ZSTDGPU_KERNEL_SCOPE_X(ParseCompressedBlocks                , L"Parse Compressed Blocks"    )
+
+#define ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_CMP_BLOCKS() \
+    ZSTDGPU_KERNEL_SCOPE_X(UpdateDispatchArgs                   , L"Update Dispatch Arguments"  )   \
+    ZSTDGPU_KERNEL_SCOPE_X(ComputePrefixSum                     , L"Compute Prefix Sums"        )   \
+    ZSTDGPU_KERNEL_SCOPE_X(GroupCompressedLiterals              , L"Group Compressed Literals"  )   \
+    ZSTDGPU_KERNEL_SCOPE_X(InitFseTable                         , L"Init FSE Tables"            )   \
+    ZSTDGPU_KERNEL_SCOPE_X(DecompressHuffmanWeights             , L"Decompress Huffman Weights" )   \
+    ZSTDGPU_KERNEL_SCOPE_X(DecodeHuffmanWeights                 , L"Decode Huffman Weights"     )   \
+    ZSTDGPU_KERNEL_SCOPE_X(InitHuffmanTableAndDecompressLiterals, L"Init Huffman Table and Decompress Literals Huffman Weights" )   \
+    ZSTDGPU_KERNEL_SCOPE_X(DecompressSequences                  , L"Decompress Sequences"       )   \
+    ZSTDGPU_KERNEL_SCOPE_X(PrefixSequenceOffsets                , L"Propagate Sequence Offsets" )   \
+    ZSTDGPU_KERNEL_SCOPE_X(FinaliseSequenceOffsets              , L"Finalise Sequence Offsets"  )   \
+    ZSTDGPU_KERNEL_SCOPE_X(ExecuteSequences                     , L"ExecuteSequences"           )
+
+#define ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_RAW_RLE_BLOCKS() \
+    ZSTDGPU_KERNEL_SCOPE_X(MemcpyRAW_MemsetRLE                  , L"Memcpy Raw/Memset RLE Blocks")
+
+#define ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_ALL_BLOCKS() \
+    ZSTDGPU_KERNEL_SCOPE_X(PrefixBlockSizes                     , L"Prefix Block Sizes"         )
+
+#define ZSTDGPU_KERNEL_SCOPE_LIST()                     \
+    ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_0()                 \
+    ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1()                 \
+    ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_CMP_BLOCKS()      \
+    ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_RAW_RLE_BLOCKS()  \
+    ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_ALL_BLOCKS()
+
 struct zstdgpu_PersistentContextImpl
 {
     void                    *thisMemoryBlock;
@@ -337,6 +373,12 @@ struct zstdgpu_PerRequestContextImpl
     ID3D12Resource         *compressedFramesRefs;
     ID3D12Resource         *uncompressedFramesData;
     ID3D12Resource         *uncompressedFramesRefs;
+
+    d3d12aid_Timestamps     timestamps;
+
+    #define ZSTDGPU_KERNEL_SCOPE_X(name, desc) uint32_t name##_TimestampSlot;
+        ZSTDGPU_KERNEL_SCOPE_LIST()
+    #undef  ZSTDGPU_KERNEL_SCOPE_X
 
     uint32_t                zstdFrameCount;
     uint32_t                zstdCompressedFramesByteCount;
@@ -509,6 +551,12 @@ zstdgpu_Status zstdgpu_CreatePerRequestContext(zstdgpu_PerRequestContext *outPer
         context->uncompressedFramesData             = NULL;
         context->uncompressedFramesRefs             = NULL;
 
+        const uint32_t timestampCount = 0
+        #define ZSTDGPU_KERNEL_SCOPE_X(name, desc) +2
+            ZSTDGPU_KERNEL_SCOPE_LIST();
+        #undef  ZSTDGPU_KERNEL_SCOPE_X
+        d3d12aid_Timestamps_Create(&context->timestamps, context->device, timestampCount, 1);
+
         context->zstdFrameCount                     = 0;
         context->zstdCompressedFramesByteCount      = 0;
 
@@ -538,6 +586,8 @@ zstdgpu_Status zstdgpu_DestroyPerRequestContext(void **outMemoryBlock, uint32_t 
 
     if (proceed)
     {
+        d3d12aid_Timestamps_Release(&inPerRequestContext->timestamps);
+
         const uint32_t stageCount = zstdgpu_GetStageCountFromSetupInputsType(inPerRequestContext->setupInputsType);
         for (uint32_t stage = 0; stage < stageCount; ++stage)
         {
@@ -1006,23 +1056,23 @@ zstdgpu_Status zstdgpu_SubmitWithInteralMemory(zstdgpu_PerRequestContext req, ui
 #define zstdgpu_PushReadback(name) if (0 != req->resInfo.name##_ByteSizeInternal) cmdList->CopyResource(req->resData.gpu2Cpu.name, req->resData.gpuOnly.name)
 #endif
 
-#if 1
-#define ZSTDGPU_KERNEL_SCOPE(name, cmdList, dispatch)                   \
-    do                                                                  \
-    {                                                                   \
-        dispatch;                                                       \
-    }                                                                   \
+#if 0
+#define ZSTDGPU_KERNEL_SCOPE(name, cmdList, statement)  \
+    do                                                  \
+    {                                                   \
+        statement                                       \
+    }                                                   \
     while (0)
 
 #else
 
-#define ZSTDGPU_KERNEL_SCOPE(name, cmdList, dispatch)                   \
-    do                                                                  \
-    {                                                                   \
-        name##Time0 = d3d12aid_Timestamps_Push(&timestamps, cmdList);   \
-        dispatch;                                                       \
-        name##Time1 = d3d12aid_Timestamps_Push(&timestamps, cmdList);   \
-    }                                                                   \
+#define ZSTDGPU_KERNEL_SCOPE(name, cmdList, statement)                                  \
+    do                                                                                  \
+    {                                                                                   \
+        req->name##_TimestampSlot = d3d12aid_Timestamps_Push(&req->timestamps, cmdList);\
+        statement                                                                       \
+        d3d12aid_Timestamps_Push(&req->timestamps, cmdList);                            \
+    }                                                                                   \
     while (0)
 
 #endif
@@ -1096,7 +1146,7 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRoot32BitConstant(1, req->zstdFrameCount, 2);
         cmdList->SetComputeRoot32BitConstant(1, initResourcesStage, 3);
         ZSTDGPU_KERNEL_SCOPE(InitResources_CountBlocks, cmdList,
-            cmdList->Dispatch(zstdgpu_InitResources_GetDispatchSizeX(allBlockCount, cmpBlockCount, req->zstdFrameCount, initResourcesStage), 1, 1)
+            cmdList->Dispatch(zstdgpu_InitResources_GetDispatchSizeX(allBlockCount, cmpBlockCount, req->zstdFrameCount, initResourcesStage), 1, 1);
         );
 
         PIXEndEvent(cmdList);
@@ -1124,7 +1174,7 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRoot32BitConstant(1, req->resInfo.CompressedData_ByteSize, 1);
         cmdList->SetComputeRoot32BitConstant(1, countBlocksOnly, 2);
         ZSTDGPU_KERNEL_SCOPE(ParseFrames_CountBlocks, cmdList,
-            cmdList->Dispatch(ZSTDGPU_TG_COUNT(req->zstdFrameCount, kzstdgpu_TgSizeX_ParseCompressedBlocks), 1, 1)
+            cmdList->Dispatch(ZSTDGPU_TG_COUNT(req->zstdFrameCount, kzstdgpu_TgSizeX_ParseCompressedBlocks), 1, 1);
         );
         PIXEndEvent(cmdList);
     }
@@ -1152,6 +1202,7 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRoot32BitConstant(2, 0 /** outputInclusive */, 1);
 
         ZSTDGPU_KERNEL_SCOPE(PrefixSum, cmdList,
+        {
             cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.PerFrameBlockCountRAW->GetGPUVirtualAddress());
             cmdList->SetComputeRootUnorderedAccessView(1, req->resData.gpuOnly.PerFrameBlockCountRAW->GetGPUVirtualAddress() + req->zstdFrameCount * sizeof(uint32_t));
             cmdList->Dispatch(tgCountX, 1, 1);
@@ -1175,7 +1226,7 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.PerFrameBlockSizesRLE->GetGPUVirtualAddress());
             cmdList->SetComputeRootUnorderedAccessView(1, req->resData.gpuOnly.PerFrameBlockSizesRLE->GetGPUVirtualAddress() + req->zstdFrameCount * sizeof(uint32_t));
             cmdList->Dispatch(tgCountX, 1, 1);
-        );
+        });
 
         PIXEndEvent(cmdList);
     }
@@ -1215,7 +1266,7 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRoot32BitConstant(1, req->zstdFrameCount, 2);
         cmdList->SetComputeRoot32BitConstant(1, initResourcesStage, 3);
         ZSTDGPU_KERNEL_SCOPE(InitResources, cmdList,
-            cmdList->Dispatch(zstdgpu_InitResources_GetDispatchSizeX(allBlockCount, req->zstdCmpBlockCount, req->zstdFrameCount, initResourcesStage), 1, 1)
+            cmdList->Dispatch(zstdgpu_InitResources_GetDispatchSizeX(allBlockCount, req->zstdCmpBlockCount, req->zstdFrameCount, initResourcesStage), 1, 1);
         );
 
         PIXEndEvent(cmdList);
@@ -1238,7 +1289,7 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRoot32BitConstant(1, req->resInfo.CompressedData_ByteSize, 1);
         cmdList->SetComputeRoot32BitConstant(1, countBlocksOnly, 2);
         ZSTDGPU_KERNEL_SCOPE(ParseFrames, cmdList,
-            cmdList->Dispatch(ZSTDGPU_TG_COUNT(req->zstdFrameCount, kzstdgpu_TgSizeX_ParseCompressedBlocks), 1, 1)
+            cmdList->Dispatch(ZSTDGPU_TG_COUNT(req->zstdFrameCount, kzstdgpu_TgSizeX_ParseCompressedBlocks), 1, 1);
         );
         PIXEndEvent(cmdList);
     }
@@ -1319,7 +1370,7 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRoot32BitConstant(1, req->zstdFrameCount, 2);
 
         ZSTDGPU_KERNEL_SCOPE(ParseCompressedBlocks, cmdList,
-            cmdList->Dispatch(ZSTDGPU_TG_COUNT(req->zstdCmpBlockCount, kzstdgpu_TgSizeX_ParseCompressedBlocks), 1, 1)
+            cmdList->Dispatch(ZSTDGPU_TG_COUNT(req->zstdCmpBlockCount, kzstdgpu_TgSizeX_ParseCompressedBlocks), 1, 1);
         );
         PIXEndEvent(cmdList);
     }
@@ -1367,7 +1418,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         d3d12aid_ComputeRsPs_Set(&req->UpdateDispatchArgs, cmdList);
         cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.Counters->GetGPUVirtualAddress());
         ZSTDGPU_KERNEL_SCOPE(UpdateDispatchArgs, cmdList,
-            cmdList->Dispatch(1, 1, 1)
+            cmdList->Dispatch(1, 1, 1);
         );
         PIXEndEvent(cmdList);
     }
@@ -1384,7 +1435,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRootUnorderedAccessView(4, req->resData.gpuOnly.Counters->GetGPUVirtualAddress());
         cmdList->SetComputeRoot32BitConstant(5, req->zstdCmpBlockCount, 0);
         ZSTDGPU_KERNEL_SCOPE(ComputePrefixSum, cmdList,
-            cmdList->Dispatch(ZSTDGPU_TG_COUNT(req->zstdCmpBlockCount, kzstdgpu_TgSizeX_PrefixSum_LiteralCount), 1, 1)
+            cmdList->Dispatch(ZSTDGPU_TG_COUNT(req->zstdCmpBlockCount, kzstdgpu_TgSizeX_PrefixSum_LiteralCount), 1, 1);
         );
         PIXEndEvent(cmdList);
     }
@@ -1443,7 +1494,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         ID3D12Resource* argBuf = req->resData.gpuOnly.Counters;
 
         ZSTDGPU_KERNEL_SCOPE(GroupCompressedLiterals, cmdList,
-            cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_GroupCompressedLiteralsGroups * sizeof(uint32_t), NULL, 0)
+            cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_GroupCompressedLiteralsGroups * sizeof(uint32_t), NULL, 0);
         );
 
         PIXEndEvent(cmdList);
@@ -1451,37 +1502,37 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
     if (req->zstdCmpBlockCount > 0)
     {
-    // Run FSE Table Initialisation
-    ZSTDGPU_KERNEL_SCOPE(InitFseTable, cmdList,
-    {
-        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Init FSE Table]");
-        BIND_RS_PS_SRT(InitFseTable);
+        // Run FSE Table Initialisation
+        ZSTDGPU_KERNEL_SCOPE(InitFseTable, cmdList,
+        {
+            PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Init FSE Table]");
+            BIND_RS_PS_SRT(InitFseTable);
 
-        // NOTE: we run 4 ExecuteIndirects (per argument) in order to be able to (but we don't do this for prototype)
-        // switch PSO to more optimial (depending on maximal FSE table size) because D3D12 doesn't allow to switch PSOs in ExecuteIndirect.
-        ID3D12Resource* argBuf = req->resData.gpuOnly.Counters;
+            // NOTE: we run 4 ExecuteIndirects (per argument) in order to be able to (but we don't do this for prototype)
+            // switch PSO to more optimial (depending on maximal FSE table size) because D3D12 doesn't allow to switch PSOs in ExecuteIndirect.
+            ID3D12Resource* argBuf = req->resData.gpuOnly.Counters;
 
-        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Huffman Weights");
-        cmdList->SetComputeRoot32BitConstant(1, 0, 0);
-        cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_FseHufW * sizeof(uint32_t), NULL, 0);
-        PIXEndEvent(cmdList);
+            PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Huffman Weights");
+            cmdList->SetComputeRoot32BitConstant(1, 0, 0);
+            cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_FseHufW * sizeof(uint32_t), NULL, 0);
+            PIXEndEvent(cmdList);
 
-        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Literal Lengths");
-        cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 0);
-        cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_FseLLen * sizeof(uint32_t), NULL, 0);
-        PIXEndEvent(cmdList);
+            PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Literal Lengths");
+            cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 0);
+            cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_FseLLen * sizeof(uint32_t), NULL, 0);
+            PIXEndEvent(cmdList);
 
-        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Offsets");
-        cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount * 2 + 1, 0);
-        cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_FseOffs * sizeof(uint32_t), NULL, 0);
-        PIXEndEvent(cmdList);
+            PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Offsets");
+            cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount * 2 + 1, 0);
+            cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_FseOffs * sizeof(uint32_t), NULL, 0);
+            PIXEndEvent(cmdList);
 
-        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Match Lengths");
-        cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount * 3 + 2, 0);
-        cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_FseMLen * sizeof(uint32_t), NULL, 0);
-        PIXEndEvent(cmdList);
-        PIXEndEvent(cmdList);
-    });
+            PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Match Lengths");
+            cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount * 3 + 2, 0);
+            cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_FseMLen * sizeof(uint32_t), NULL, 0);
+            PIXEndEvent(cmdList);
+            PIXEndEvent(cmdList);
+        });
     }
 
     // Needed by readback
@@ -1509,7 +1560,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
         ID3D12Resource* argBuf = req->resData.gpuOnly.Counters;
         ZSTDGPU_KERNEL_SCOPE(DecompressHuffmanWeights, cmdList,
-            cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_DecompressHuffmanWeightsGroups * sizeof(uint32_t), NULL, 0)
+            cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_DecompressHuffmanWeightsGroups * sizeof(uint32_t), NULL, 0);
         );
         PIXEndEvent(cmdList);
     }
@@ -1523,7 +1574,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
         ID3D12Resource* argBuf = req->resData.gpuOnly.Counters;
         ZSTDGPU_KERNEL_SCOPE(DecodeHuffmanWeights, cmdList,
-            cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_DecodeHuffmanWeightsGroups * sizeof(uint32_t), NULL, 0)
+            cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_DecodeHuffmanWeightsGroups * sizeof(uint32_t), NULL, 0);
         );
         PIXEndEvent(cmdList);
     }
@@ -1546,14 +1597,12 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     if (req->zstdCmpBlockCount > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Init Huffman Table and Decompress Literals]");
-        d3d12aid_ComputeRsPs_Set(&req->InitHuffmanTableAndDecompressLiterals, cmdList);
-        cmdList->SetDescriptorHeaps(1, &req->srts.heap);
-        cmdList->SetComputeRootDescriptorTable(0, req->srts.InitHuffmanTable_And_DecompressLiteralsGpuHandle);
+        BIND_RS_PS_SRT(InitHuffmanTableAndDecompressLiterals);
         cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 0);
 
         ID3D12Resource* argBuf = req->resData.gpuOnly.Counters;
         ZSTDGPU_KERNEL_SCOPE(InitHuffmanTableAndDecompressLiterals, cmdList,
-            cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_DecompressLiteralsGroups * sizeof(uint32_t), NULL, 0)
+            cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_DecompressLiteralsGroups * sizeof(uint32_t), NULL, 0);
         );
         PIXEndEvent(cmdList);
     }
@@ -1566,7 +1615,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
         ID3D12Resource* argBuf = req->resData.gpuOnly.Counters;
         ZSTDGPU_KERNEL_SCOPE(DecompressSequences, cmdList,
-            cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_DecompressSequencesGroups * sizeof(uint32_t), NULL, 0)
+            cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_DecompressSequencesGroups * sizeof(uint32_t), NULL, 0);
         );
         PIXEndEvent(cmdList);
     }
@@ -1615,7 +1664,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRoot32BitConstant(2, 1 /** outputInclusive */, 1);
 
         ZSTDGPU_KERNEL_SCOPE(PrefixBlockSizes, cmdList,
-            cmdList->Dispatch(ZSTDGPU_TG_COUNT(allBlockCount, kzstdgpu_TgSizeX_PrefixSum), 1, 1)
+            cmdList->Dispatch(ZSTDGPU_TG_COUNT(allBlockCount, kzstdgpu_TgSizeX_PrefixSum), 1, 1);
         );
 
         PIXEndEvent(cmdList);
@@ -1638,7 +1687,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRoot32BitConstant(9, req->zstdFrameCount, 1);
 
         ZSTDGPU_KERNEL_SCOPE(PrefixSequenceOffsets, cmdList,
-            cmdList->Dispatch(ZSTDGPU_TG_COUNT(req->zstdSeqStreamCount, kzstdgpu_TgSizeX_PrefixSequenceOffsets), 1, 1)
+            cmdList->Dispatch(ZSTDGPU_TG_COUNT(req->zstdSeqStreamCount, kzstdgpu_TgSizeX_PrefixSequenceOffsets), 1, 1);
         );
 
         PIXEndEvent(cmdList);
@@ -1667,12 +1716,12 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     if (req->zstdCmpBlockCount > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Finalise Sequence Offsets]");
-        d3d12aid_ComputeRsPs_Set(&req->FinaliseSequenceOffsets, cmdList);
-        cmdList->SetDescriptorHeaps(1, &req->srts.heap);
-        cmdList->SetComputeRootDescriptorTable(0, req->srts.FinaliseSequenceOffsetsGpuHandle);
+        BIND_RS_PS_SRT(FinaliseSequenceOffsets);
 
         const uint32_t tgCount = ZSTDGPU_TG_COUNT(req->zstdUncompressedSequenceCount, kzstdgpu_TgSizeX_FinaliseSequenceOffsets);
-        zstdgpu_Dispatch32Bit(cmdList, tgCount, 1, 0);
+        ZSTDGPU_KERNEL_SCOPE(FinaliseSequenceOffsets, cmdList,
+            zstdgpu_Dispatch32Bit(cmdList, tgCount, 1, 0);
+        );
 
         PIXEndEvent(cmdList);
     }
@@ -1686,13 +1735,14 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->ResourceBarrier(_countof(barriers), barriers);
         PIXEndEvent(cmdList);
     }
+    if (req->zstdRawByteCount > 0 || req->zstdRleByteCount > 0)
     {
-        if (req->zstdRawByteCount > 0 || req->zstdRleByteCount > 0)
+        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Memcpy RAW blocks, Memset RLE blocks]");
+        d3d12aid_ComputeRsPs_Set(&req->MemsetMemcpy, cmdList);
+        cmdList->SetDescriptorHeaps(1, &req->srts.heap);
+        cmdList->SetComputeRootDescriptorTable(0, req->srts.MemsetMemcpyGpuHandle);
+        ZSTDGPU_KERNEL_SCOPE(MemcpyRAW_MemsetRLE, cmdList,
         {
-            PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Memcpy RAW blocks, Memset RLE blocks]");
-            d3d12aid_ComputeRsPs_Set(&req->MemsetMemcpy, cmdList);
-            cmdList->SetDescriptorHeaps(1, &req->srts.heap);
-            cmdList->SetComputeRootDescriptorTable(0, req->srts.MemsetMemcpyGpuHandle);
             if (req->zstdRawByteCount > 0)
             {
                 cmdList->SetComputeRootShaderResourceView(1, req->resData.gpuOnly.RawBlockSizePrefix->GetGPUVirtualAddress());
@@ -1717,26 +1767,23 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
                 cmdList->SetComputeRoot32BitConstant(5, 0 /* flags */, 3);
                 zstdgpu_Dispatch32Bit(cmdList, ZSTDGPU_TG_COUNT(req->zstdRleByteCount, kzstdgpu_TgSizeX_MemsetMemcpy), 5, 4);
             }
-            PIXEndEvent(cmdList);
-        }
+        });
+        PIXEndEvent(cmdList);
     }
     if (req->zstdCmpBlockCount > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Execute Sequences]");
-        d3d12aid_ComputeRsPs_Set(&req->ExecuteSequences, cmdList);
-        cmdList->SetDescriptorHeaps(1, &req->srts.heap);
-        cmdList->SetComputeRootDescriptorTable(0, req->srts.ExecuteSequencesGpuHandle);
+        BIND_RS_PS_SRT(ExecuteSequences);
 
-        cmdList->Dispatch(req->zstdFrameCount, 1, 1);
-
+        ZSTDGPU_KERNEL_SCOPE(ExecuteSequences, cmdList,
+            cmdList->Dispatch(req->zstdFrameCount, 1, 1);
+        );
         PIXEndEvent(cmdList);
     }
     if (0) /** IMPORTANT: requires DecompressedSequencesMLen to contain inclusive prefix of total sequence sizes */
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Compute Dest Sequence Offsets]");
-        d3d12aid_ComputeRsPs_Set(&req->ComputeDestSequenceOffsets, cmdList);
-        cmdList->SetDescriptorHeaps(1, &req->srts.heap);
-        cmdList->SetComputeRootDescriptorTable(0, req->srts.ComputeDestSequenceOffsetsGpuHandle);
+        BIND_RS_PS_SRT(ComputeDestSequenceOffsets);
 
         zstdgpu_Dispatch32Bit(cmdList, ZSTDGPU_TG_COUNT(req->zstdUncompressedSequenceCount, 256), 1, 0);
 
@@ -1798,4 +1845,70 @@ ZSTDGPU_API void zstdgpu_RetrieveGpuResults(zstdgpu_ResourceDataCpu *outGpuResou
     outGpuResources->Counters[kzstdgpu_CounterIndex_Blocks_RAW] = req->zstdRawBlockCount;
     outGpuResources->Counters[kzstdgpu_CounterIndex_Blocks_RLE] = req->zstdRleBlockCount;
     outGpuResources->Counters[kzstdgpu_CounterIndex_Blocks_CMP] = req->zstdCmpBlockCount;
+}
+
+ZSTDGPU_API void zstdgpu_ReadbackTimestamps(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandList *cmdList)
+{
+    d3d12aid_Timestamps_AdvanceFrame(&req->timestamps, cmdList);
+}
+
+ZSTDGPU_API void zstdgpu_RetrieveTimestamps(const wchar_t **outTimestampScopeNames, uint64_t *outTimestampScopeClocks, uint32_t *inoutTimestampScopeCnt, zstdgpu_PerRequestContext req, uint32_t stageIndex)
+{
+    uint32_t timestampScopeCountPerStage = 0;
+    #define ZSTDGPU_KERNEL_SCOPE_X(name, desc) +1
+    if (stageIndex == 0)
+    {
+        timestampScopeCountPerStage += 0 ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_0();
+    }
+    else if (stageIndex == 1)
+    {
+        timestampScopeCountPerStage += 0 ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1();
+    }
+    else if (stageIndex == 2)
+    {
+        timestampScopeCountPerStage += 0 ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_ALL_BLOCKS();
+        if (req->zstdCmpBlockCount > 0)
+        {
+            timestampScopeCountPerStage += 0 ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_CMP_BLOCKS();
+        }
+        if (req->zstdRawBlockCount > 0 || req->zstdRleBlockCount > 0)
+        {
+            timestampScopeCountPerStage += 0 ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_RAW_RLE_BLOCKS();
+        }
+    }
+    #undef  ZSTDGPU_KERNEL_SCOPE_X
+
+    if (timestampScopeCountPerStage > 0 && *inoutTimestampScopeCnt >= timestampScopeCountPerStage)
+    {
+        *inoutTimestampScopeCnt = timestampScopeCountPerStage;
+        uint32_t i = 0;
+        #define ZSTDGPU_KERNEL_SCOPE_X(name, desc)  \
+            outTimestampScopeNames[i] = desc;       \
+            outTimestampScopeClocks[i++] = d3d12aid_Timestamps_GetScopeDelta(&req->timestamps, 0, req->name##_TimestampSlot);
+        if (stageIndex == 0)
+        {
+            ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_0()
+        }
+        else if (stageIndex == 1)
+        {
+            ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1()
+        }
+        else if (stageIndex == 2)
+        {
+            ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_ALL_BLOCKS()
+            if (req->zstdCmpBlockCount > 0)
+            {
+                ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_CMP_BLOCKS();
+            }
+            if (req->zstdRawBlockCount > 0 || req->zstdRleBlockCount > 0)
+            {
+                ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_RAW_RLE_BLOCKS();
+            }
+        }
+        #undef  ZSTDGPU_KERNEL_SCOPE_X
+    }
+    else
+    {
+        *inoutTimestampScopeCnt = 0;
+    }
 }

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -1406,19 +1406,19 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
     \
     ZSTDGPU_RW_TYPED_BUFFER_DECL(uint32_t, uint8_t              , UnCompressedFramesData        , 0)
 
-#define ZSTDGPU_SRT_LIST()                                                                                            \
-    ZSTDGPU_SRT(InitResources                          , ZSTDGPU_INIT_RESOURCES_SRT())                                \
-    ZSTDGPU_SRT(ParseFrames                            , ZSTDGPU_PARSE_FRAMES_SRT())                                  \
-    ZSTDGPU_SRT(ParseCompressedBlocks                  , ZSTDGPU_PARSE_COMPRESSED_BLOCKS_SRT())                       \
-    ZSTDGPU_SRT(InitFseTable                           , ZSTDGPU_INIT_FSE_TABLE_SRT())                                \
-    ZSTDGPU_SRT(DecompressHuffmanWeights               , ZSTDGPU_DECOMPRESS_HUFFMAN_WEIGHTS_SRT())                    \
-    ZSTDGPU_SRT(DecodeHuffmanWeights                   , ZSTDGPU_DECODE_HUFFMAN_WEIGHTS_SRT())                        \
-    ZSTDGPU_SRT(InitHuffmanTable_And_DecompressLiterals, ZSTDGPU_INIT_HUFFMAN_TABLE_AND_DECOMPRESS_LITERALS_SRT())    \
-    ZSTDGPU_SRT(DecompressSequences                    , ZSTDGPU_DECOMPRESS_SEQUENCES_SRT())                          \
-    ZSTDGPU_SRT(FinaliseSequenceOffsets                , ZSTDGPU_FINALISE_SEQUENCE_OFFSETS_SRT())                     \
-    ZSTDGPU_SRT(MemsetMemcpy                           , ZSTDGPU_MEMSET_MEMCPY_SRT())                                 \
-    ZSTDGPU_SRT(ExecuteSequences                       , ZSTDGPU_EXECUTE_SEQUENCES_SRT())                             \
-    ZSTDGPU_SRT(ComputeDestSequenceOffsets             , ZSTDGPU_COMPUTE_DEST_SEQUENCE_OFFSETS_SRT())
+#define ZSTDGPU_SRT_LIST()                                                                                          \
+    ZSTDGPU_SRT(InitResources                           , ZSTDGPU_INIT_RESOURCES_SRT())                             \
+    ZSTDGPU_SRT(ParseFrames                             , ZSTDGPU_PARSE_FRAMES_SRT())                               \
+    ZSTDGPU_SRT(ParseCompressedBlocks                   , ZSTDGPU_PARSE_COMPRESSED_BLOCKS_SRT())                    \
+    ZSTDGPU_SRT(InitFseTable                            , ZSTDGPU_INIT_FSE_TABLE_SRT())                             \
+    ZSTDGPU_SRT(DecompressHuffmanWeights                , ZSTDGPU_DECOMPRESS_HUFFMAN_WEIGHTS_SRT())                 \
+    ZSTDGPU_SRT(DecodeHuffmanWeights                    , ZSTDGPU_DECODE_HUFFMAN_WEIGHTS_SRT())                     \
+    ZSTDGPU_SRT(InitHuffmanTableAndDecompressLiterals   , ZSTDGPU_INIT_HUFFMAN_TABLE_AND_DECOMPRESS_LITERALS_SRT()) \
+    ZSTDGPU_SRT(DecompressSequences                     , ZSTDGPU_DECOMPRESS_SEQUENCES_SRT())                       \
+    ZSTDGPU_SRT(FinaliseSequenceOffsets                 , ZSTDGPU_FINALISE_SEQUENCE_OFFSETS_SRT())                  \
+    ZSTDGPU_SRT(MemsetMemcpy                            , ZSTDGPU_MEMSET_MEMCPY_SRT())                              \
+    ZSTDGPU_SRT(ExecuteSequences                        , ZSTDGPU_EXECUTE_SEQUENCES_SRT())                          \
+    ZSTDGPU_SRT(ComputeDestSequenceOffsets              , ZSTDGPU_COMPUTE_DEST_SEQUENCE_OFFSETS_SRT())
 
 #define ZSTDGPU_RO_BUFFER_DECL(type, name, index)                      ZSTDGPU_RO_BUFFER(type)                    in##name;
 #define ZSTDGPU_RW_BUFFER_DECL(type, name, index)                      ZSTDGPU_RW_BUFFER(type)                    inout##name;

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -738,7 +738,10 @@ static void zstdgpu_DefaultUploadCallback(void *zstdCompressedFramesBytes, uint3
 }
 
 ZSTDGPU_API void zstdgpu_ReadbackGpuResults(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandList* cmdList);
-ZSTDGPU_API void zstdgpu_RetrieveGpuResults(zstdgpu_ResourceDataCpu* outGpuResources, zstdgpu_PerRequestContext req);
+ZSTDGPU_API void zstdgpu_RetrieveGpuResults(zstdgpu_ResourceDataCpu *outGpuResources, zstdgpu_PerRequestContext req);
+
+ZSTDGPU_API void zstdgpu_ReadbackTimestamps(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandList *cmdList);
+ZSTDGPU_API void zstdgpu_RetrieveTimestamps(const wchar_t **outTimestampScopeNames, uint64_t *outTimestampScopeClocks, uint32_t *inoutTimestampScopeCnt, zstdgpu_PerRequestContext req, uint32_t stageIndex);
 
 // Entry point
 #ifndef _GAMING_XBOX
@@ -758,12 +761,14 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
     bool chkCpu = false;
     bool simGpu = false;
     bool d3dDbg = false;
+    bool d3dGfx = false;
 
     const wchar_t *zstFilePath = L"data\\group_0_cmp17_block8192.zst";
     wchar_t *zstFilePathStorage = NULL;
     uint32_t gpuVenId = 0x1414; // means -- find any vendor id, but not 0x1414
     uint32_t gpuDevId = ~0u;    // means -- find any device id
     uint32_t repCount = 10;
+    uint32_t prfLevel = 0;
 
 #ifndef _GAMING_XBOX
     {
@@ -773,6 +778,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
             bool nextGpuVenId = false;
             bool nextGpuDevId = false;
             bool nextRepCount = false;
+            bool nextPrfLevel = false;
             for (argi = 1; argi < argc; ++argi)
             {
                 if (nextZst)
@@ -796,15 +802,21 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
                     nextGpuVenId = false;
                     nextGpuDevId = false;
                 }
-                else if (nextRepCount)
+                else if (nextRepCount || nextPrfLevel)
                 {
                     errno = 0;
                     wchar_t *end = NULL;
                     uint32_t value = (uint32_t)wcstol(argv[argi], &end, 10);
                     if (*end == L'\0' && ERANGE != errno)
-                        repCount = value;
+                    {
+                        if (nextRepCount)
+                            repCount = value;
+                        else if (nextPrfLevel)
+                            prfLevel = value;
+                    }
 
                     nextRepCount = false;
+                    nextPrfLevel = false;
                 }
                 else if (0 == wcscmp(argv[argi], L"--chk-gpu"))
                 {
@@ -834,6 +846,10 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
                 {
                     d3dDbg = true;
                 }
+                else if (0 == wcscmp(argv[argi], L"--d3d-gfx"))
+                {
+                    d3dGfx = true;
+                }
                 else if (0 == wcscmp(argv[argi], L"--run-cnt"))
                 {
                     nextRepCount = true;
@@ -841,6 +857,10 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
                 else if (0 == wcscmp(argv[argi], L"--ext-mem"))
                 {
                     extMem = true;
+                }
+                else if (0 == wcscmp(argv[argi], L"--prf-lvl"))
+                {
+                    nextPrfLevel = true;
                 }
             }
             if (1 == argc)
@@ -853,8 +873,10 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
                 debugPrint(L"\t--gpu-ven-id <id (hex)>   [Optional] VendorId (base16) to use when choosing GPU to run on.\n");
                 debugPrint(L"\t--gpu-dev-id <id (hex)>   [Optional] DeviceId (base16) to use when choosing GPU to run on.\n");
                 debugPrint(L"\t--d3d-dbg                 [Optional] Enables D3D12 debug layer.\n");
+                debugPrint(L"\t--d3d-gfx                 [Optional] Enables D3D12 Graphics queue (DIRECT), otherwise COMPUTE (by default).\n");
                 debugPrint(L"\t--run-cnt <count>         [Optional] The number of times to repeat the experiment.\n");
                 debugPrint(L"\t--ext-mem                 [Optional] Enables external heaps so the library doesn't create them.\n");
+                debugPrint(L"\t--prf-lvl <0, 1, 2>       [Optional] Chooses the level of profiling: 0 - overall bandwidth in GB/s, 1 - stage cost, 2 - internal pass cost.\n");
             }
             if (NULL == zstFilePathStorage)
             {
@@ -934,7 +956,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
 #ifdef _GAMING_XBOX
     d3d12aid_CmdQueue_Create(&cmdQueue, device, kBackBufferCount, 1u, D3D12_COMMAND_LIST_TYPE_DIRECT);
 #else
-    d3d12aid_CmdQueue_Create(&cmdQueue, device, kBackBufferCount, 1u, D3D12_COMMAND_LIST_TYPE_COMPUTE);
+    d3d12aid_CmdQueue_Create(&cmdQueue, device, kBackBufferCount, 1u, d3dGfx ? D3D12_COMMAND_LIST_TYPE_DIRECT : D3D12_COMMAND_LIST_TYPE_COMPUTE);
 #endif
 
     #define ZSTDGPU_TS_LIST()   \
@@ -1223,7 +1245,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
 
                     d3d12aid_MappedBuffer_Transfer(cmdList, &zstdUnCompressedFramesMemory, 0 /** works only when submissions aren't overlapped*/);
                 }
-
+                zstdgpu_ReadbackTimestamps(perRequestContext, cmdList);
                 if (simGpu || chkGpu)
                 {
                     zstdgpu_ReadbackGpuResults(perRequestContext, cmdList);
@@ -1295,14 +1317,43 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
                 {
                     cmdQueue.queue->GetTimestampFrequency(&freqGpuClocks);
                 }
-                #define ZSTDGPU_TS(name)                                                                                        \
-                    if (name##_Stamp != ~0u)                                                                                    \
-                    {                                                                                                           \
-                        const uint64_t clks = d3d12aid_Timestamps_GetScopeDelta(&timestamps, kBackBufferIndex, name##_Stamp);   \
-                        const uint64_t usec = (clks * 1000000) / freqGpuClocks;                                                 \
-                        debugPrint(L"%u frame: " #name " took %llu us\n", frameIndex, usec);                                    \
+                const wchar_t *timestampScopeNames[16];
+                uint64_t timestampScopeClocks[16];
+                uint64_t clks = 0;
+                #define ZSTDGPU_TS(name)                                                                        \
+                    if (name##_Stamp != ~0u && prfLevel > 0)                                                    \
+                    {                                                                                           \
+                        clks = d3d12aid_Timestamps_GetScopeDelta(&timestamps, kBackBufferIndex, name##_Stamp);  \
+                        const uint64_t usec = (clks * 1000000) / freqGpuClocks;                                 \
+                        debugPrint(L"%u frame: %7llu us - '" #name "' \n", frameIndex, usec);                  \
                     }
-                    ZSTDGPU_TS_LIST()
+
+                #define ZSTDGPU_DETAIL_TS(stage) \
+                    if (prfLevel > 1)            \
+                    {                            \
+                        uint32_t timestampScopeCount = _countof(timestampScopeClocks);                                                                              \
+                        zstdgpu_RetrieveTimestamps(timestampScopeNames, timestampScopeClocks, &timestampScopeCount, perRequestContext, stage);                      \
+                        for (uint32_t i = 0; i < timestampScopeCount; ++i)                                                                                          \
+                        {                                                                                                                                           \
+                            debugPrint(L"%u frame: \t%7llu us - 'Stage"#stage" :: %s'\n", frameIndex,  (timestampScopeClocks[i] * 1000000) / freqGpuClocks, timestampScopeNames[i]);  \
+                        }                                                                                                                                           \
+                    }
+                    ZSTDGPU_TS(Stage0)
+                    ZSTDGPU_DETAIL_TS(0)
+                    ZSTDGPU_TS(Readback0)
+                    ZSTDGPU_TS(Stage1)
+                    ZSTDGPU_DETAIL_TS(1)
+                    ZSTDGPU_TS(Readback1)
+                    ZSTDGPU_TS(Stage2)
+                    ZSTDGPU_DETAIL_TS(2)
+                    if (prfLevel == 0)
+                    {
+                        clks = d3d12aid_Timestamps_GetDelta(&timestamps, kBackBufferIndex, Stage0_Stamp, Stage2_Stamp + 1);
+                        const uint64_t ns = (clks * 1000000000) / freqGpuClocks;
+                        const double decompressionThroughput = (double)zstdUnCompressedFramesMemorySizeInBytes / ns;
+                        debugPrint(L"%u frame: Decompression throughput %lf (GB/s)\n", frameIndex, decompressionThroughput);
+                    }
+                #undef ZSTDGPU_DETAIL_TS
                 #undef ZSTDGPU_TS
             }
 


### PR DESCRIPTION
This PR mainly restores lost capability of profiling internal passes. Additionally, it adds two command line options: 
- `--prf-lvl <0,1,2>` - allowing to choose how verbose profiling is
- `--d3d-gfx` - allowing to run decompression on DIRECT D3D12 queue instead of COMPUTE which is chosen by default

and fixes `d3d12aid.h` issue where incorrect allocator index could be chosen.