### PR TITLE
zstd: Use b64-load backwards-bitbuffer for Huffman literal decompression.

### DIFF
--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressLiterals.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressLiterals.hlsl
@@ -1,0 +1,69 @@
+/**
+ * ZstdGpuDecompressLiterals.hlsl
+ *
+ * A compute shader that decompresses Huffman-compressed literals
+ *
+ * Copyright (c) Microsoft. All rights reserved.
+ * This code is licensed under the MIT License (MIT).
+ * THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+ * ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+ * IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+ *
+ * Advanced Technology Group (ATG)
+ * Author(s):   Pavel Martishevsky (pamartis@microsoft.com)
+ */
+
+#include "../zstdgpu_shaders.h"
+
+struct Consts
+{
+    uint32_t huffmanTableSlotCount;
+};
+
+ConstantBuffer<Consts> Constants : register(b0);
+
+#define ZSTDGPU_RO_BUFFER_DECL(type, name, index)                  ZSTDGPU_RO_BUFFER(type)                    ZstdIn##name    : register(t##index);
+#define ZSTDGPU_RW_BUFFER_DECL(type, name, index)                  ZSTDGPU_RW_BUFFER(type)                    ZstdInOut##name : register(u##index);
+#define ZSTDGPU_RO_TYPED_BUFFER_DECL(hlsl_type, type, name, index) ZSTDGPU_RO_TYPED_BUFFER(hlsl_type, type)   ZstdIn##name    : register(t##index);
+#define ZSTDGPU_RW_TYPED_BUFFER_DECL(hlsl_type, type, name, index) ZSTDGPU_RW_TYPED_BUFFER(hlsl_type, type)   ZstdInOut##name : register(u##index);
+
+ZSTDGPU_DECOMPRESS_LITERALS_SRT()
+
+#undef ZSTDGPU_RW_TYPED_BUFFER_DECL
+#undef ZSTDGPU_RO_TYPED_BUFFER_DECL
+#undef ZSTDGPU_RW_BUFFER_DECL
+#undef ZSTDGPU_RO_BUFFER_DECL
+
+// WARN(pamartis): Wasteful, need only uint8_t but HLSL doesn't support it
+groupshared uint32_t GS_Lds[kzstdgpu_MaxCount_HuffmanTableExpandedUInts];
+#define ZSTDGPU_LDS GS_Lds
+#include "../zstdgpu_lds_hlsl.h"
+
+#ifdef __XBOX_SCARLETT
+#define __XBOX_ENABLE_WAVE32 1
+#endif
+
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=9), UAV(u0, numDescriptors=1)),RootConstants(b0, num32BitConstants=1)")]
+[numthreads(kzstdgpu_TgSizeX_DecompressLiterals, 1, 1)]
+void main(uint groupId : SV_GroupId, uint i : SV_GroupThreadId)
+{
+    zstdgpu_DecompressLiterals_SRT srt;
+
+#define ZSTDGPU_RO_BUFFER_DECL(type, name, index)                      srt.in##name    = ZstdIn##name;
+#define ZSTDGPU_RW_BUFFER_DECL(type, name, index)                      srt.inout##name = ZstdInOut##name;
+#define ZSTDGPU_RO_TYPED_BUFFER_DECL(hlsl_type, type, name, index)     srt.in##name    = ZstdIn##name;
+#define ZSTDGPU_RW_TYPED_BUFFER_DECL(hlsl_type, type, name, index)     srt.inout##name = ZstdInOut##name;
+    ZSTDGPU_DECOMPRESS_LITERALS_SRT()
+
+#undef ZSTDGPU_RW_TYPED_BUFFER_DECL
+#undef ZSTDGPU_RO_TYPED_BUFFER_DECL
+#undef ZSTDGPU_RW_BUFFER_DECL
+#undef ZSTDGPU_RO_BUFFER_DECL
+    srt.huffmanTableSlotCount   = Constants.huffmanTableSlotCount;
+
+    if (groupId >= srt.inCounters[kzstdgpu_CounterIndex_DecompressLiteralsGroups])
+        return;
+
+    zstdgpu_ShaderEntry_DecompressLiterals(srt, groupId, i, kzstdgpu_TgSizeX_DecompressLiterals);
+}

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressLiterals.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressLiterals.hlsl
@@ -23,6 +23,7 @@ struct Consts
 
 ConstantBuffer<Consts> Constants : register(b0);
 
+#define ZSTDGPU_RO_RAW_BUFFER_DECL(type, name, index)              ZSTDGPU_RO_RAW_BUFFER(type)                ZstdIn##name    : register(t##index);
 #define ZSTDGPU_RO_BUFFER_DECL(type, name, index)                  ZSTDGPU_RO_BUFFER(type)                    ZstdIn##name    : register(t##index);
 #define ZSTDGPU_RW_BUFFER_DECL(type, name, index)                  ZSTDGPU_RW_BUFFER(type)                    ZstdInOut##name : register(u##index);
 #define ZSTDGPU_RO_TYPED_BUFFER_DECL(hlsl_type, type, name, index) ZSTDGPU_RO_TYPED_BUFFER(hlsl_type, type)   ZstdIn##name    : register(t##index);
@@ -34,6 +35,7 @@ ZSTDGPU_DECOMPRESS_LITERALS_SRT()
 #undef ZSTDGPU_RO_TYPED_BUFFER_DECL
 #undef ZSTDGPU_RW_BUFFER_DECL
 #undef ZSTDGPU_RO_BUFFER_DECL
+#undef ZSTDGPU_RO_RAW_BUFFER_DECL
 
 // WARN(pamartis): Wasteful, need only uint8_t but HLSL doesn't support it
 groupshared uint32_t GS_Lds[kzstdgpu_MaxCount_HuffmanTableExpandedUInts];
@@ -50,6 +52,7 @@ void main(uint groupId : SV_GroupId, uint i : SV_GroupThreadId)
 {
     zstdgpu_DecompressLiterals_SRT srt;
 
+#define ZSTDGPU_RO_RAW_BUFFER_DECL(type, name, index)                  srt.in##name    = ZstdIn##name;
 #define ZSTDGPU_RO_BUFFER_DECL(type, name, index)                      srt.in##name    = ZstdIn##name;
 #define ZSTDGPU_RW_BUFFER_DECL(type, name, index)                      srt.inout##name = ZstdInOut##name;
 #define ZSTDGPU_RO_TYPED_BUFFER_DECL(hlsl_type, type, name, index)     srt.in##name    = ZstdIn##name;
@@ -60,6 +63,7 @@ void main(uint groupId : SV_GroupId, uint i : SV_GroupThreadId)
 #undef ZSTDGPU_RO_TYPED_BUFFER_DECL
 #undef ZSTDGPU_RW_BUFFER_DECL
 #undef ZSTDGPU_RO_BUFFER_DECL
+#undef ZSTDGPU_RO_RAW_BUFFER_DECL
     srt.huffmanTableSlotCount   = Constants.huffmanTableSlotCount;
 
     if (groupId >= srt.inCounters[kzstdgpu_CounterIndex_DecompressLiteralsGroups])

--- a/zstd/zstdgpu/Shaders/ZstdGpuInitHuffmanTable.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuInitHuffmanTable.hlsl
@@ -1,0 +1,67 @@
+/**
+ * ZstdGpuInitHuffmanTable.hlsl
+ *
+ * A compute shader that partially initializes Huffman table given weights.
+ * The shader initializes single Huffman table per threadgroup.
+ *
+ * Copyright (c) Microsoft. All rights reserved.
+ * This code is licensed under the MIT License (MIT).
+ * THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+ * ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+ * IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+ *
+ * Advanced Technology Group (ATG)
+ * Author(s):   Pavel Martishevsky (pamartis@microsoft.com)
+ */
+
+#include "../zstdgpu_shaders.h"
+
+struct Consts
+{
+    uint32_t HuffmanTableBase;
+};
+
+ConstantBuffer<Consts> Constants : register(b0);
+
+#define ZSTDGPU_RO_BUFFER_DECL(type, name, index)                  ZSTDGPU_RO_BUFFER(type)                    ZstdIn##name    : register(t##index);
+#define ZSTDGPU_RW_BUFFER_DECL(type, name, index)                  ZSTDGPU_RW_BUFFER(type)                    ZstdInOut##name : register(u##index);
+#define ZSTDGPU_RO_TYPED_BUFFER_DECL(hlsl_type, type, name, index) ZSTDGPU_RO_TYPED_BUFFER(hlsl_type, type)   ZstdIn##name    : register(t##index);
+#define ZSTDGPU_RW_TYPED_BUFFER_DECL(hlsl_type, type, name, index) ZSTDGPU_RW_TYPED_BUFFER(hlsl_type, type)   ZstdInOut##name : register(u##index);
+
+ZSTDGPU_INIT_HUFFMAN_TABLE_SRT()
+
+#undef ZSTDGPU_RW_TYPED_BUFFER_DECL
+#undef ZSTDGPU_RO_TYPED_BUFFER_DECL
+#undef ZSTDGPU_RW_BUFFER_DECL
+#undef ZSTDGPU_RO_BUFFER_DECL
+
+// WARN(pamartis): Wasteful, need only uint8_t but HLSL doesn't support it
+groupshared uint32_t GS_Lds[kzstdgpu_MaxCount_HuffmanWeights + kzstdgpu_MaxCount_HuffmanWeightsAllDigitBits + kzstdgpu_MaxCount_HuffmanWeightRanks * 3 + 2];
+#define ZSTDGPU_LDS GS_Lds
+#include "../zstdgpu_lds_hlsl.h"
+
+#ifdef __XBOX_SCARLETT
+#define __XBOX_ENABLE_WAVE32 1
+#endif
+
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=2), UAV(u0, numDescriptors=3)), RootConstants(b0, num32BitConstants=1)")]
+[numthreads(kzstdgpu_TgSizeX_DecompressLiterals, 1, 1)]
+void main(uint groupId : SV_GroupId, uint i : SV_GroupThreadId)
+{
+    zstdgpu_InitHuffmanTable_SRT srt;
+
+#define ZSTDGPU_RO_BUFFER_DECL(type, name, index)                      srt.in##name    = ZstdIn##name;
+#define ZSTDGPU_RW_BUFFER_DECL(type, name, index)                      srt.inout##name = ZstdInOut##name;
+#define ZSTDGPU_RO_TYPED_BUFFER_DECL(hlsl_type, type, name, index)     srt.in##name    = ZstdIn##name;
+#define ZSTDGPU_RW_TYPED_BUFFER_DECL(hlsl_type, type, name, index)     srt.inout##name = ZstdInOut##name;
+    ZSTDGPU_INIT_HUFFMAN_TABLE_SRT()
+#undef ZSTDGPU_RW_TYPED_BUFFER_DECL
+#undef ZSTDGPU_RO_TYPED_BUFFER_DECL
+#undef ZSTDGPU_RW_BUFFER_DECL
+#undef ZSTDGPU_RO_BUFFER_DECL
+
+    groupId = (Constants.HuffmanTableBase != 0) ? (Constants.HuffmanTableBase - 1 - groupId) : groupId;
+
+    zstdgpu_ShaderEntry_InitHuffmanTable(srt, groupId, i, kzstdgpu_TgSizeX_DecompressLiterals);
+}

--- a/zstd/zstdgpu/Shaders/ZstdGpuInitHuffmanTableAndDecompressLiterals.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuInitHuffmanTableAndDecompressLiterals.hlsl
@@ -28,6 +28,7 @@ struct Consts
 
 ConstantBuffer<Consts> Constants : register(b0);
 
+#define ZSTDGPU_RO_RAW_BUFFER_DECL(name, index)                    ByteAddressBuffer                          ZstdIn##name    : register(t##index);
 #define ZSTDGPU_RO_BUFFER_DECL(type, name, index)                  ZSTDGPU_RO_BUFFER(type)                    ZstdIn##name    : register(t##index);
 #define ZSTDGPU_RW_BUFFER_DECL(type, name, index)                  ZSTDGPU_RW_BUFFER(type)                    ZstdInOut##name : register(u##index);
 #define ZSTDGPU_RO_TYPED_BUFFER_DECL(hlsl_type, type, name, index) ZSTDGPU_RO_TYPED_BUFFER(hlsl_type, type)   ZstdIn##name    : register(t##index);
@@ -39,6 +40,7 @@ ZSTDGPU_INIT_HUFFMAN_TABLE_AND_DECOMPRESS_LITERALS_SRT()
 #undef ZSTDGPU_RO_TYPED_BUFFER_DECL
 #undef ZSTDGPU_RW_BUFFER_DECL
 #undef ZSTDGPU_RO_BUFFER_DECL
+#undef ZSTDGPU_RO_RAW_BUFFER_DECL
 
 // WARN(pamartis): Wasteful, need only uint8_t but HLSL doesn't support it
 groupshared uint32_t GS_Lds[kzstdgpu_MaxCount_HuffmanWeights * 2 + kzstdgpu_MaxCount_HuffmanWeightsAllDigitBits + kzstdgpu_MaxCount_HuffmanWeightRanks * 3 + 2 + kzstdgpu_MaxCount_HuffmanTableExpandedUInts];
@@ -55,6 +57,7 @@ void main(uint groupId : SV_GroupId, uint i : SV_GroupThreadId)
 {
     zstdgpu_InitHuffmanTable_And_DecompressLiterals_SRT srt;
 
+#define ZSTDGPU_RO_RAW_BUFFER_DECL(name, index)                        srt.in##name    = ZstdIn##name;
 #define ZSTDGPU_RO_BUFFER_DECL(type, name, index)                      srt.in##name    = ZstdIn##name;
 #define ZSTDGPU_RW_BUFFER_DECL(type, name, index)                      srt.inout##name = ZstdInOut##name;
 #define ZSTDGPU_RO_TYPED_BUFFER_DECL(hlsl_type, type, name, index)     srt.in##name    = ZstdIn##name;
@@ -65,6 +68,7 @@ void main(uint groupId : SV_GroupId, uint i : SV_GroupThreadId)
 #undef ZSTDGPU_RO_TYPED_BUFFER_DECL
 #undef ZSTDGPU_RW_BUFFER_DECL
 #undef ZSTDGPU_RO_BUFFER_DECL
+#undef ZSTDGPU_RO_RAW_BUFFER_DECL
     srt.huffmanTableSlotCount   = Constants.huffmanTableSlotCount;
 
     if (groupId >= srt.inCounters[kzstdgpu_CounterIndex_DecompressLiteralsGroups])

--- a/zstd/zstdgpu/Shaders/ZstdGpuInitHuffmanTableAndDecompressLiterals.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuInitHuffmanTableAndDecompressLiterals.hlsl
@@ -28,7 +28,7 @@ struct Consts
 
 ConstantBuffer<Consts> Constants : register(b0);
 
-#define ZSTDGPU_RO_RAW_BUFFER_DECL(name, index)                    ByteAddressBuffer                          ZstdIn##name    : register(t##index);
+#define ZSTDGPU_RO_RAW_BUFFER_DECL(type, name, index)              ZSTDGPU_RO_RAW_BUFFER(type)                ZstdIn##name    : register(t##index);
 #define ZSTDGPU_RO_BUFFER_DECL(type, name, index)                  ZSTDGPU_RO_BUFFER(type)                    ZstdIn##name    : register(t##index);
 #define ZSTDGPU_RW_BUFFER_DECL(type, name, index)                  ZSTDGPU_RW_BUFFER(type)                    ZstdInOut##name : register(u##index);
 #define ZSTDGPU_RO_TYPED_BUFFER_DECL(hlsl_type, type, name, index) ZSTDGPU_RO_TYPED_BUFFER(hlsl_type, type)   ZstdIn##name    : register(t##index);
@@ -57,7 +57,7 @@ void main(uint groupId : SV_GroupId, uint i : SV_GroupThreadId)
 {
     zstdgpu_InitHuffmanTable_And_DecompressLiterals_SRT srt;
 
-#define ZSTDGPU_RO_RAW_BUFFER_DECL(name, index)                        srt.in##name    = ZstdIn##name;
+#define ZSTDGPU_RO_RAW_BUFFER_DECL(type, name, index)                  srt.in##name    = ZstdIn##name;
 #define ZSTDGPU_RO_BUFFER_DECL(type, name, index)                      srt.in##name    = ZstdIn##name;
 #define ZSTDGPU_RW_BUFFER_DECL(type, name, index)                      srt.inout##name = ZstdInOut##name;
 #define ZSTDGPU_RO_TYPED_BUFFER_DECL(hlsl_type, type, name, index)     srt.in##name    = ZstdIn##name;

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -38,6 +38,7 @@
 #include "ZstdGpuComputePrefixSum.h"
 #include "ZstdGpuDecodeHuffmanWeights.h"
 #include "ZstdGpuDecompressHuffmanWeights.h"
+#include "ZstdGpuDecompressLiterals.h"
 #include "ZstdGpuDecompressSequences.h"
 #include "ZstdGpuExecuteSequences128.h"
 #include "ZstdGpuExecuteSequences64.h"
@@ -45,6 +46,7 @@
 #include "ZstdGpuFinaliseSequenceOffsets.h"
 #include "ZstdGpuGroupCompressedLiterals.h"
 #include "ZstdGpuInitFseTable.h"
+#include "ZstdGpuInitHuffmanTable.h"
 #include "ZstdGpuInitHuffmanTableAndDecompressLiterals.h"
 #include "ZstdGpuInitResources.h"
 #include "ZstdGpuMemsetMemcpy.h"
@@ -279,6 +281,7 @@ static void zstdgpu_ReCreate_SRTs(zstdgpu_SRTs & srts, ID3D12Device *device, con
     ZSTDGPU_KERNEL(ComputePrefixSum                         , L"Compute Prefix of Literal and TG Count for Literal Decompression")  \
     ZSTDGPU_KERNEL(DecodeHuffmanWeights                     , L"Decode (from nibbles) Uncompressed Huffman Weights")                \
     ZSTDGPU_KERNEL(DecompressHuffmanWeights                 , L"Decompress FSE-compressed Huffman Weights")                         \
+    ZSTDGPU_KERNEL(DecompressLiterals                       , L"Decompress Literals")                                               \
     ZSTDGPU_KERNEL(DecompressSequences                      , L"Decompress Sequences")                                              \
     ZSTDGPU_KERNEL(ExecuteSequences128                      , L"Execute Sequences 128")                                             \
     ZSTDGPU_KERNEL(ExecuteSequences64                       , L"Execute Sequences 64")                                              \
@@ -286,6 +289,7 @@ static void zstdgpu_ReCreate_SRTs(zstdgpu_SRTs & srts, ID3D12Device *device, con
     ZSTDGPU_KERNEL(FinaliseSequenceOffsets                  , L"Finalise Sequence Offsets")                                         \
     ZSTDGPU_KERNEL(GroupCompressedLiterals                  , L"Group Huffman-compressed Literals")                                 \
     ZSTDGPU_KERNEL(InitFseTable                             , L"Init Fse Table")                                                    \
+    ZSTDGPU_KERNEL(InitHuffmanTable                         , L"Init Huffman Table")                                                \
     ZSTDGPU_KERNEL(InitHuffmanTableAndDecompressLiterals    , L"Init Huffman Table and Decompress Literals")                        \
     ZSTDGPU_KERNEL(InitResources                            , L"Init Resources")                                                    \
     ZSTDGPU_KERNEL(MemsetMemcpy                             , L"Memset-Memcpy")                                                     \
@@ -312,7 +316,9 @@ static void zstdgpu_ReCreate_SRTs(zstdgpu_SRTs & srts, ID3D12Device *device, con
     ZSTDGPU_KERNEL_SCOPE_X(InitFseTable                         , L"Init FSE Tables"            )   \
     ZSTDGPU_KERNEL_SCOPE_X(DecompressHuffmanWeights             , L"Decompress Huffman Weights" )   \
     ZSTDGPU_KERNEL_SCOPE_X(DecodeHuffmanWeights                 , L"Decode Huffman Weights"     )   \
-    ZSTDGPU_KERNEL_SCOPE_X(InitHuffmanTableAndDecompressLiterals, L"Init Huffman Table and Decompress Literals Huffman Weights" )   \
+    ZSTDGPU_KERNEL_SCOPE_X(InitHuffmanTable                     , L"Init Huffman Table"         )   \
+    ZSTDGPU_KERNEL_SCOPE_X(DecompressLiterals                   , L"Decompress Literals"         )  \
+    ZSTDGPU_KERNEL_SCOPE_X(InitHuffmanTableAndDecompressLiterals, L"Init Huffman Table and Decompress Literals" )   \
     ZSTDGPU_KERNEL_SCOPE_X(DecompressSequences                  , L"Decompress Sequences"       )   \
     ZSTDGPU_KERNEL_SCOPE_X(PrefixSequenceOffsets                , L"Propagate Sequence Offsets" )   \
     ZSTDGPU_KERNEL_SCOPE_X(FinaliseSequenceOffsets              , L"Finalise Sequence Offsets"  )   \
@@ -1596,13 +1602,65 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
     if (req->zstdCmpBlockCount > 0)
     {
+        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Pre-Init Huffman Table]");
+        BIND_RS_PS_SRT(InitHuffmanTable);
+        ID3D12Resource* argBuf = req->resData.gpuOnly.Counters;
+
+        ZSTDGPU_KERNEL_SCOPE(InitHuffmanTable, cmdList,
+        {
+            PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Path: FSE-compressed Huffman Weights]");
+            {
+                cmdList->SetComputeRoot32BitConstant(1, /** HuffmaTableIndexBase*/0, 0);
+                cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_FseHufW * sizeof(uint32_t), NULL, 0);
+            }
+            PIXEndEvent(cmdList);
+
+            PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Path: Uncompressed Huffman Weights]");
+            {
+                cmdList->SetComputeRoot32BitConstant(1, /** HuffmaTableIndexBase = zstdCmpBlockCount meaning indices are reversed */req->zstdCmpBlockCount, 0);
+                cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_HUF_WgtStreams * sizeof(uint32_t), NULL, 0);
+            }
+            PIXEndEvent(cmdList);
+        });
+
+        PIXEndEvent(cmdList);
+    }
+
+    if (req->zstdCmpBlockCount > 0)
+    {
+        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier with Resources for [Decompress Literals]");
+        D3D12_RESOURCE_BARRIER barriers[3];
+        // last written by [Init Huffman Table]
+        // next read by [Decompress Literals]
+        setResourceUavToSrvSync(barriers, 0, req->resData.gpuOnly.HuffmanTableInfo);
+        setResourceUavToSrvSync(barriers, 1, req->resData.gpuOnly.HuffmanTableRankIndex);
+        setResourceUavToSrvSync(barriers, 2, req->resData.gpuOnly.HuffmanTableCodeAndSymbol);
+        cmdList->ResourceBarrier(_countof(barriers), barriers);
+        PIXEndEvent(cmdList);
+    }
+
+    if (req->zstdCmpBlockCount > 0)
+    {
+        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Decompress Literals]");
+        BIND_RS_PS_SRT(DecompressLiterals);
+        cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 0);
+
+        ID3D12Resource* argBuf = req->resData.gpuOnly.Counters;
+        ZSTDGPU_KERNEL_SCOPE(DecompressLiterals, cmdList,
+            cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_DecompressLiteralsGroups * sizeof(uint32_t), NULL, 0);
+        );
+        PIXEndEvent(cmdList);
+    }
+
+    if (req->zstdCmpBlockCount > 0)
+    {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Init Huffman Table and Decompress Literals]");
         BIND_RS_PS_SRT(InitHuffmanTableAndDecompressLiterals);
         cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 0);
 
-        ID3D12Resource* argBuf = req->resData.gpuOnly.Counters;
+        //ID3D12Resource* argBuf = req->resData.gpuOnly.Counters;
         ZSTDGPU_KERNEL_SCOPE(InitHuffmanTableAndDecompressLiterals, cmdList,
-            cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_DecompressLiteralsGroups * sizeof(uint32_t), NULL, 0);
+            //cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_DecompressLiteralsGroups * sizeof(uint32_t), NULL, 0);
         );
         PIXEndEvent(cmdList);
     }

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -207,6 +207,7 @@ static uint32_t zstdgpu_Count_SRTs(void)
 {
     uint32_t descCount = 0;
 
+    #define ZSTDGPU_RO_RAW_BUFFER_DECL(name, index)                        descCount += 1;
     #define ZSTDGPU_RO_BUFFER_DECL(type, name, index)                      descCount += 1;
     #define ZSTDGPU_RW_BUFFER_DECL(type, name, index)                      descCount += 1;
     #define ZSTDGPU_RW_BUFFER_DECL_GLC(type, name, index)                  descCount += 1;
@@ -222,8 +223,17 @@ static uint32_t zstdgpu_Count_SRTs(void)
     #undef ZSTDGPU_RW_BUFFER_DECL_GLC
     #undef ZSTDGPU_RW_BUFFER_DECL
     #undef ZSTDGPU_RO_BUFFER_DECL
+    #undef ZSTDGPU_RO_RAW_BUFFER_DECL
 
     return descCount;
+}
+
+static void zstdgpu_CreateByteAddressBufferSrv(D3D12_CPU_DESCRIPTOR_HANDLE cpuDest, ID3D12Device* device, ID3D12Resource* resource, uint32_t byteSize)
+{
+    D3D12_SHADER_RESOURCE_VIEW_DESC desc = { DXGI_FORMAT_R32_TYPELESS, D3D12_SRV_DIMENSION_BUFFER, D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING };
+    desc.Buffer.NumElements = byteSize / sizeof(uint32_t);
+    desc.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_RAW;
+    device->CreateShaderResourceView(resource, &desc, cpuDest);
 }
 
 static void zstdgpu_ReCreate_SRTs(zstdgpu_SRTs & srts, ID3D12Device *device, const zstdgpu_ResourceInfo & resInfo, const zstdgpu_ResourceDataGpu & gpuResData)
@@ -257,6 +267,13 @@ static void zstdgpu_ReCreate_SRTs(zstdgpu_SRTs & srts, ID3D12Device *device, con
         cpuDest.ptr += descSize;                                                                            \
         gpuDest.ptr += descSize;
 
+
+    #define ZSTDGPU_PUSH_RAW_BUFFER(name)                                                                           \
+        (zstdgpu_CreateByteAddressBufferSrv(cpuDest, device, gpuResData.gpuOnly.name, resInfo.name##_ByteSize),     \
+         cpuDest.ptr += descSize,                                                                                   \
+         gpuDest.ptr += descSize);
+
+    #define ZSTDGPU_RO_RAW_BUFFER_DECL(name, index) ZSTDGPU_PUSH_RAW_BUFFER(name)
     #define ZSTDGPU_RO_BUFFER_DECL(type, name, index) ZSTDGPU_PUSH_STRUCT_BUFFER(type, name, SRV)
     #define ZSTDGPU_RW_BUFFER_DECL(type, name, index) ZSTDGPU_PUSH_STRUCT_BUFFER(type, name, UAV)
     #define ZSTDGPU_RW_BUFFER_DECL_GLC(type, name, index) ZSTDGPU_PUSH_STRUCT_BUFFER(type, name, UAV)
@@ -272,6 +289,7 @@ static void zstdgpu_ReCreate_SRTs(zstdgpu_SRTs & srts, ID3D12Device *device, con
     #undef ZSTDGPU_RW_BUFFER_DECL_GLC
     #undef ZSTDGPU_RW_BUFFER_DECL
     #undef ZSTDGPU_RO_BUFFER_DECL
+    #undef ZSTDGPU_RO_RAW_BUFFER_DECL
 }
 
 #define ZSTDGPU_KERNEL_LIST()                                                                                                       \

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -209,7 +209,7 @@ static uint32_t zstdgpu_Count_SRTs(void)
 {
     uint32_t descCount = 0;
 
-    #define ZSTDGPU_RO_RAW_BUFFER_DECL(name, index)                        descCount += 1;
+    #define ZSTDGPU_RO_RAW_BUFFER_DECL(type, name, index)                  descCount += 1;
     #define ZSTDGPU_RO_BUFFER_DECL(type, name, index)                      descCount += 1;
     #define ZSTDGPU_RW_BUFFER_DECL(type, name, index)                      descCount += 1;
     #define ZSTDGPU_RW_BUFFER_DECL_GLC(type, name, index)                  descCount += 1;
@@ -280,7 +280,7 @@ static void zstdgpu_ReCreate_SRTs(zstdgpu_SRTs & srts, ID3D12Device *device, con
          cpuDest.ptr += descSize,                                                                                   \
          gpuDest.ptr += descSize);
 
-    #define ZSTDGPU_RO_RAW_BUFFER_DECL(name, index) ZSTDGPU_PUSH_RAW_BUFFER(name)
+    #define ZSTDGPU_RO_RAW_BUFFER_DECL(type, name, index) ZSTDGPU_PUSH_RAW_BUFFER(name)
     #define ZSTDGPU_RO_BUFFER_DECL(type, name, index) ZSTDGPU_PUSH_STRUCT_BUFFER(type, name, SRV)
     #define ZSTDGPU_RW_BUFFER_DECL(type, name, index) ZSTDGPU_PUSH_STRUCT_BUFFER(type, name, UAV)
     #define ZSTDGPU_RW_BUFFER_DECL_GLC(type, name, index) ZSTDGPU_PUSH_STRUCT_BUFFER(type, name, UAV)

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -230,7 +230,12 @@ static uint32_t zstdgpu_Count_SRTs(void)
 
 static void zstdgpu_CreateByteAddressBufferSrv(D3D12_CPU_DESCRIPTOR_HANDLE cpuDest, ID3D12Device* device, ID3D12Resource* resource, uint32_t byteSize)
 {
-    D3D12_SHADER_RESOURCE_VIEW_DESC desc = { DXGI_FORMAT_R32_TYPELESS, D3D12_SRV_DIMENSION_BUFFER, D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING };
+    D3D12_SHADER_RESOURCE_VIEW_DESC desc =
+    {
+        DXGI_FORMAT_R32_TYPELESS,
+        D3D12_SRV_DIMENSION_BUFFER,
+        D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING
+    };
     desc.Buffer.NumElements = byteSize / sizeof(uint32_t);
     desc.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_RAW;
     device->CreateShaderResourceView(resource, &desc, cpuDest);

--- a/zstd/zstdgpu/zstdgpu_resources.h
+++ b/zstd/zstdgpu/zstdgpu_resources.h
@@ -98,7 +98,10 @@
     ZSTDGPU_BUFFER(zstdgpu_OffsetAndSize                    , BlocksRAWRefs                 )   \
     ZSTDGPU_BUFFER(zstdgpu_OffsetAndSize                    , BlocksCMPRefs                 )
 
-#define ZSTDGPU_BUFFERS_LIST_STAGE_1() /* empty so far*/
+#define ZSTDGPU_BUFFERS_LIST_STAGE_1() \
+    ZSTDGPU_BUFFER(uint32_t                                 , HuffmanTableCodeAndSymbol     )   \
+    ZSTDGPU_BUFFER(uint32_t                                 , HuffmanTableRankIndex         )   \
+    ZSTDGPU_BUFFER(uint32_t                                 , HuffmanTableInfo              )
 
 #define ZSTDGPU_ALL_BUFFERS_LIST_STAGE_0()     \
     ZSTDGPU_BUFFERS_LIST_UPLOAD_STAGE_0()      \
@@ -315,6 +318,10 @@ static void zstdgpu_ResourceInfo_Stage_1_InitSize(zstdgpu_ResourceInfo *outInfo,
     const uint32_t LitGroupEndPerHuffmanTable_Count = LitStreamEndPerHuffmanTable_Count;
     const uint32_t BlockSeqCountPrefixLookback_Count = TableIndexLookback_Count;
     const uint32_t SeqCountPrefixLookback_Count = TableIndexLookback_Count;
+
+    const uint32_t HuffmanTableCodeAndSymbol_Count = kzstdgpu_MaxCount_HuffmanWeights * cmpBlockCount;
+    const uint32_t HuffmanTableRankIndex_Count = kzstdgpu_MaxCount_HuffmanWeightRanks * cmpBlockCount;
+    const uint32_t HuffmanTableInfo_Count = cmpBlockCount;
 
     ZSTDGPU_ALL_BUFFERS_LIST_STAGE_1()
 }

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -154,6 +154,75 @@ static inline uint32_t zstdgpu_BinarySearch(ZSTDGPU_RO_BUFFER(uint32_t) sortedSe
     return rangeBase;
 }
 
+static inline uint32_t zstdgpu_BinarySearchMasked(ZSTDGPU_RO_BUFFER(uint32_t) sortedSequence, uint32_t start, uint32_t count, uint32_t key, uint32_t tstMask)
+{
+    uint32_t rangeBase = start;
+    uint32_t rangeSize = count;
+
+    while (rangeSize > 1)
+    {
+        const uint32_t rangeTest = rangeSize >> 1;
+        const uint32_t rangeNext = rangeBase + rangeTest;
+
+        const uint32_t tst = sortedSequence[rangeNext]  & tstMask;
+        rangeBase = key < tst ? rangeBase : rangeNext;
+        rangeSize -= rangeTest;
+    }
+
+    return rangeBase;
+}
+
+static inline uint32_t zstdgpu_BinarySearchLds(ZSTDGPU_PARAM_LDS_IN(uint32_t) GS_Base, uint32_t start, uint32_t count, uint32_t key, uint32_t tstMask)
+{
+    uint32_t rangeBase = start;
+    uint32_t rangeSize = count;
+
+    while (rangeSize > 1)
+    {
+        const uint32_t rangeTest = rangeSize >> 1;
+        const uint32_t rangeNext = rangeBase + rangeTest;
+
+        const uint32_t tst = zstdgpu_LdsLoadU32(GS_Base + rangeNext) & tstMask;
+        rangeBase = key < tst ? rangeBase : rangeNext;
+        rangeSize -= rangeTest;
+    }
+
+    return rangeBase;
+}
+
+static inline void zstdgpu_GroupBallotLdsStore(uint32_t laneCnt, uint32_t VGPR, ZSTDGPU_PARAM_LDS_INOUT(uint32_t) ballot_GroupDwStart, uint32_t ballot_GroupDwCountPerBit, uint32_t waveId, uint32_t bitIdx)
+{
+    const uint32_t4 b = WaveActiveBallot((VGPR & (1u << bitIdx)) != 0);
+    if (laneCnt <= 16)
+    {
+        uint32_t offsetInDw = ballot_GroupDwCountPerBit * (bitIdx);
+        const uint32_t ballotMaskCntPerDw = 32 / laneCnt;
+        offsetInDw += (waveId) / ballotMaskCntPerDw;
+        const uint32_t ballotMaskIdInDw = (waveId) % ballotMaskCntPerDw;
+        zstdgpu_LdsAtomicOrU32(ballot_GroupDwStart + offsetInDw, b.x << (ballotMaskIdInDw * laneCnt));
+    }
+    else if (laneCnt == 32)
+    {
+        const uint32_t offsetInDw = ballot_GroupDwCountPerBit * (bitIdx) + (waveId);
+        zstdgpu_LdsStoreU32(ballot_GroupDwStart + offsetInDw + 0, b.x);
+    }
+    else if (laneCnt == 64)
+    {
+        const uint32_t offsetInDw = ballot_GroupDwCountPerBit * (bitIdx) + (waveId) * 2;
+        zstdgpu_LdsStoreU32(ballot_GroupDwStart + offsetInDw + 0, b.x);
+        zstdgpu_LdsStoreU32(ballot_GroupDwStart + offsetInDw + 1, b.y);
+    }
+    /* for some GPUs with 128-wide waves, store extra masks*/
+    else
+    {
+        const uint32_t offsetInDw = ballot_GroupDwCountPerBit * (bitIdx) + (waveId) * 4;
+        zstdgpu_LdsStoreU32(ballot_GroupDwStart + offsetInDw + 0, b.x);
+        zstdgpu_LdsStoreU32(ballot_GroupDwStart + offsetInDw + 1, b.y);
+        zstdgpu_LdsStoreU32(ballot_GroupDwStart + offsetInDw + 2, b.z);
+        zstdgpu_LdsStoreU32(ballot_GroupDwStart + offsetInDw + 3, b.w);
+    }
+}
+
 static inline void zstdgpu_ShaderEntry_ParseFrame(ZSTDGPU_PARAM_INOUT(zstdgpu_FrameInfo) outFrameInfo,
                                                   ZSTDGPU_RW_BUFFER(zstdgpu_OffsetAndSize) outBlocksRAWRefs,
                                                   ZSTDGPU_RW_BUFFER(zstdgpu_OffsetAndSize) outBlocksRLERefs,
@@ -497,7 +566,8 @@ static void zstdgpu_ShaderEntry_InitResources(ZSTDGPU_PARAM_INOUT(zstdgpu_InitRe
                                 || i == kzstdgpu_CounterIndex_GroupCompressedLiteralsGroups
                                 || i == kzstdgpu_CounterIndex_DecompressLiteralsGroups
                                 || i == kzstdgpu_CounterIndex_DecompressSequencesGroups
-                                || i >= kzstdgpu_CounterIndex_HUF_WgtStreams;
+                                || i == kzstdgpu_CounterIndex_HUF_WgtStreams
+                                || i >= kzstdgpu_CounterIndex_Seq_Streams_DecodedItems;
 
             if (needsZero)
                 srt.inoutCounters[i] = 0;
@@ -2138,38 +2208,6 @@ static void zstdgpu_ShaderEntry_InitFseTable(ZSTDGPU_PARAM_INOUT(zstdgpu_InitFse
         }
     }
     GroupMemoryBarrierWithGroupSync();
-    #define zstdgpu_Store_VGPR_Bit_PerTg(laneCnt, storage, VGPR, waveId, bitIdx)                        \
-        {                                                                                               \
-            const uint32_t4 b = WaveActiveBallot((VGPR & (1u << bitIdx)) != 0);                         \
-            if (laneCnt <= 16)                                                                          \
-            {                                                                                           \
-                const uint32_t offset = kzstdgpu_MaxCount_FseElemsOneDigitBits * (bitIdx);               \
-                const uint32_t ballotMaskCntInUInt = 32 / laneCnt;                                      \
-                const uint32_t ballotMaskUIntIndex = (waveId) / ballotMaskCntInUInt + offset;           \
-                const uint32_t ballotMaskIdInUInt = (waveId) % ballotMaskCntInUInt;                     \
-                zstdgpu_LdsAtomicOrU32(storage + ballotMaskUIntIndex, b.x << (ballotMaskIdInUInt * laneCnt)); \
-            }                                                                                           \
-            else if (laneCnt == 32)                                                                     \
-            {                                                                                           \
-                const uint32_t offset = kzstdgpu_MaxCount_FseElemsOneDigitBits * (bitIdx) + (waveId);    \
-                zstdgpu_LdsStoreU32(storage + offset + 0, b.x);                                         \
-            }                                                                                           \
-            else if (laneCnt == 64)                                                                     \
-            {                                                                                           \
-                const uint32_t offset = kzstdgpu_MaxCount_FseElemsOneDigitBits * (bitIdx) + (waveId) * 2;\
-                zstdgpu_LdsStoreU32(storage + offset + 0, b.x);                                         \
-                zstdgpu_LdsStoreU32(storage + offset + 1, b.y);                                         \
-            }                                                                                           \
-            /* for some GPUs with 128-wide waves, store extra masks*/                                   \
-            else                                                                                        \
-            {                                                                                           \
-                const uint32_t offset = kzstdgpu_MaxCount_FseElemsOneDigitBits * (bitIdx) + (waveId) * 4;\
-                zstdgpu_LdsStoreU32(storage + offset + 0, b.x);                                         \
-                zstdgpu_LdsStoreU32(storage + offset + 1, b.y);                                         \
-                zstdgpu_LdsStoreU32(storage + offset + 2, b.z);                                         \
-                zstdgpu_LdsStoreU32(storage + offset + 3, b.w);                                         \
-            }                                                                                           \
-        }
 
     // NOTE(pamartis): Transpose N=`tblAllDataCount` symbols (store only bits with index 0, then with index 1 and so on.)
     // and store the transposed representation in LDS (as eight `tblAllDataCount`-wide masks)
@@ -2178,16 +2216,15 @@ static void zstdgpu_ShaderEntry_InitFseTable(ZSTDGPU_PARAM_INOUT(zstdgpu_InitFse
     {
         const uint32_t symbol = srt.inoutFseSymbols[tblDataOffset + workItemId];
 
-        zstdgpu_Store_VGPR_Bit_PerTg(laneCnt, GS_SymbolBitMasks, symbol, waveOfs, 0)
-        zstdgpu_Store_VGPR_Bit_PerTg(laneCnt, GS_SymbolBitMasks, symbol, waveOfs, 1)
-        zstdgpu_Store_VGPR_Bit_PerTg(laneCnt, GS_SymbolBitMasks, symbol, waveOfs, 2)
-        zstdgpu_Store_VGPR_Bit_PerTg(laneCnt, GS_SymbolBitMasks, symbol, waveOfs, 3)
-        zstdgpu_Store_VGPR_Bit_PerTg(laneCnt, GS_SymbolBitMasks, symbol, waveOfs, 4)
-        zstdgpu_Store_VGPR_Bit_PerTg(laneCnt, GS_SymbolBitMasks, symbol, waveOfs, 5)
-        zstdgpu_Store_VGPR_Bit_PerTg(laneCnt, GS_SymbolBitMasks, symbol, waveOfs, 6)
-        zstdgpu_Store_VGPR_Bit_PerTg(laneCnt, GS_SymbolBitMasks, symbol, waveOfs, 7)
+        zstdgpu_GroupBallotLdsStore(laneCnt, symbol, GS_SymbolBitMasks, kzstdgpu_MaxCount_FseElemsOneDigitBits, waveOfs, 0);
+        zstdgpu_GroupBallotLdsStore(laneCnt, symbol, GS_SymbolBitMasks, kzstdgpu_MaxCount_FseElemsOneDigitBits, waveOfs, 1);
+        zstdgpu_GroupBallotLdsStore(laneCnt, symbol, GS_SymbolBitMasks, kzstdgpu_MaxCount_FseElemsOneDigitBits, waveOfs, 2);
+        zstdgpu_GroupBallotLdsStore(laneCnt, symbol, GS_SymbolBitMasks, kzstdgpu_MaxCount_FseElemsOneDigitBits, waveOfs, 3);
+        zstdgpu_GroupBallotLdsStore(laneCnt, symbol, GS_SymbolBitMasks, kzstdgpu_MaxCount_FseElemsOneDigitBits, waveOfs, 4);
+        zstdgpu_GroupBallotLdsStore(laneCnt, symbol, GS_SymbolBitMasks, kzstdgpu_MaxCount_FseElemsOneDigitBits, waveOfs, 5);
+        zstdgpu_GroupBallotLdsStore(laneCnt, symbol, GS_SymbolBitMasks, kzstdgpu_MaxCount_FseElemsOneDigitBits, waveOfs, 6);
+        zstdgpu_GroupBallotLdsStore(laneCnt, symbol, GS_SymbolBitMasks, kzstdgpu_MaxCount_FseElemsOneDigitBits, waveOfs, 7);
 
-        #undef zstdgpu_Store_VGPR_Bit_PerTg
         waveOfs += waveCnt;
     }
     GroupMemoryBarrierWithGroupSync();
@@ -2413,14 +2450,315 @@ static void zstdgpu_ShaderEntry_DecodeHuffmanWeights(ZSTDGPU_PARAM_INOUT(zstdgpu
     }
 }
 
-static void zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(ZSTDGPU_PARAM_INOUT(zstdgpu_InitHuffmanTable_And_DecompressLiterals_SRT) srt, uint32_t groupId, uint32_t threadId)
+static void zstdgpu_PreInitHuffmanTableToLds(ZSTDGPU_RO_TYPED_BUFFER(uint32_t, uint8_t) HuffmanWeights,
+                                             ZSTDGPU_RO_TYPED_BUFFER(uint32_t, uint8_t) HuffmanWeightCount,
+                                             uint32_t tableId,
+                                             uint32_t threadId,
+                                             uint32_t threadCnt,
+                                             ZSTDGPU_PARAM_INOUT(uint32_t) outBitsMax,
+                                             ZSTDGPU_PARAM_INOUT(uint32_t) outCodeTableSize,
+                                             /**
+                                              * NOTE(pamartis): Since HLSL doesn't allow us to declare 'groupshared' memory region within function
+                                              * or pass such region as a parameter, we resort to passing an integer 'GS_Region' (and later) variable(s) controlling the start
+                                              * of region of LDS memory allocated externally.
+                                              *
+                                              * HLSL also doesn't give us any means of enforcing 'GS_Region' to be a compile-time constant.
+                                              */
+                                             ZSTDGPU_PARAM_LDS_INOUT(uint32_t) GS_Region,
+                                             /**
+                                              * NOTE(pamartis): Since HLSL is doesn't give us way to specify callbacks/lambdas, in this case
+                                              * to either implement storing pre-initialised Huffman Table to either LDS or Memory, we have
+                                              * to pass both:
+                                              *     - LDS region as 'GS_OutCodeAndSymbol'
+                                              *     - Memory region as 'MEM_OutCodeAndSymbol'
+                                              * and supply additional 'bool isMemStore' controlling whether to use LDS or Memory as destination
+                                              */
+                                             ZSTDGPU_PARAM_LDS_INOUT(uint32_t) GS_RankIndex,
+                                             ZSTDGPU_PARAM_LDS_INOUT(uint32_t) GS_CodeAndSymbol,
+                                             ZSTDGPU_RW_BUFFER(uint32_t) MEM_CodeAndSymbol,
+                                             bool isMemStore)
 {
-    uint32_t htTableIndex = 0;
+    const uint32_t weightCntMinusOne = HuffmanWeightCount[tableId];
+
+    ZSTDGPU_DECLARE_GROUPSHARED(Bits            , kzstdgpu_MaxCount_HuffmanWeights); //< WARN(pamartis): Wasteful, need only uint8_t but HLSL doesn't support it
+    ZSTDGPU_DECLARE_GROUPSHARED(BitsMask        , kzstdgpu_MaxCount_HuffmanWeightsAllDigitBits);
+    ZSTDGPU_DECLARE_GROUPSHARED(RankCount       , kzstdgpu_MaxCount_HuffmanWeightRanks);
+    ZSTDGPU_DECLARE_GROUPSHARED(RankCountPrefix , kzstdgpu_MaxCount_HuffmanWeightRanks);
+    ZSTDGPU_DECLARE_GROUPSHARED(WeightSum       , 1);
+    ZSTDGPU_DECLARE_GROUPSHARED(BitsMax         , 1);
+
+    ZSTDGPU_FOR_WORK_ITEMS(i, 1, threadId, threadCnt)
+    {
+        zstdgpu_LdsStoreU32(GS_WeightSum, 0);
+        zstdgpu_LdsStoreU32(GS_BitsMax, 0);
+    }
+
+    ZSTDGPU_FOR_WORK_ITEMS(i, kzstdgpu_MaxCount_HuffmanWeightRanks, threadId, threadCnt)
+    {
+        zstdgpu_LdsStoreU32(GS_RankCount + i, 0);
+        zstdgpu_LdsStoreU32(GS_RankIndex + i, 0);
+        zstdgpu_LdsStoreU32(GS_RankCountPrefix + i, 0);
+    }
+
+    #ifdef __hlsl_dx_compiler
+    // NOTE(pamartis): When the number of lanes in the wave <= 16, we need to initialize GS_BitsMask to zero
+    // because we use InterlockedOr on each 32-bit GS_BitsMask[i] to store wave masks (see StoreGroupBitMask)...
+    if (WaveGetLaneCount() <= 16)
+        #else
+        // always in non-HLSL case
+        #endif
+    {
+        ZSTDGPU_FOR_WORK_ITEMS(i, kzstdgpu_MaxCount_HuffmanWeightsAllDigitBits, threadId, threadCnt)
+        {
+            zstdgpu_LdsStoreU32(GS_BitsMask + i, 0);
+        }
+    }
+    GroupMemoryBarrierWithGroupSync();
+
+    ZSTDGPU_FOR_WORK_ITEMS(i, weightCntMinusOne, threadId, threadCnt)
+    {
+        const uint32_t weight = HuffmanWeights[tableId * kzstdgpu_MaxCount_HuffmanWeights + i];
+
+        // weights are in range [0;16], so the maximim accumulated value is 0x8000
+        const uint32_t weightSumPerWave = WaveActiveSum(weight > 0u ? (1u << (weight - 1u)) : 0u);
+
+        if (WaveIsFirstLane())
+        {
+            zstdgpu_LdsAtomicAddU32(GS_WeightSum, weightSumPerWave);
+        }
+    }
+    GroupMemoryBarrierWithGroupSync();
+
+    // because the maximal accumulated value is 0x8000 and there're only 255 weights possible (because the last weight isn't stored)
+    // the maximum value of `GS_WeightSum` is 0x8000 * 255 = 0x7f8000, which means the largest possible highest bit index is 22, and
+    // the largest possible `maxBitsUniform` is `23`
+
+    const uint32_t weightSumUniform = zstdgpu_LdsLoadU32(GS_WeightSum);
+
+    const uint32_t maxBitsUniform = zstdgpu_FindFirstBitHiU32(weightSumUniform) + 1u;
+    const uint32_t leftoverBitsUniform = (1u << maxBitsUniform) - weightSumUniform;
+    const uint32_t lastWeightUniform = zstdgpu_FindFirstBitHiU32(leftoverBitsUniform) + 1u;
+
+    const uint32_t laneCnt = zstdgpu_MinU32(threadCnt, WaveGetLaneCount());
+    // NOTE(pamartis): the above is important because `threadCnt` is fixed,
+    // so WaveGetLaneCount() could be > `threadCnt`
+    #ifdef __hlsl_dx_compiler
+    const uint32_t waveCnt = threadCnt / laneCnt;
+    #else
+    const uint32_t waveCnt = 1;
+    #endif
+
+    // NOTE(pamartis): Use `WaveReadLaneFirst` to make sure `waveIdx` is wave-uniform
+    const uint32_t waveIdx = WaveReadLaneFirst(threadId / laneCnt);
+
+    uint32_t waveOfs = waveIdx;
+    const uint32_t weightCnt = weightCntMinusOne + 1;
+    ZSTDGPU_FOR_WORK_ITEMS(weightId, weightCnt, threadId, threadCnt)
+    {
+        // TODO(pamartis): consider if we can avoid re-loading weights from memory (it's only 256 bytes worst case)
+        const uint32_t weight = HuffmanWeights[tableId * kzstdgpu_MaxCount_HuffmanWeights + weightId];
+
+        uint32_t bits = 0u;
+        if (weightId < weightCntMinusOne)
+        {
+            bits = weight > 0u ? (maxBitsUniform + 1u - weight) : 0u;
+        }
+        else
+        {
+            bits = maxBitsUniform + 1u - lastWeightUniform;
+        }
+
+        zstdgpu_LdsStoreU32(GS_Bits + weightId, bits);
+
+        zstdgpu_GroupBallotLdsStore(laneCnt, bits, GS_BitsMask, kzstdgpu_MaxCount_HuffmanWeightsOneDigitBits, waveOfs, 0);
+        zstdgpu_GroupBallotLdsStore(laneCnt, bits, GS_BitsMask, kzstdgpu_MaxCount_HuffmanWeightsOneDigitBits, waveOfs, 1);
+        zstdgpu_GroupBallotLdsStore(laneCnt, bits, GS_BitsMask, kzstdgpu_MaxCount_HuffmanWeightsOneDigitBits, waveOfs, 2);
+        zstdgpu_GroupBallotLdsStore(laneCnt, bits, GS_BitsMask, kzstdgpu_MaxCount_HuffmanWeightsOneDigitBits, waveOfs, 3);
+        zstdgpu_GroupBallotLdsStore(laneCnt, bits, GS_BitsMask, kzstdgpu_MaxCount_HuffmanWeightsOneDigitBits, waveOfs, 4);
+
+        const uint32_t bitsMaxPerWave = WaveActiveMax(bits);
+
+        if (WaveIsFirstLane())
+        {
+            zstdgpu_LdsAtomicMaxU32(GS_BitsMax, bitsMaxPerWave);
+        }
+        zstdgpu_LdsAtomicAddU32(GS_RankCount + bits, 1);
+
+        waveOfs += waveCnt;
+    }
+    GroupMemoryBarrierWithGroupSync();
+
+    outBitsMax = zstdgpu_LdsLoadU32(GS_BitsMax);
+
+    // NOTE(pamartis): initialize RankIndex which is used to determine the starting number of bits
+    #ifndef __hlsl_dx_compiler
+    uint32_t prevRankIndex = 0;
+    uint32_t prevRankCountPrefix = 0;
+    #endif
+    ZSTDGPU_FOR_WORK_ITEMS(workItemId, outBitsMax + 1u, threadId, threadCnt)
+    {
+        const uint32_t rankCountId = outBitsMax - workItemId;
+        const uint32_t rankCount= zstdgpu_LdsLoadU32(GS_RankCount + rankCountId);
+        #ifdef __hlsl_dx_compiler
+        uint32_t rankIndexInWave = WavePrefixSum(rankCount << workItemId);
+        uint32_t rankCountPrefixInWave = WavePrefixSum(rankCount);
+
+        zstdgpu_LdsAtomicAddU32(GS_RankIndex + workItemId, rankIndexInWave);
+        zstdgpu_LdsAtomicAddU32(GS_RankCountPrefix + workItemId, rankCountPrefixInWave);
+
+        // NOTE(pamartis): In case if the number of lanes is smaller than `bitsMax + 1`, every wave needs to update local prefix sums of other waves
+        if (laneCnt < outBitsMax + 1)
+        {
+            const uint32_t lastLaneIndex = WaveActiveCountBits(true) - 1;
+            const uint32_t rankIndexWaveSum = WaveReadLaneAt(rankIndexInWave + (rankCount << workItemId), lastLaneIndex);
+            const uint32_t rankCountPrefixWaveSum = WaveReadLaneAt(rankCountPrefixInWave + rankCount, lastLaneIndex);
+
+            for (uint32_t workItemNxt = workItemId + laneCnt; workItemNxt < outBitsMax + 1; workItemNxt += laneCnt)
+            {
+                zstdgpu_LdsAtomicAddU32(GS_RankIndex + workItemNxt, rankIndexWaveSum);
+                zstdgpu_LdsAtomicAddU32(GS_RankCountPrefix + workItemNxt, rankCountPrefixWaveSum);
+            }
+        }
+
+        #else
+        zstdgpu_LdsStoreU32(GS_RankIndex + workItemId, prevRankIndex);
+        prevRankIndex += rankCount << workItemId;
+
+        zstdgpu_LdsStoreU32(GS_RankCountPrefix + workItemId, prevRankCountPrefix);
+        prevRankCountPrefix += rankCount;
+        #endif
+    }
+
+    GroupMemoryBarrierWithGroupSync();
+
+    ZSTDGPU_FOR_WORK_ITEMS(weightId, weightCnt, threadId, threadCnt)
+    {
+        const uint32_t uintIdx = weightId >> 5;
+        const uint32_t uintOfs = weightId & 0x1fu;
+
+        const uint32_t bits = zstdgpu_LdsLoadU32(GS_Bits + weightId);
+
+        #define FetchBitsAndAccumulateMask(mask, bits, storage, bitIdx, uintId)     \
+        const uint32_t bit##bitIdx = zstdgpu_LdsLoadU32(storage + (kzstdgpu_MaxCount_HuffmanWeightsOneDigitBits * bitIdx) + uintId);    \
+            mask &= (((bits >> bitIdx) & 0x1u) + ~0u) ^ bit##bitIdx;
+
+        uint32_t prefix = 0;
+        for (uint32_t uintId = 0; uintId < uintIdx; ++uintId)
+        {
+            uint32_t mask = ~0u;
+
+            FetchBitsAndAccumulateMask(mask, bits, GS_BitsMask, 0, uintId);
+            FetchBitsAndAccumulateMask(mask, bits, GS_BitsMask, 1, uintId);
+            FetchBitsAndAccumulateMask(mask, bits, GS_BitsMask, 2, uintId);
+            FetchBitsAndAccumulateMask(mask, bits, GS_BitsMask, 3, uintId);
+            FetchBitsAndAccumulateMask(mask, bits, GS_BitsMask, 4, uintId);
+            prefix += zstdgpu_CountBitsU32(mask);
+        }
+        uint32_t mask = (1u << uintOfs) - 1u;
+        FetchBitsAndAccumulateMask(mask, bits, GS_BitsMask, 0, uintIdx);
+        FetchBitsAndAccumulateMask(mask, bits, GS_BitsMask, 1, uintIdx);
+        FetchBitsAndAccumulateMask(mask, bits, GS_BitsMask, 2, uintIdx);
+        FetchBitsAndAccumulateMask(mask, bits, GS_BitsMask, 3, uintIdx);
+        FetchBitsAndAccumulateMask(mask, bits, GS_BitsMask, 4, uintIdx);
+        #undef FetchBitsAndAccumulateMask
+        prefix += zstdgpu_CountBitsU32(mask);
+
+        const uint32_t bitsInv = outBitsMax - bits;
+        const uint32_t code = zstdgpu_LdsLoadU32(GS_RankIndex + bitsInv) + (prefix << bitsInv);
+        const uint32_t codePos = zstdgpu_LdsLoadU32(GS_RankCountPrefix + bitsInv) + prefix;
+
+        ZSTDGPU_ASSERT(codePos < kzstdgpu_MaxCount_HuffmanWeights);
+
+        const uint32_t weightIdAndCodePacked = (weightId << 24) | (code & 0x00ffffffu);
+
+        if (isMemStore) /** NOTE(pamartis): This must be a compile-time constant, see the comment at the top of the function */
+        {
+            MEM_CodeAndSymbol[tableId * kzstdgpu_MaxCount_HuffmanWeights + codePos] = weightIdAndCodePacked;
+        }
+        else
+        {
+            zstdgpu_LdsStoreU32(GS_CodeAndSymbol + codePos, weightIdAndCodePacked);
+        }
+
+    }
+    outCodeTableSize = zstdgpu_LdsLoadU32(GS_RankCountPrefix + outBitsMax);
+}
+
+static void zstdgpu_ShaderEntry_InitHuffmanTable(ZSTDGPU_PARAM_INOUT(zstdgpu_InitHuffmanTable_SRT) srt, uint32_t groupId, uint32_t threadId, uint32_t tgSize)
+{
+    ZSTDGPU_START_GROUPSHARED()
+    ZSTDGPU_DECLARE_GROUPSHARED(PreInit         , kzstdgpu_MaxCount_HuffmanWeights
+                                                + kzstdgpu_MaxCount_HuffmanWeightsAllDigitBits
+                                                + kzstdgpu_MaxCount_HuffmanWeightRanks
+                                                + kzstdgpu_MaxCount_HuffmanWeightRanks
+                                                + 2);
+
+    ZSTDGPU_DECLARE_GROUPSHARED(RankIndex       , kzstdgpu_MaxCount_HuffmanWeightRanks);
+    ZSTDGPU_DECLARE_GROUPSHARED(CodeAndSymbol   , 1);
+
+    uint32_t bitsMax = 0;
+    uint32_t codeTableSize = 0;
+    zstdgpu_PreInitHuffmanTableToLds(
+        srt.inDecompressedHuffmanWeights,
+        srt.inDecompressedHuffmanWeightCount,
+        groupId,
+        threadId,
+        tgSize,
+        bitsMax,
+        codeTableSize,
+        GS_PreInit,
+        GS_RankIndex,
+        GS_CodeAndSymbol,
+        srt.inoutHuffmanTableCodeAndSymbol,
+        true
+    );
+    ZSTDGPU_FOR_WORK_ITEMS(workItemId, bitsMax + 1u, threadId, tgSize)
+    {
+        srt.inoutHuffmanTableRankIndex[groupId * kzstdgpu_MaxCount_HuffmanWeightRanks + workItemId] = zstdgpu_LdsLoadU32(GS_RankIndex + workItemId);
+    }
+    if (threadId == 0)
+    {
+        srt.inoutHuffmanTableInfo[groupId] = (bitsMax << 16) | codeTableSize;
+    }
+}
+
+static inline void zstdgpu_DecompressHuffmanCompressedLiterals(ZSTDGPU_RO_BUFFER(uint32_t) CompressedData,
+                                                               ZSTDGPU_RO_BUFFER(uint32_t) LitStreamRemap,
+                                                               ZSTDGPU_RO_BUFFER(zstdgpu_LitStreamInfo) LitRefs,
+                                                               ZSTDGPU_RW_TYPED_BUFFER(uint32_t, uint8_t) DecompressedLiterals,
+#if 1 // ASSUME_11BIT_HUFFMAN_CODES
+                                                               ZSTDGPU_PARAM_LDS_IN(uint32_t) GS_HuffmanTable,
+#else
+                                                               ZSTDGPU_PARAM_LDS_IN(uint32_t) GS_RankIndex,
+                                                               ZSTDGPU_PARAM_LDS_IN(uint32_t) GS_CodeAndSymbol,
+#endif
+                                                               uint32_t groupId,
+                                                               uint32_t threadId,
+                                                               uint32_t htGroupStart,
+                                                               uint32_t htLiteralStart,
+                                                               uint32_t htLiteralCount,
+                                                               uint32_t bitsMax,
+#if 0 // !ASSUME_11BIT_HUFFMAN_CODES
+                                                               uint32_t codeTableSize,
+#endif
+                                                               uint32_t tgSize);
+
+
+static void zstdgpu_ConvertThreadgroupIdToDecompressLiteralsInputs(ZSTDGPU_RO_BUFFER(uint32_t) LitGroupEndPerHuffmanTable,
+                                                                   ZSTDGPU_RO_BUFFER(uint32_t) LitStreamEndPerHuffmanTable,
+                                                                   uint32_t htCount,
+                                                                   uint32_t groupId,
+                                                                   ZSTDGPU_PARAM_INOUT(uint32_t) htIndex,
+                                                                   ZSTDGPU_PARAM_INOUT(uint32_t) htGroupStart,
+                                                                   ZSTDGPU_PARAM_INOUT(uint32_t) htLiteralStart,
+                                                                   ZSTDGPU_PARAM_INOUT(uint32_t) htLiteralCount)
+{
+    htIndex = 0;
     {
         uint32_t rangeBase = 0;
 
         // NOTE(pamartis): This number is the number of compressedBlocks
-        uint32_t rangeSize = srt.huffmanTableSlotCount;
+        uint32_t rangeSize = htCount;
 
         // NOTE(pamartis): Binary search for the right Huffman Table Slot (the actual index is different) */
         while (rangeSize > 1)
@@ -2432,32 +2770,152 @@ static void zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(ZSTDGPU_
             if (rangeNext > 0)
                 rangeLoad = rangeNext - 1;
 
-            const uint32_t groupIdStart = srt.inLitGroupEndPerHuffmanTable[rangeLoad];
+            const uint32_t groupIdStart = LitGroupEndPerHuffmanTable[rangeLoad];
 
             rangeBase = groupId < groupIdStart ? rangeBase : rangeNext;
             rangeSize -= rangeTest;
         }
 
-        htTableIndex = rangeBase;
+        htIndex = rangeBase;
     }
 
-    uint32_t htLiteralCount = srt.inLitStreamEndPerHuffmanTable[htTableIndex];
-    uint32_t htLiteralStart = 0;
+    htLiteralCount = LitStreamEndPerHuffmanTable[htIndex];
+    htLiteralStart = 0;
     //uint32_t htGroupCount = ZstdLitGroupStartPerHuffmanTable[rangeBase];
-    uint32_t htGroupStart = 0;
-    if (htTableIndex > 0)
+    htGroupStart = 0;
+    if (htIndex > 0)
     {
-        htLiteralStart = srt.inLitStreamEndPerHuffmanTable[htTableIndex - 1];
+        htLiteralStart = LitStreamEndPerHuffmanTable[htIndex - 1];
         htLiteralCount -= htLiteralStart;
 
-        htGroupStart = srt.inLitGroupEndPerHuffmanTable[htTableIndex - 1];
+        htGroupStart = LitGroupEndPerHuffmanTable[htIndex - 1];
         //htGroupCount -= htGroupStart;
     }
+}
+
+static void zstdgpu_ShaderEntry_DecompressLiterals(ZSTDGPU_PARAM_INOUT(zstdgpu_DecompressLiterals_SRT) srt, uint32_t groupId, uint32_t threadId, uint32_t tgSize)
+{
+    uint32_t htIndex = 0;
+    uint32_t htGroupStart = 0;
+    uint32_t htLiteralStart = 0;
+    uint32_t htLiteralCount= 0;
+
+    zstdgpu_ConvertThreadgroupIdToDecompressLiteralsInputs(
+        srt.inLitGroupEndPerHuffmanTable,
+        srt.inLitStreamEndPerHuffmanTable,
+        srt.huffmanTableSlotCount,
+        groupId,
+        htIndex,
+        htGroupStart,
+        htLiteralStart,
+        htLiteralCount
+    );
+
+
+    ZSTDGPU_START_GROUPSHARED()
+    ZSTDGPU_DECLARE_GROUPSHARED(HuffmanTable, kzstdgpu_MaxCount_HuffmanTableExpandedUInts);
+
+#if 1 // ASSUME_11BIT_HUFFMAN_CODES
+    const uint32_t htInfo = WaveReadLaneFirst(srt.inHuffmanTableInfo[htIndex]);
+    const uint32_t bitsMax = htInfo >> 16;
+    const uint32_t codeTableSize = htInfo & 0xffffu;
+    const uint32_t stateCnt = WaveReadLaneFirst(srt.inHuffmanTableRankIndex[htIndex * kzstdgpu_MaxCount_HuffmanWeightRanks + bitsMax]);
+
+    // Expand Huffman Table
+    ZSTDGPU_FOR_WORK_ITEMS(stateId, stateCnt, threadId, kzstdgpu_TgSizeX_DecompressLiterals)
+    {
+        const uint32_t symbolIndex = zstdgpu_BinarySearchMasked(srt.inHuffmanTableCodeAndSymbol, htIndex * kzstdgpu_MaxCount_HuffmanWeights, codeTableSize, stateId, 0x00ffffffu);
+        const uint32_t bitcntIndex = zstdgpu_BinarySearchMasked(srt.inHuffmanTableRankIndex, htIndex * kzstdgpu_MaxCount_HuffmanWeightRanks, bitsMax + 1, stateId, 0xffffffffu)
+                                   - htIndex * kzstdgpu_MaxCount_HuffmanWeightRanks;
+        const uint32_t symbol = srt.inHuffmanTableCodeAndSymbol[symbolIndex] >> 24;
+        const uint32_t bitcnt = bitsMax - bitcntIndex;
+
+        zstdgpu_LdsStoreU32(GS_HuffmanTable + stateId, (symbol << 16) | bitcnt);
+    }
+    GroupMemoryBarrierWithGroupSync();
+#endif
+
+    zstdgpu_DecompressHuffmanCompressedLiterals(
+        srt.inCompressedData,
+        srt.inLitStreamRemap,
+        srt.inLitRefs,
+        srt.inoutDecompressedLiterals,
+#if 1 // ASSUME_11BIT_HUFFMAN_CODES
+        GS_HuffmanTable,
+#else
+        GS_RankIndex,
+        GS_CodeAndSymbol,
+#endif
+        groupId,
+        threadId,
+        htGroupStart,
+        htLiteralStart,
+        htLiteralCount,
+        bitsMax,
+#if 0 // !ASSUME_11BIT_HUFFMAN_CODES
+        codeTableSize,
+#endif
+        tgSize
+    );
+}
+
+static void zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(ZSTDGPU_PARAM_INOUT(zstdgpu_InitHuffmanTable_And_DecompressLiterals_SRT) srt, uint32_t groupId, uint32_t threadId)
+{
+    uint32_t htIndex = 0;
+    uint32_t htGroupStart = 0;
+    uint32_t htLiteralStart = 0;
+    uint32_t htLiteralCount= 0;
+
+    zstdgpu_ConvertThreadgroupIdToDecompressLiteralsInputs(
+        srt.inLitGroupEndPerHuffmanTable,
+        srt.inLitStreamEndPerHuffmanTable,
+        srt.huffmanTableSlotCount,
+        groupId,
+        htIndex,
+        htGroupStart,
+        htLiteralStart,
+        htLiteralCount
+    );
 
     //
     // The start of the Huffman Table initialisation
     //
-    const uint32_t weightCntMinusOne = srt.inDecompressedHuffmanWeightCount[htTableIndex];
+#if 1
+    ZSTDGPU_START_GROUPSHARED()
+    ZSTDGPU_DECLARE_GROUPSHARED(CodeAndSymbol   , kzstdgpu_MaxCount_HuffmanWeights);
+    ZSTDGPU_DECLARE_GROUPSHARED(PreInit         , kzstdgpu_MaxCount_HuffmanWeights
+                                                + kzstdgpu_MaxCount_HuffmanWeightsAllDigitBits
+                                                + kzstdgpu_MaxCount_HuffmanWeightRanks
+                                                + kzstdgpu_MaxCount_HuffmanWeightRanks
+                                                + 2);
+
+    ZSTDGPU_DECLARE_GROUPSHARED(RankIndex       , kzstdgpu_MaxCount_HuffmanWeightRanks);
+    ZSTDGPU_DECLARE_GROUPSHARED(HuffmanTable    , kzstdgpu_MaxCount_HuffmanTableExpandedUInts);
+
+    ZSTDGPU_RW_BUFFER(uint32_t) dummyBuffer;
+    #ifndef __hlsl_dx_compiler
+    dummyBuffer = 0;
+    #endif
+
+    uint32_t bitsMax = 0;
+    uint32_t codeTableSize = 0;
+    zstdgpu_PreInitHuffmanTableToLds(
+        srt.inDecompressedHuffmanWeights,
+        srt.inDecompressedHuffmanWeightCount,
+        htIndex,
+        threadId,
+        kzstdgpu_TgSizeX_DecompressLiterals,
+        bitsMax,
+        codeTableSize,
+        GS_PreInit,
+        GS_RankIndex,
+        GS_CodeAndSymbol,
+        dummyBuffer,
+        false
+    );
+
+#else
+    const uint32_t weightCntMinusOne = srt.inDecompressedHuffmanWeightCount[htIndex];
 
     ZSTDGPU_START_GROUPSHARED()
     ZSTDGPU_DECLARE_GROUPSHARED(Bits          , kzstdgpu_MaxCount_HuffmanWeights); //< WARN(pamartis): Wasteful, need only uint8_t but HLSL doesn't support it
@@ -2502,7 +2960,7 @@ static void zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(ZSTDGPU_
 
     ZSTDGPU_FOR_WORK_ITEMS(i, weightCntMinusOne, threadId, kzstdgpu_TgSizeX_DecompressLiterals)
     {
-        const uint32_t weight = srt.inDecompressedHuffmanWeights[htTableIndex * kzstdgpu_MaxCount_HuffmanWeights + i];
+        const uint32_t weight = srt.inDecompressedHuffmanWeights[htIndex * kzstdgpu_MaxCount_HuffmanWeights + i];
 
         // weights are in range [0;16], so the maximim accumulated value is 0x8000
         const uint32_t weightSumPerWave = WaveActiveSum(weight > 0u ? (1u << (weight - 1u)) : 0u);
@@ -2537,44 +2995,11 @@ static void zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(ZSTDGPU_
     const uint32_t waveIdx = WaveReadLaneFirst(threadId / laneCnt);
     //const uint32_t laneIdx = threadId % laneCnt;
 
-    #define zstdgpu_Store_VGPR_Bit_PerTg(laneCnt, storage, VGPR, waveId, bitIdx)                    \
-        {                                                                                           \
-            const uint32_t4 b = WaveActiveBallot((VGPR & (1u << bitIdx)) != 0);                     \
-            if (laneCnt <= 16)                                                                      \
-            {                                                                                       \
-                const uint32_t offset = kzstdgpu_MaxCount_HuffmanWeightsOneDigitBits * (bitIdx);    \
-                const uint32_t ballotMaskCntInUInt = 32 / laneCnt;                                  \
-                const uint32_t ballotMaskUIntIndex = (waveId) / ballotMaskCntInUInt + offset;       \
-                const uint32_t ballotMaskIdInUInt = (waveId) % ballotMaskCntInUInt;                 \
-                zstdgpu_LdsAtomicOrU32(storage + ballotMaskUIntIndex, b.x << (ballotMaskIdInUInt * laneCnt)); \
-            }                                                                                       \
-            else if (laneCnt == 32)                                                                 \
-            {                                                                                       \
-                const uint32_t offset = kzstdgpu_MaxCount_HuffmanWeightsOneDigitBits * (bitIdx) + (waveId);      \
-                zstdgpu_LdsStoreU32(storage + offset + 0, b.x);                                     \
-            }                                                                                       \
-            else if (laneCnt == 64)                                                                 \
-            {                                                                                       \
-                const uint32_t offset = kzstdgpu_MaxCount_HuffmanWeightsOneDigitBits * (bitIdx) + (waveId) * 2;  \
-                zstdgpu_LdsStoreU32(storage + offset + 0, b.x);                                     \
-                zstdgpu_LdsStoreU32(storage + offset + 1, b.y);                                     \
-            }                                                                                       \
-            /* for some GPUs with 128-wide waves, store extra masks*/                               \
-            else                                                                                    \
-            {                                                                                       \
-                const uint32_t offset = kzstdgpu_MaxCount_HuffmanWeightsOneDigitBits * (bitIdx) + (waveId) * 4;  \
-                zstdgpu_LdsStoreU32(storage + offset + 0, b.x);                                     \
-                zstdgpu_LdsStoreU32(storage + offset + 1, b.y);                                     \
-                zstdgpu_LdsStoreU32(storage + offset + 2, b.z);                                     \
-                zstdgpu_LdsStoreU32(storage + offset + 3, b.w);                                     \
-            }                                                                                       \
-        }
-
     uint32_t waveOfs = waveIdx;
     const uint32_t weightCnt = weightCntMinusOne + 1;
     ZSTDGPU_FOR_WORK_ITEMS(weightId, weightCnt, threadId, kzstdgpu_TgSizeX_DecompressLiterals)
     {
-        const uint32_t weight = srt.inDecompressedHuffmanWeights[htTableIndex * kzstdgpu_MaxCount_HuffmanWeights + weightId];
+        const uint32_t weight = srt.inDecompressedHuffmanWeights[htIndex * kzstdgpu_MaxCount_HuffmanWeights + weightId];
 
         uint32_t bits = 0u;
         if (weightId < weightCntMinusOne)
@@ -2588,12 +3013,11 @@ static void zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(ZSTDGPU_
 
         zstdgpu_LdsStoreU32(GS_Bits + weightId, bits);
 
-        zstdgpu_Store_VGPR_Bit_PerTg(laneCnt, GS_BitsMask, bits, waveOfs, 0);
-        zstdgpu_Store_VGPR_Bit_PerTg(laneCnt, GS_BitsMask, bits, waveOfs, 1);
-        zstdgpu_Store_VGPR_Bit_PerTg(laneCnt, GS_BitsMask, bits, waveOfs, 2);
-        zstdgpu_Store_VGPR_Bit_PerTg(laneCnt, GS_BitsMask, bits, waveOfs, 3);
-        zstdgpu_Store_VGPR_Bit_PerTg(laneCnt, GS_BitsMask, bits, waveOfs, 4);
-        #undef zstdgpu_Store_VGPR_Bit_PerTg
+        zstdgpu_GroupBallotLdsStore(laneCnt, bits, GS_BitsMask, kzstdgpu_MaxCount_HuffmanWeightsOneDigitBits, waveOfs, 0);
+        zstdgpu_GroupBallotLdsStore(laneCnt, bits, GS_BitsMask, kzstdgpu_MaxCount_HuffmanWeightsOneDigitBits, waveOfs, 1);
+        zstdgpu_GroupBallotLdsStore(laneCnt, bits, GS_BitsMask, kzstdgpu_MaxCount_HuffmanWeightsOneDigitBits, waveOfs, 2);
+        zstdgpu_GroupBallotLdsStore(laneCnt, bits, GS_BitsMask, kzstdgpu_MaxCount_HuffmanWeightsOneDigitBits, waveOfs, 3);
+        zstdgpu_GroupBallotLdsStore(laneCnt, bits, GS_BitsMask, kzstdgpu_MaxCount_HuffmanWeightsOneDigitBits, waveOfs, 4);
 
         const uint32_t bitsMaxPerWave = WaveActiveMax(bits);
 
@@ -2647,22 +3071,6 @@ static void zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(ZSTDGPU_
         prevRankCountPrefix += rankCount;
     #endif
     }
-    // NOTE(pamartis): helper to determine the starting number of bits
-    #define zstdgpu_GetBitcnt(outNumBits, inState)                                      \
-        {                                                                               \
-            uint32_t rangeBase = 0;                                                     \
-            uint32_t rangeSize = bitsMax + 1u;                                          \
-                                                                                        \
-            while (rangeSize > 1)                                                       \
-            {                                                                           \
-                const uint32_t rangeTest = rangeSize >> 1;                              \
-                const uint32_t rangeNext = rangeBase + rangeTest;                       \
-                                                                                        \
-                rangeBase = inState < zstdgpu_LdsLoadU32(GS_RankIndex + rangeNext) ? rangeBase : rangeNext;\
-                rangeSize -= rangeTest;                                                 \
-            }                                                                           \
-            outNumBits = bitsMax - rangeBase;                                           \
-        }
 
     GroupMemoryBarrierWithGroupSync();
 
@@ -2706,25 +3114,7 @@ static void zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(ZSTDGPU_
         zstdgpu_LdsStoreU32(GS_CodeAndSymbol + codePos, (weightId << 24) | (code & 0x00ffffffu));
     }
     const uint32_t codeTableSize = zstdgpu_LdsLoadU32(GS_RankCountPrefix + bitsMax);
-    const uint32_t maxBitcntMask = (1u << bitsMax) - 1u;
-
-    // NOTE(pamartis): helper to determine the symbol
-    #define zstdgpu_GetSymbol(outSymbol, inState)                                       \
-        {                                                                               \
-            uint32_t rangeBase = 0;                                                     \
-            uint32_t rangeSize = codeTableSize;                        \
-                                                                                        \
-            while (rangeSize > 1)                                                       \
-            {                                                                           \
-                const uint32_t rangeTest = rangeSize >> 1;                              \
-                const uint32_t rangeNext = rangeBase + rangeTest;                       \
-                                                                                        \
-                const uint32_t code = zstdgpu_LdsLoadU32(GS_CodeAndSymbol + rangeNext) & 0x00ffffffu;\
-                rangeBase = inState < code ? rangeBase : rangeNext;                     \
-                rangeSize -= rangeTest;                                                 \
-            }                                                                           \
-            outSymbol = zstdgpu_LdsLoadU32(GS_CodeAndSymbol + rangeBase) >> 24;         \
-        }
+#endif
 
     GroupMemoryBarrierWithGroupSync();
 
@@ -2734,32 +3124,76 @@ static void zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(ZSTDGPU_
     // Expand Huffman Table
     ZSTDGPU_FOR_WORK_ITEMS(stateId, stateCnt, threadId, kzstdgpu_TgSizeX_DecompressLiterals)
     {
-        uint32_t symbol = 0;
-        uint32_t bitcnt = 0;
-        zstdgpu_GetSymbol(symbol, stateId);
-        zstdgpu_GetBitcnt(bitcnt, stateId);
-        #undef zstdgpu_GetSymbol
-        #undef zstdgpu_GetBitcnt
+        const uint32_t symbolIndex = zstdgpu_BinarySearchLds(GS_CodeAndSymbol, 0, codeTableSize, stateId, 0x00ffffffu);
+        const uint32_t bitcntIndex = zstdgpu_BinarySearchLds(GS_RankIndex, 0, bitsMax + 1, stateId, 0xffffffffu);
+        const uint32_t symbol = zstdgpu_LdsLoadU32(GS_CodeAndSymbol + symbolIndex) >> 24;
+        const uint32_t bitcnt = bitsMax - bitcntIndex;
+
         zstdgpu_LdsStoreU32(GS_HuffmanTable + stateId, (symbol << 16) | bitcnt);
     }
     GroupMemoryBarrierWithGroupSync();
 #endif
 
+    zstdgpu_DecompressHuffmanCompressedLiterals(
+        srt.inCompressedData,
+        srt.inLitStreamRemap,
+        srt.inLitRefs,
+        srt.inoutDecompressedLiterals,
+#if 1 // ASSUME_11BIT_HUFFMAN_CODES
+        GS_HuffmanTable,
+#else
+        GS_RankIndex,
+        GS_CodeAndSymbol,
+#endif
+        groupId,
+        threadId,
+        htGroupStart,
+        htLiteralStart,
+        htLiteralCount,
+        bitsMax,
+#if 0 // !ASSUME_11BIT_HUFFMAN_CODES
+        codeTableSize,
+#endif
+        kzstdgpu_TgSizeX_DecompressLiterals
+    );
+}
+
+void zstdgpu_DecompressHuffmanCompressedLiterals(ZSTDGPU_RO_BUFFER(uint32_t) CompressedData,
+                                                 ZSTDGPU_RO_BUFFER(uint32_t) LitStreamRemap,
+                                                 ZSTDGPU_RO_BUFFER(zstdgpu_LitStreamInfo) LitRefs,
+                                                 ZSTDGPU_RW_TYPED_BUFFER(uint32_t, uint8_t) DecompressedLiterals,
+#if 1 // ASSUME_11BIT_HUFFMAN_CODES
+                                                 ZSTDGPU_PARAM_LDS_IN(uint32_t) GS_HuffmanTable,
+#else
+                                                 ZSTDGPU_PARAM_LDS_IN(uint32_t) GS_RankIndex,
+                                                 ZSTDGPU_PARAM_LDS_IN(uint32_t) GS_CodeAndSymbol,
+#endif
+                                                 uint32_t groupId,
+                                                 uint32_t threadId,
+                                                 uint32_t htGroupStart,
+                                                 uint32_t htLiteralStart,
+                                                 uint32_t htLiteralCount,
+                                                 uint32_t bitsMax,
+#if 0 // !ASSUME_11BIT_HUFFMAN_CODES
+                                                 uint32_t codeTableSize,
+#endif
+                                                 uint32_t tgSize)
+{
+    ZSTDGPU_UNUSED(threadId);
+    const uint32_t maxBitcntMask = (1u << bitsMax) - 1u;
     //
     // The start of decompression of Huffman-compressed literals
     //
-    //const uint32_t literalIndex = (groupId - htGroupStart) * kzstdgpu_TgSizeX_DecompressLiterals + threadId;
-
-    const uint32_t thisGroupLiteralStart = (groupId - htGroupStart) * kzstdgpu_TgSizeX_DecompressLiterals;
-    const uint32_t thisGroupLiteralRemain = zstdgpu_MinU32(htLiteralCount - thisGroupLiteralStart, kzstdgpu_TgSizeX_DecompressLiterals);
-    ZSTDGPU_FOR_WORK_ITEMS(literalIndex, thisGroupLiteralRemain, threadId, kzstdgpu_TgSizeX_DecompressLiterals)
+    const uint32_t thisGroupLiteralStart = (groupId - htGroupStart) * tgSize;
+    const uint32_t thisGroupLiteralRemain = zstdgpu_MinU32(htLiteralCount - thisGroupLiteralStart, tgSize);
+    ZSTDGPU_FOR_WORK_ITEMS(literalIndex, thisGroupLiteralRemain, threadId, tgSize)
     {
-        const uint32_t literalStreamId = srt.inLitStreamRemap[htLiteralStart + thisGroupLiteralStart + literalIndex];
+        const uint32_t literalStreamId = LitStreamRemap[htLiteralStart + thisGroupLiteralStart + literalIndex];
 
-        zstdgpu_LitStreamInfo compressedLiteral = srt.inLitRefs[literalStreamId];
+        zstdgpu_LitStreamInfo compressedLiteral = LitRefs[literalStreamId];
 
         zstdgpu_Backward_BitBuffer_V0 bitBuffer;
-        zstdgpu_Backward_BitBuffer_V0_InitWithSegment(bitBuffer, srt.inCompressedData, compressedLiteral.src);
+        zstdgpu_Backward_BitBuffer_V0_InitWithSegment(bitBuffer, CompressedData, compressedLiteral.src);
 
         uint32_t state = zstdgpu_Backward_BitBuffer_V0_Get_Huffman(bitBuffer, bitsMax, bitsMax);
         uint32_t decodedByteCnt = 0;
@@ -2770,17 +3204,15 @@ static void zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(ZSTDGPU_
             const uint32_t symbol = symbolAndBitcnt >> 16;
             const uint32_t bitcnt = symbolAndBitcnt & 0xffffu;
 #else
-            uint32_t symbol = 0;
-            uint32_t bitcnt = 0;
-            zstdgpu_GetSymbol(symbol, state);
-            zstdgpu_GetBitcnt(bitcnt, state);
-            #undef zstdgpu_GetSymbol
-            #undef zstdgpu_GetBitcnt
+            const uint32_t symbolIndex = zstdgpu_BinarySearchLds(GS_CodeAndSymbol, 0, codeTableSize, state, 0x00ffffffu);
+            const uint32_t bitcntIndex = zstdgpu_BinarySearchLds(GS_RankIndex, 0, bitsMax + 1, state, 0xffffffffu);
+            const uint32_t symbol = zstdgpu_LdsLoadU32(GS_CodeAndSymbol + symbolIndex) >> 24;
+            const uint32_t bitcnt = bitsMax - bitcntIndex;
 #endif
 
             // FIXME/TODO(pamartis): Experiment with storing data to LDS first (we have some allocated but unused)
             // and then to memory. At least try small LDS cache of 32-dwords per literal
-            zstdgpu_TypedStoreU8(srt.inoutDecompressedLiterals, compressedLiteral.dst.offs + decodedByteCnt++, symbol);
+            zstdgpu_TypedStoreU8(DecompressedLiterals, compressedLiteral.dst.offs + decodedByteCnt++, symbol);
 
             if (zstdgpu_Backward_BitBuffer_V0_CanRefill_Huffman(bitBuffer, bitcnt))
             {

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -2722,7 +2722,7 @@ static void zstdgpu_ShaderEntry_InitHuffmanTable(ZSTDGPU_PARAM_INOUT(zstdgpu_Ini
     }
 }
 
-static inline void zstdgpu_DecompressHuffmanCompressedLiterals(ZSTDGPU_RO_BUFFER(uint32_t) CompressedData,
+static inline void zstdgpu_DecompressHuffmanCompressedLiterals(ZSTDGPU_RO_RAW_BUFFER(uint32_t) CompressedData,
                                                                ZSTDGPU_RO_BUFFER(uint32_t) LitStreamRemap,
                                                                ZSTDGPU_RO_BUFFER(zstdgpu_LitStreamInfo) LitRefs,
                                                                ZSTDGPU_RW_TYPED_BUFFER(uint32_t, uint8_t) DecompressedLiterals,
@@ -3158,7 +3158,7 @@ static void zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(ZSTDGPU_
     );
 }
 
-void zstdgpu_DecompressHuffmanCompressedLiterals(ZSTDGPU_RO_BUFFER(uint32_t) CompressedData,
+void zstdgpu_DecompressHuffmanCompressedLiterals(ZSTDGPU_RO_RAW_BUFFER(uint32_t) CompressedData,
                                                  ZSTDGPU_RO_BUFFER(uint32_t) LitStreamRemap,
                                                  ZSTDGPU_RO_BUFFER(zstdgpu_LitStreamInfo) LitRefs,
                                                  ZSTDGPU_RW_TYPED_BUFFER(uint32_t, uint8_t) DecompressedLiterals,
@@ -3189,7 +3189,43 @@ void zstdgpu_DecompressHuffmanCompressedLiterals(ZSTDGPU_RO_BUFFER(uint32_t) Com
     ZSTDGPU_FOR_WORK_ITEMS(literalIndex, thisGroupLiteralRemain, threadId, tgSize)
     {
         const uint32_t literalStreamId = LitStreamRemap[htLiteralStart + thisGroupLiteralStart + literalIndex];
+
         zstdgpu_LitStreamInfo compressedLiteral = LitRefs[literalStreamId];
+
+#if 0
+        zstdgpu_Backward_BitBuffer_V0 bitBuffer;
+        zstdgpu_Backward_BitBuffer_V0_InitWithSegment(bitBuffer, CompressedData, compressedLiteral.src);
+
+        uint32_t state = zstdgpu_Backward_BitBuffer_V0_Get_Huffman(bitBuffer, bitsMax, bitsMax);
+        uint32_t decodedByteCnt = 0;
+        while (decodedByteCnt < compressedLiteral.dst.size)
+        {
+#if 1 // ASSUME_11BIT_HUFFMAN_CODES
+            const uint32_t symbolAndBitcnt = zstdgpu_LdsLoadU32(GS_HuffmanTable + state);
+            const uint32_t symbol = symbolAndBitcnt >> 16;
+            const uint32_t bitcnt = symbolAndBitcnt & 0xffffu;
+#else
+            const uint32_t symbolIndex = zstdgpu_BinarySearchLds(GS_CodeAndSymbol, 0, codeTableSize, state, 0x00ffffffu);
+            const uint32_t bitcntIndex = zstdgpu_BinarySearchLds(GS_RankIndex, 0, bitsMax + 1, state, 0xffffffffu);
+            const uint32_t symbol = zstdgpu_LdsLoadU32(GS_CodeAndSymbol + symbolIndex) >> 24;
+            const uint32_t bitcnt = bitsMax - bitcntIndex;
+#endif
+
+            // FIXME/TODO(pamartis): Experiment with storing data to LDS first (we have some allocated but unused)
+            // and then to memory. At least try small LDS cache of 32-dwords per literal
+            zstdgpu_TypedStoreU8(DecompressedLiterals, compressedLiteral.dst.offs + decodedByteCnt++, symbol);
+
+            if (zstdgpu_Backward_BitBuffer_V0_CanRefill_Huffman(bitBuffer, bitcnt))
+            {
+                const uint32_t rest = zstdgpu_Backward_BitBuffer_V0_Get_Huffman(bitBuffer, bitcnt, bitsMax);
+                state = ((state << bitcnt) + rest) & maxBitcntMask;
+            }
+            else
+            {
+                break;
+            }
+        }
+#else
         if (compressedLiteral.dst.size != 0) // derived from block Regenerated_Size
         {
             zstdgpu_HuffmanStream stream;
@@ -3216,6 +3252,7 @@ void zstdgpu_DecompressHuffmanCompressedLiterals(ZSTDGPU_RO_BUFFER(uint32_t) Com
                 zstdgpu_HuffmanStream_Consume(stream, bitcnt);
             } while (decodedByteCnt < compressedLiteral.dst.size);
         }
+#endif
     }
 }
 

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -2764,13 +2764,14 @@ static void zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(ZSTDGPU_
         if (compressedLiteral.dst.size == 0) // derived from block Regenerated_Size
             continue;
 
-        zstdgpu_Backward_BitBuffer_V0 bitBuffer;
-        zstdgpu_Backward_BitBuffer_V0_InitWithSegment(bitBuffer, srt.inCompressedData, compressedLiteral.src);
-
-        uint32_t state = zstdgpu_Backward_BitBuffer_V0_Get_Huffman(bitBuffer, bitsMax, bitsMax);
+        HuffmanStream stream;
+        zstdgpu_HuffmanStream_InitWithSegment(stream, srt.inCompressedData, compressedLiteral.src, bitsMax);
         uint32_t decodedByteCnt = 0;
-        for (;;)
+        do
         {
+            zstdgpu_HuffmanStream_Refill(stream);
+            const uint32_t state = zstdgpu_HuffmanStream_Peek(stream);
+
 #if 1 // ASSUME_11BIT_HUFFMAN_CODES
             const uint32_t symbolAndBitcnt = zstdgpu_LdsLoadU32(GS_HuffmanTable + state);
             const uint32_t symbol = symbolAndBitcnt >> 16;
@@ -2784,17 +2785,13 @@ static void zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(ZSTDGPU_
             #undef zstdgpu_GetBitcnt
 #endif
 
-            // FIXME/TODO(pamartis): Experiment with storing data to LDS first (we have some allocated but unused)
-            // and then to memory. At least try small LDS cache of 32-dwords per literal
+            // TODO(jweinste): Experiment with partial-loop-unrolling with R8G8B8A8_UINT UAV.
             zstdgpu_TypedStoreU8(srt.inoutDecompressedLiterals, compressedLiteral.dst.offs + decodedByteCnt++, symbol);
 
-            if (decodedByteCnt == compressedLiteral.dst.size)
-            {
-                break;
-            }
-            const uint32_t rest = zstdgpu_Backward_BitBuffer_V0_Get_Huffman(bitBuffer, bitcnt, bitsMax);
-            state = ((state << bitcnt) + rest) & maxBitcntMask;
-        }
+            // _Consume is "harmless" here; don't need to mid-break on (decodedByteCnt == compressedLiteral.dst.size).
+            // A classic "do-while" loop _might_ compile better.
+            zstdgpu_HuffmanStream_Consume(stream, bitcnt);
+        } while (decodedByteCnt < compressedLiteral.dst.size);
     }
 }
 

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -2755,44 +2755,37 @@ static void zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(ZSTDGPU_
     ZSTDGPU_FOR_WORK_ITEMS(literalIndex, thisGroupLiteralRemain, threadId, kzstdgpu_TgSizeX_DecompressLiterals)
     {
         const uint32_t literalStreamId = srt.inLitStreamRemap[htLiteralStart + thisGroupLiteralStart + literalIndex];
-
         zstdgpu_LitStreamInfo compressedLiteral = srt.inLitRefs[literalStreamId];
-        // Possibly useful too:
-        // "The process continues up to reading the required number of symbols per stream.
-        // If a bitstream is not entirely and exactly consumed, hence reaching exactly its beginning position with all bits consumed,
-        // the decoding process is considered faulty."
-        if (compressedLiteral.dst.size == 0) // derived from block Regenerated_Size
-            continue;
-
-        HuffmanStream stream;
-        zstdgpu_HuffmanStream_InitWithSegment(stream, srt.inCompressedData, compressedLiteral.src, bitsMax);
-
-        uint32_t decodedByteCnt = 0;
-        do
+        if (compressedLiteral.dst.size != 0) // derived from block Regenerated_Size
         {
-            zstdgpu_HuffmanStream_Refill(stream);
-            const uint32_t state = zstdgpu_HuffmanStream_Peek(stream);
+            zstdgpu_HuffmanStream stream;
+            zstdgpu_HuffmanStream_InitWithSegment(stream, srt.inCompressedData, compressedLiteral.src, bitsMax);
 
+            uint32_t decodedByteCnt = 0;
+            do
+            {
+                const uint32_t state = zstdgpu_HuffmanStream_RefillAndPeek(stream);
 #if 1 // ASSUME_11BIT_HUFFMAN_CODES
-            const uint32_t symbolAndBitcnt = zstdgpu_LdsLoadU32(GS_HuffmanTable + state);
-            const uint32_t symbol = symbolAndBitcnt >> 16;
-            const uint32_t bitcnt = symbolAndBitcnt & 0xffffu;
+                const uint32_t symbolAndBitcnt = zstdgpu_LdsLoadU32(GS_HuffmanTable + state);
+                const uint32_t symbol = symbolAndBitcnt >> 16;
+                const uint32_t bitcnt = symbolAndBitcnt & 0xffffu;
 #else
-            uint32_t symbol = 0;
-            uint32_t bitcnt = 0;
-            zstdgpu_GetSymbol(symbol, state);
-            zstdgpu_GetBitcnt(bitcnt, state);
-            #undef zstdgpu_GetSymbol
-            #undef zstdgpu_GetBitcnt
+                uint32_t symbol = 0;
+                uint32_t bitcnt = 0;
+                zstdgpu_GetSymbol(symbol, state);
+                zstdgpu_GetBitcnt(bitcnt, state);
+                #undef zstdgpu_GetSymbol
+                #undef zstdgpu_GetBitcnt
 #endif
+                // FIXME/TODO(pamartis): Experiment with storing data to LDS first (we have some allocated but unused)
+                // and then to memory. At least try small LDS cache of 32-dwords per literal
+                zstdgpu_TypedStoreU8(srt.inoutDecompressedLiterals, compressedLiteral.dst.offs + decodedByteCnt++, symbol);
 
-            // TODO(jweinste): Experiment with partial-loop-unrolling with R8G8B8A8_UINT UAV.
-            zstdgpu_TypedStoreU8(srt.inoutDecompressedLiterals, compressedLiteral.dst.offs + decodedByteCnt++, symbol);
-
-            // _Consume is "harmless" here; don't need to mid-break on (decodedByteCnt == compressedLiteral.dst.size).
-            // A classic "do-while" loop _might_ compile better.
-            zstdgpu_HuffmanStream_Consume(stream, bitcnt);
-        } while (decodedByteCnt < compressedLiteral.dst.size);
+                // Consume() is not illegal here; it's not needed to mid-break on (decodedByteCnt == compressedLiteral.dst.size).
+                // A more conventional do-while loop might compile better.
+                zstdgpu_HuffmanStream_Consume(stream, bitcnt);
+            } while (decodedByteCnt < compressedLiteral.dst.size);
+        }
     }
 }
 

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -2757,13 +2757,19 @@ static void zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(ZSTDGPU_
         const uint32_t literalStreamId = srt.inLitStreamRemap[htLiteralStart + thisGroupLiteralStart + literalIndex];
 
         zstdgpu_LitStreamInfo compressedLiteral = srt.inLitRefs[literalStreamId];
+        // Possibly useful too:
+        // "The process continues up to reading the required number of symbols per stream.
+        // If a bitstream is not entirely and exactly consumed, hence reaching exactly its beginning position with all bits consumed,
+        // the decoding process is considered faulty."
+        if (compressedLiteral.dst.size == 0) // derived from block Regenerated_Size
+            continue;
 
         zstdgpu_Backward_BitBuffer_V0 bitBuffer;
         zstdgpu_Backward_BitBuffer_V0_InitWithSegment(bitBuffer, srt.inCompressedData, compressedLiteral.src);
 
         uint32_t state = zstdgpu_Backward_BitBuffer_V0_Get_Huffman(bitBuffer, bitsMax, bitsMax);
         uint32_t decodedByteCnt = 0;
-        while (decodedByteCnt < compressedLiteral.dst.size)
+        for (;;)
         {
 #if 1 // ASSUME_11BIT_HUFFMAN_CODES
             const uint32_t symbolAndBitcnt = zstdgpu_LdsLoadU32(GS_HuffmanTable + state);
@@ -2782,18 +2788,14 @@ static void zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(ZSTDGPU_
             // and then to memory. At least try small LDS cache of 32-dwords per literal
             zstdgpu_TypedStoreU8(srt.inoutDecompressedLiterals, compressedLiteral.dst.offs + decodedByteCnt++, symbol);
 
-            if (zstdgpu_Backward_BitBuffer_V0_CanRefill_Huffman(bitBuffer, bitcnt))
-            {
-                const uint32_t rest = zstdgpu_Backward_BitBuffer_V0_Get_Huffman(bitBuffer, bitcnt, bitsMax);
-                state = ((state << bitcnt) + rest) & maxBitcntMask;
-            }
-            else
+            if (decodedByteCnt == compressedLiteral.dst.size)
             {
                 break;
             }
+            const uint32_t rest = zstdgpu_Backward_BitBuffer_V0_Get_Huffman(bitBuffer, bitcnt, bitsMax);
+            state = ((state << bitcnt) + rest) & maxBitcntMask;
         }
     }
-
 }
 
 #ifdef __hlsl_dx_compiler

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -2780,9 +2780,7 @@ static void zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(ZSTDGPU_
                 // FIXME/TODO(pamartis): Experiment with storing data to LDS first (we have some allocated but unused)
                 // and then to memory. At least try small LDS cache of 32-dwords per literal
                 zstdgpu_TypedStoreU8(srt.inoutDecompressedLiterals, compressedLiteral.dst.offs + decodedByteCnt++, symbol);
-
-                // Consume() is not illegal here; it's not needed to mid-break on (decodedByteCnt == compressedLiteral.dst.size).
-                // A more conventional do-while loop might compile better.
+                // It could make sense to mid-break on (decodedByteCnt == compressedLiteral.dst.size) instead.
                 zstdgpu_HuffmanStream_Consume(stream, bitcnt);
             } while (decodedByteCnt < compressedLiteral.dst.size);
         }

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -2766,6 +2766,7 @@ static void zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(ZSTDGPU_
 
         HuffmanStream stream;
         zstdgpu_HuffmanStream_InitWithSegment(stream, srt.inCompressedData, compressedLiteral.src, bitsMax);
+
         uint32_t decodedByteCnt = 0;
         do
         {

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -103,6 +103,22 @@
 #   endif
 #endif
 
+#ifndef ZSTDGPU_PARAM_LDS_IN
+#   ifdef __hlsl_dx_compiler
+#       define ZSTDGPU_PARAM_LDS_IN(type) type
+#   else
+#       define ZSTDGPU_PARAM_LDS_IN(type) const type *
+#   endif
+#endif
+
+#ifndef ZSTDGPU_PARAM_LDS_INOUT
+#   ifdef __hlsl_dx_compiler
+#       define ZSTDGPU_PARAM_LDS_INOUT(type) type
+#   else
+#       define ZSTDGPU_PARAM_LDS_INOUT(type) type *
+#   endif
+#endif
+
 #ifndef ZSTDGPU_BRANCH
 #   ifdef __hlsl_dx_compiler
 #      define ZSTDGPU_BRANCH [branch]
@@ -178,23 +194,23 @@ static const uint32_t kzstdgpu_CounterIndex_DecompressSequencesGroups = 24;
 
 static const uint32_t kzstdgpu_CounterIndex_HUF_WgtStreams = 27;
 
-static const uint32_t kzstdgpu_CounterIndex_Seq_Streams_DecodedItems = 28;
-static const uint32_t kzstdgpu_CounterIndex_HUF_Streams_DecodedBytes = 29;
-static const uint32_t kzstdgpu_CounterIndex_Seq_Streams = 30;
-static const uint32_t kzstdgpu_CounterIndex_HUF_Streams = 31;
-static const uint32_t kzstdgpu_CounterIndex_RAW_Streams = 32;
-static const uint32_t kzstdgpu_CounterIndex_RLE_Streams = 33;
+static const uint32_t kzstdgpu_CounterIndex_Seq_Streams_DecodedItems = 30;
+static const uint32_t kzstdgpu_CounterIndex_HUF_Streams_DecodedBytes = 31;
+static const uint32_t kzstdgpu_CounterIndex_Seq_Streams = 32;
+static const uint32_t kzstdgpu_CounterIndex_HUF_Streams = 33;
+static const uint32_t kzstdgpu_CounterIndex_RAW_Streams = 34;
+static const uint32_t kzstdgpu_CounterIndex_RLE_Streams = 35;
 
-static const uint32_t kzstdgpu_CounterIndex_Blocks_RAW = 34;
-static const uint32_t kzstdgpu_CounterIndex_Blocks_RLE = 35;
-static const uint32_t kzstdgpu_CounterIndex_Blocks_CMP = 36;
+static const uint32_t kzstdgpu_CounterIndex_Blocks_RAW = 36;
+static const uint32_t kzstdgpu_CounterIndex_Blocks_RLE = 37;
+static const uint32_t kzstdgpu_CounterIndex_Blocks_CMP = 38;
 
-static const uint32_t kzstdgpu_CounterIndex_BlocksBytes_RAW = 37;
-static const uint32_t kzstdgpu_CounterIndex_BlocksBytes_RLE = 38;
+static const uint32_t kzstdgpu_CounterIndex_BlocksBytes_RAW = 39;
+static const uint32_t kzstdgpu_CounterIndex_BlocksBytes_RLE = 40;
 
-static const uint32_t kzstdgpu_CounterIndex_Frames = 39;
-static const uint32_t kzstdgpu_CounterIndex_Frames_UncompressedByteSize = 40;
-static const uint32_t kzstdgpu_CounterIndex_Count = 42;
+static const uint32_t kzstdgpu_CounterIndex_Frames = 41;
+static const uint32_t kzstdgpu_CounterIndex_Frames_UncompressedByteSize = 42;
+static const uint32_t kzstdgpu_CounterIndex_Count = 43;
 
 // NOTE(pamartis):
 //      We use macro here to make sure we can use them to compile-out
@@ -1324,6 +1340,14 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
     ZSTDGPU_RW_TYPED_BUFFER_DECL(uint32_t, uint8_t              , DecompressedHuffmanWeights    , 0)    \
     ZSTDGPU_RW_TYPED_BUFFER_DECL(uint32_t, uint8_t              , DecompressedHuffmanWeightCount, 1)
 
+#define ZSTDGPU_INIT_HUFFMAN_TABLE_SRT()                                                                \
+    ZSTDGPU_RO_TYPED_BUFFER_DECL(uint32_t, uint8_t              , DecompressedHuffmanWeights    , 0)    \
+    ZSTDGPU_RO_TYPED_BUFFER_DECL(uint32_t, uint8_t              , DecompressedHuffmanWeightCount, 1)    \
+    \
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , HuffmanTableInfo              , 0)    \
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , HuffmanTableCodeAndSymbol     , 1)    \
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , HuffmanTableRankIndex         , 2)
+
 #define ZSTDGPU_INIT_HUFFMAN_TABLE_AND_DECOMPRESS_LITERALS_SRT()                                        \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , LitStreamEndPerHuffmanTable   , 0)    \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , LitGroupEndPerHuffmanTable    , 1)    \
@@ -1334,6 +1358,20 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
     \
     ZSTDGPU_RO_TYPED_BUFFER_DECL(uint32_t, uint8_t              , DecompressedHuffmanWeights    , 6)    \
     ZSTDGPU_RO_TYPED_BUFFER_DECL(uint32_t, uint8_t              , DecompressedHuffmanWeightCount, 7)    \
+    \
+    ZSTDGPU_RW_TYPED_BUFFER_DECL(uint32_t, uint8_t              , DecompressedLiterals          , 0)
+
+#define ZSTDGPU_DECOMPRESS_LITERALS_SRT()                                                               \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , LitStreamEndPerHuffmanTable   , 0)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , LitGroupEndPerHuffmanTable    , 1)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , Counters                      , 2)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , LitStreamRemap                , 3)    \
+    ZSTDGPU_RO_BUFFER_DECL(zstdgpu_LitStreamInfo                , LitRefs                       , 4)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , CompressedData                , 5)    \
+    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , HuffmanTableInfo              , 6)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , HuffmanTableCodeAndSymbol     , 7)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , HuffmanTableRankIndex         , 8)    \
     \
     ZSTDGPU_RW_TYPED_BUFFER_DECL(uint32_t, uint8_t              , DecompressedLiterals          , 0)
 
@@ -1413,7 +1451,9 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
     ZSTDGPU_SRT(InitFseTable                            , ZSTDGPU_INIT_FSE_TABLE_SRT())                             \
     ZSTDGPU_SRT(DecompressHuffmanWeights                , ZSTDGPU_DECOMPRESS_HUFFMAN_WEIGHTS_SRT())                 \
     ZSTDGPU_SRT(DecodeHuffmanWeights                    , ZSTDGPU_DECODE_HUFFMAN_WEIGHTS_SRT())                     \
+    ZSTDGPU_SRT(InitHuffmanTable                        , ZSTDGPU_INIT_HUFFMAN_TABLE_SRT())                         \
     ZSTDGPU_SRT(InitHuffmanTableAndDecompressLiterals   , ZSTDGPU_INIT_HUFFMAN_TABLE_AND_DECOMPRESS_LITERALS_SRT()) \
+    ZSTDGPU_SRT(DecompressLiterals                      , ZSTDGPU_DECOMPRESS_LITERALS_SRT())                        \
     ZSTDGPU_SRT(DecompressSequences                     , ZSTDGPU_DECOMPRESS_SEQUENCES_SRT())                       \
     ZSTDGPU_SRT(FinaliseSequenceOffsets                 , ZSTDGPU_FINALISE_SEQUENCE_OFFSETS_SRT())                  \
     ZSTDGPU_SRT(MemsetMemcpy                            , ZSTDGPU_MEMSET_MEMCPY_SRT())                              \
@@ -1477,11 +1517,22 @@ typedef struct zstdgpu_DecodeHuffmanWeights_SRT
     uint32_t    compressedBufferSizeInBytes;
 } zstdgpu_DecodeHuffmanWeights_SRT;
 
+typedef struct zstdgpu_InitHuffmanTable_SRT
+{
+    ZSTDGPU_INIT_HUFFMAN_TABLE_SRT();
+} zstdgpu_InitHuffmanTable_SRT;
+
 typedef struct zstdgpu_InitHuffmanTable_And_DecompressLiterals_SRT
 {
     ZSTDGPU_INIT_HUFFMAN_TABLE_AND_DECOMPRESS_LITERALS_SRT()
     uint32_t    huffmanTableSlotCount;
 } zstdgpu_InitHuffmanTable_And_DecompressLiterals_SRT;
+
+typedef struct zstdgpu_DecompressLiterals_SRT
+{
+    ZSTDGPU_DECOMPRESS_LITERALS_SRT()
+    uint32_t    huffmanTableSlotCount;
+} zstdgpu_DecompressLiterals_SRT;
 
 typedef struct zstdgpu_DecompressSequences_SRT
 {

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -87,6 +87,14 @@
 #   endif
 #endif
 
+#ifndef ZSTDGPU_RO_BYTE_BUFFER
+#   ifdef __hlsl_dx_compiler
+#       define ZSTDGPU_RO_RAW_BUFFER(type) ByteAddressBuffer /* no type, it's opaquue in HLSL side */
+#   else
+#       define ZSTDGPU_RO_RAW_BUFFER(type) const type *
+#   endif
+#endif
+
 #ifndef ZSTDGPU_PARAM_IN
 #   ifdef __hlsl_dx_compiler
 #       define ZSTDGPU_PARAM_IN(type) in type
@@ -329,8 +337,6 @@ static const uint32_t kzstdgpu_TgSizeX_ExecuteSequences = 32;
 #endif
 
 #ifndef __hlsl_dx_compiler
-typedef const uint32_t* zstdgpu_RawBufferSrvU32;
-
 typedef struct uint32_t4
 {
     uint32_t x, y, z, w;
@@ -359,11 +365,9 @@ static inline void InterlockedMin(uint32_t & dst, uint32_t x) { dst = dst < x ? 
 static inline void InterlockedMax(uint32_t & dst, uint32_t x) { dst = dst > x ? dst : x; }
 static inline void InterlockedAdd(uint32_t & dst, uint32_t x, uint32_t & ret) { ret = dst; dst += x; }
 static inline void InterlockedCompareStore(uint32_t & dst, uint32_t compare, uint32_t x) { if (dst == compare) dst = x; }
-#else
-typedef ByteAddressBuffer zstdgpu_RawBufferSrvU32;
 #endif
 
-static inline uint64_t zstdgpu_RawLoadU64AtByteOffset(zstdgpu_RawBufferSrvU32 buffer, uint32_t offset)
+static inline uint64_t zstdgpu_RawLoadU64AtByteOffset(ZSTDGPU_RO_RAW_BUFFER(uint32_t) buffer, uint32_t offset)
 {
 #ifdef __hlsl_dx_compiler
     uint2 v = buffer.Load2(offset);
@@ -797,6 +801,7 @@ typedef struct zstdgpu_Backward_BitBuffer_V0
     uint32_t lastDword;   // VGPR as it store any memory block size varying per lane
     uint32_t baseDword;
     bool     hadlastrefill;
+    bool     hadlastrefillHuffman;
 } zstdgpu_Backward_BitBuffer_V0;
 
 typedef struct zstdgpu_Backward_BitBuffer
@@ -871,6 +876,7 @@ static inline void zstdgpu_Backward_BitBuffer_V0_InitWithSegment(ZSTDGPU_PARAM_I
     outBuffer.lastDword = lastDword;
     outBuffer.baseDword = baseDword;
     outBuffer.hadlastrefill = baseDword == lastDword;
+    outBuffer.hadlastrefillHuffman = false;
     //outBuffer.bytesz = bytesz;
 }
 
@@ -951,12 +957,58 @@ static inline void zstdgpu_Backward_BitBuffer_V0_Pop(ZSTDGPU_PARAM_INOUT(zstdgpu
 
 ZSTDGPU_BITBUF_DEFINE_STANDARD_METHODS(Backward_BitBuffer_V0)
 
+static inline bool zstdgpu_Backward_BitBuffer_V0_CanRefill_Huffman(ZSTDGPU_PARAM_IN(zstdgpu_Backward_BitBuffer_V0) inBuffer, uint32_t bitcnt)
+{
+    ZSTDGPU_ASSERT(bitcnt <= 32);
+    if (inBuffer.bitcnt >= bitcnt)
+    {
+        return true;
+    }
+    else
+    {
+        return !inBuffer.hadlastrefillHuffman;
+    }
+}
+
+static inline void zstdgpu_Backward_BitBuffer_V0_Refill_Huffman(ZSTDGPU_PARAM_INOUT(zstdgpu_Backward_BitBuffer_V0) inoutBuffer, uint32_t bitcnt, uint32_t extrabits)
+{
+    if (inoutBuffer.hadlastrefill == false)
+    {
+        zstdgpu_Backward_BitBuffer_V0_Refill(inoutBuffer, bitcnt);
+    }
+
+    if (inoutBuffer.bitcnt < bitcnt)
+    {
+        inoutBuffer.bitcnt += extrabits;    // simply increment counter because upper bits are zeros
+        inoutBuffer.hadlastrefillHuffman = true;
+    }
+}
+
+static inline uint32_t zstdgpu_Backward_BitBuffer_V0_Get_Huffman(ZSTDGPU_PARAM_INOUT(zstdgpu_Backward_BitBuffer_V0) inoutBuffer, uint32_t bitcnt, uint32_t extrabits)
+{
+    if (inoutBuffer.hadlastrefill == false)
+    {
+        zstdgpu_Backward_BitBuffer_V0_Refill(inoutBuffer, bitcnt);
+    }
+
+    if (inoutBuffer.bitcnt < bitcnt)
+    {
+        inoutBuffer.bitcnt += extrabits;    // simply increment counter because upper bits are zeros
+        inoutBuffer.bitbuf <<= extrabits;
+        inoutBuffer.hadlastrefillHuffman = true;
+    }
+
+    uint32_t result = zstdgpu_Backward_BitBuffer_V0_Top(inoutBuffer, bitcnt);
+    zstdgpu_Backward_BitBuffer_V0_Pop(inoutBuffer, bitcnt);
+    return result;
+}
+
 // NOTE(jweinste): Backwards bitstream that loads aligned 64-bit elements (instead of 32-bit elements) per-lane needing refill.
 struct zstdgpu_HuffmanStream
 {
-    zstdgpu_RawBufferSrvU32 buffer;
-    uint32_t                finalByteOffset;
-    uint32_t                lastByteOffset;
+    ZSTDGPU_RO_RAW_BUFFER(uint32_t) buffer;
+    uint32_t finalByteOffset;
+    uint32_t lastByteOffset;
 
     uint32_t dataSpare;
     uint32_t numBitsSpare; // always strictly < maxBitsPerCode
@@ -978,7 +1030,7 @@ struct zstdgpu_HuffmanStream
     uint32_t _32MinusMaxBitsPerCode;
 };
 
-static inline void zstdgpu_HuffmanStream_InitWithSegment(ZSTDGPU_PARAM_INOUT(zstdgpu_HuffmanStream) stream, zstdgpu_RawBufferSrvU32 buffer, ZSTDGPU_PARAM_IN(zstdgpu_OffsetAndSize) segment, ZSTDGPU_PARAM_IN(uint32_t) maxBitsPerCode)
+static inline void zstdgpu_HuffmanStream_InitWithSegment(ZSTDGPU_PARAM_INOUT(zstdgpu_HuffmanStream) stream, ZSTDGPU_RO_RAW_BUFFER(uint32_t) buffer, ZSTDGPU_PARAM_IN(zstdgpu_OffsetAndSize) segment, ZSTDGPU_PARAM_IN(uint32_t) maxBitsPerCode)
 {
     // NOTE(jweinste): we could just load a single DWORD here to reduce codesize/ALU here in InitWithSegment(),
     // but we want to ensure that the DWORDx2 loads in RefillAndPeek() are 8-byte aligned.
@@ -1434,7 +1486,7 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , Counters                      , 2)    \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , LitStreamRemap                , 3)    \
     ZSTDGPU_RO_BUFFER_DECL(zstdgpu_LitStreamInfo                , LitRefs                       , 4)    \
-    ZSTDGPU_RO_RAW_BUFFER_DECL(                                   CompressedData                , 5)    \
+    ZSTDGPU_RO_RAW_BUFFER_DECL(uint32_t                         , CompressedData                , 5)    \
     \
     ZSTDGPU_RO_TYPED_BUFFER_DECL(uint32_t, uint8_t              , DecompressedHuffmanWeights    , 6)    \
     ZSTDGPU_RO_TYPED_BUFFER_DECL(uint32_t, uint8_t              , DecompressedHuffmanWeightCount, 7)    \
@@ -1447,7 +1499,7 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , Counters                      , 2)    \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , LitStreamRemap                , 3)    \
     ZSTDGPU_RO_BUFFER_DECL(zstdgpu_LitStreamInfo                , LitRefs                       , 4)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , CompressedData                , 5)    \
+    ZSTDGPU_RO_RAW_BUFFER_DECL(uint32_t                         , CompressedData                , 5)    \
     \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , HuffmanTableInfo              , 6)    \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , HuffmanTableCodeAndSymbol     , 7)    \
@@ -1540,7 +1592,7 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
     ZSTDGPU_SRT(ExecuteSequences                        , ZSTDGPU_EXECUTE_SEQUENCES_SRT())                          \
     ZSTDGPU_SRT(ComputeDestSequenceOffsets              , ZSTDGPU_COMPUTE_DEST_SEQUENCE_OFFSETS_SRT())
 
-#define ZSTDGPU_RO_RAW_BUFFER_DECL(name, index)                        zstdgpu_RawBufferSrvU32                    in##name;
+#define ZSTDGPU_RO_RAW_BUFFER_DECL(type, name, index)                  ZSTDGPU_RO_RAW_BUFFER(type)                in##name;
 #define ZSTDGPU_RO_BUFFER_DECL(type, name, index)                      ZSTDGPU_RO_BUFFER(type)                    in##name;
 #define ZSTDGPU_RW_BUFFER_DECL(type, name, index)                      ZSTDGPU_RW_BUFFER(type)                    inout##name;
 #define ZSTDGPU_RW_BUFFER_DECL_GLC(type, name, index)                  ZSTDGPU_RW_BUFFER_GLC(type)                inout##name;

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -452,6 +452,15 @@ static inline uint32_t zstdgpu_MaxU32(uint32_t a, uint32_t b)
 #endif
 }
 
+static inline uint32_t zstdgpu_MaxI32(int32_t a, int32_t b)
+{
+#ifdef __hlsl_dx_compiler
+    return max(a, b);
+#else
+    return a > b ? a : b;
+#endif
+}
+
 static inline uint32_t zstdgpu_Encode30BitLookbackSelf(uint32_t x)
 {
     ZSTDGPU_ASSERT(x <= ~0xc0000000u);
@@ -891,6 +900,85 @@ static inline uint32_t zstdgpu_Backward_BitBuffer_V0_Get_Huffman(ZSTDGPU_PARAM_I
     uint32_t result = zstdgpu_Backward_BitBuffer_V0_Top(inoutBuffer, bitcnt);
     zstdgpu_Backward_BitBuffer_V0_Pop(inoutBuffer, bitcnt);
     return result;
+}
+
+struct HuffmanStream {
+    ZSTDGPU_RO_BUFFER(uint32_t) buffer;
+
+    uint32_t dataSpare;
+    uint32_t numBitsSpare;
+
+    uint32_t data0;
+    uint32_t numBits0;
+
+    // uint32_t baseDwordIdx; SRD from table is bounds-checked, or there should be at least 8 bytes before
+    // the start of compressed literals between the zstd-frame begin and first block.
+    uint32_t lastDwordIdx;
+
+    uint32_t maxBitsPerCode;
+    uint32_t bwMinusMaxBitsPerCode;
+};
+
+static inline void zstdgpu_HuffmanStream_InitWithSegment(
+    ZSTDGPU_PARAM_INOUT(HuffmanStream)      stream,
+    ZSTDGPU_RO_BUFFER(uint32_t)             buffer,
+    ZSTDGPU_PARAM_IN(zstdgpu_OffsetAndSize) segment,
+    ZSTDGPU_PARAM_IN(uint32_t) maxBitsPerCode)
+{
+    const uint32_t lastByteIdx = (segment.offs + segment.size) - 1; // NOTE: - 1, not end
+
+    // const uint32_t baseDwordIdx = segment.offs / 4u;
+    const uint32_t lastDwordIdx = lastByteIdx / 4u;
+
+    uint32_t data = buffer[lastDwordIdx];
+    uint32_t goodBitCount = (lastByteIdx % 4u) * 8 + 8;      // byte index within DWORD of 0 yeilds 8
+    data &= ~0u >> (32 - goodBitCount);                      // keep {1,2,3,4} * 8 low bits
+    goodBitCount = zstdgpu_FindFirstBitHiU32(data);          // NOTE: could become zero, in [0:31]
+
+    data <<= ((32 - goodBitCount) & 31); // lets first try/see how keeping bits at MSB looks
+
+    stream.buffer = buffer;
+
+    stream.dataSpare    = 0;
+    stream.numBitsSpare = 0;
+
+    stream.data0        = data;
+    stream.numBits0     = goodBitCount;
+
+    stream.lastDwordIdx = lastDwordIdx;
+
+    stream.maxBitsPerCode = maxBitsPerCode;
+    stream.bwMinusMaxBitsPerCode = 32 - maxBitsPerCode;
+}
+
+static inline void zstdgpu_HuffmanStream_Refill(ZSTDGPU_PARAM_INOUT(HuffmanStream) stream)
+{
+    if (stream.numBits0 < stream.maxBitsPerCode)
+    {
+        ZSTDGPU_ASSERT(stream.numBitsSpare == 0);
+        stream.dataSpare    = stream.data0;
+        stream.numBitsSpare = stream.numBits0;
+        stream.numBits0     = 32;
+        stream.data0 = stream.buffer[--stream.lastDwordIdx];
+    }
+}
+
+static inline uint32_t zstdgpu_HuffmanStream_Peek(ZSTDGPU_PARAM_INOUT(HuffmanStream) stream)
+{
+    const uint32_t k = stream.bwMinusMaxBitsPerCode;
+    return (stream.dataSpare >> k) |
+           (stream.data0 >> (k + stream.numBitsSpare));
+}
+
+static inline void zstdgpu_HuffmanStream_Consume(ZSTDGPU_PARAM_INOUT(HuffmanStream) stream, ZSTDGPU_PARAM_IN(int) actualBitCount)
+{
+    int ns = stream.numBitsSpare;
+    uint32_t data0Consumed = zstdgpu_MaxI32(0, actualBitCount - ns);
+    stream.numBitsSpare    = zstdgpu_MaxI32(0, ns - actualBitCount);
+    stream.dataSpare <<= actualBitCount;
+
+    stream.numBits0 -= data0Consumed;
+    stream.data0 <<= data0Consumed;
 }
 
 static inline void zstdgpu_Backward_BitBuffer_Init(ZSTDGPU_PARAM_INOUT(zstdgpu_Backward_BitBuffer) outBitBuffer, ZSTDGPU_RO_BUFFER(uint32_t) buffer, ZSTDGPU_PARAM_IN(zstdgpu_OffsetAndSize) segment)

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -341,6 +341,30 @@ static inline void InterlockedMin(uint32_t & dst, uint32_t x) { dst = dst < x ? 
 static inline void InterlockedMax(uint32_t & dst, uint32_t x) { dst = dst > x ? dst : x; }
 static inline void InterlockedAdd(uint32_t & dst, uint32_t x, uint32_t & ret) { ret = dst; dst += x; }
 static inline void InterlockedCompareStore(uint32_t & dst, uint32_t compare, uint32_t x) { if (dst == compare) dst = x; }
+
+using RawBufferSrvU32 = const uint32_t*;
+static inline uint32_t LoadU32AtByteOffset(RawBufferSrvU32 buffer, uint32_t offset)
+{
+    return *reinterpret_cast<const uint32_t*>(reinterpret_cast<const char*>(buffer) + offset);
+}
+static inline uint64_t LoadU64AtByteOffset(RawBufferSrvU32 buffer, uint32_t offset)
+{
+    return *reinterpret_cast<const uint64_t* __unaligned>(reinterpret_cast<const char*>(buffer) + offset);
+}
+
+#else
+
+#define RawBufferSrvU32 ByteAddressBuffer
+static inline uint32_t LoadU32AtByteOffset(RawBufferSrvU32 buffer, uint32_t offset)
+{
+    return buffer.Load(offset);
+}
+static inline uint64_t LoadU64AtByteOffset(RawBufferSrvU32 buffer, uint32_t offset)
+{
+    uint2 v = buffer.Load2(offset);
+    return v.x | (uint64_t(v.y) << 32);
+}
+
 #endif
 
 static inline uint32_t zstdgpu_BitFieldExtractU32(uint32_t x, uint32_t start, uint32_t count)
@@ -902,15 +926,8 @@ static inline uint32_t zstdgpu_Backward_BitBuffer_V0_Get_Huffman(ZSTDGPU_PARAM_I
     return result;
 }
 
-static inline uint64_t LoadU32x2(ZSTDGPU_RO_BUFFER(uint32_t) buffer32, uint32_t lowDwordIndex)
-{
-    // ByteAddressBuffer (raw buffer) will gen buffer_load_b64? Change loop term conds and increment.
-    // Or make it StructuredBuffer<uint64_t>. In both cases API says descriptors need larger alignment than 4 though.
-    return uint64_t(buffer32[lowDwordIndex + 1]) << 32 | buffer32[lowDwordIndex];
-}
-
 struct HuffmanStream {
-    ZSTDGPU_RO_BUFFER(uint32_t) buffer;
+    RawBufferSrvU32 buffer;
 
     uint32_t dataSpare; // can be u32, even when data0 is u64
     uint32_t numBitsSpare;
@@ -918,9 +935,9 @@ struct HuffmanStream {
     uint64_t data0;
     uint32_t numBits0;
 
-    // uint32_t baseDwordIdx; SRD from table is bounds-checked, or there should be at least 8 bytes before
+    // SRD from table is bounds-checked, or there should be at least 8 bytes before
     // the start of compressed literals between the zstd-frame begin and first block(?).
-    uint32_t lastDwordIdx;
+    uint32_t lastByteOffset;
 
     uint32_t maxBitsPerCode;
     uint32_t _32MinusMaxBitsPerCode;
@@ -928,16 +945,16 @@ struct HuffmanStream {
 
 static inline void zstdgpu_HuffmanStream_InitWithSegment(
     ZSTDGPU_PARAM_INOUT(HuffmanStream)      stream,
-    ZSTDGPU_RO_BUFFER(uint32_t)             buffer,
+    ZSTDGPU_PARAM_IN(RawBufferSrvU32)       buffer,
     ZSTDGPU_PARAM_IN(zstdgpu_OffsetAndSize) segment,
     ZSTDGPU_PARAM_IN(uint32_t) maxBitsPerCode)
 {
     const uint32_t lastByteIdx = (segment.offs + segment.size) - 1; // NOTE: - 1, not end
 
-    const uint32_t lastDwordIdx = lastByteIdx / 4u;
+    const uint32_t lastByteOffsetForDword = lastByteIdx & -4;
 
-    // For experiment with U64 _loads_ in the loop, still do U32 for init since its maybe simpler.
-    uint32_t data = buffer[lastDwordIdx];
+    // Doing U64 loads in the loop, but do U32 for init since its maybe simpler.
+    uint32_t data = LoadU32AtByteOffset(buffer, lastByteOffsetForDword);
     uint32_t goodBitCount = (lastByteIdx % 4u) * 8 + 8;      // byte index within DWORD of 0 yeilds 8
     data &= ~0u >> (32 - goodBitCount);                      // keep {1,2,3,4} * 8 low bits
     goodBitCount = zstdgpu_FindFirstBitHiU32(data);          // NOTE: could become zero, in [0:31]
@@ -958,7 +975,7 @@ static inline void zstdgpu_HuffmanStream_InitWithSegment(
     stream.data0        = data64;
     stream.numBits0     = goodBitCount;
 
-    stream.lastDwordIdx = lastDwordIdx;
+    stream.lastByteOffset = lastByteOffsetForDword;
 
     stream.maxBitsPerCode = maxBitsPerCode;
     stream._32MinusMaxBitsPerCode = 32 - maxBitsPerCode;
@@ -974,7 +991,7 @@ static inline void zstdgpu_HuffmanStream_Refill(ZSTDGPU_PARAM_INOUT(HuffmanStrea
         stream.dataSpare    = uint32_t(stream.data0 >> 32);
         stream.numBitsSpare = stream.numBits0;
         stream.numBits0     = 64;
-        stream.data0        = LoadU32x2(stream.buffer, stream.lastDwordIdx -= 2);
+        stream.data0        = LoadU64AtByteOffset(stream.buffer, stream.lastByteOffset -= sizeof(uint64_t));
     }
 }
 
@@ -1371,7 +1388,7 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , Counters                      , 2)    \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , LitStreamRemap                , 3)    \
     ZSTDGPU_RO_BUFFER_DECL(zstdgpu_LitStreamInfo                , LitRefs                       , 4)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , CompressedData                , 5)    \
+    ZSTDGPU_RO_RAW_BUFFER_DECL(                                   CompressedData                , 5)    \
     \
     ZSTDGPU_RO_TYPED_BUFFER_DECL(uint32_t, uint8_t              , DecompressedHuffmanWeights    , 6)    \
     ZSTDGPU_RO_TYPED_BUFFER_DECL(uint32_t, uint8_t              , DecompressedHuffmanWeightCount, 7)    \
@@ -1461,6 +1478,7 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
     ZSTDGPU_SRT(ExecuteSequences                        , ZSTDGPU_EXECUTE_SEQUENCES_SRT())                          \
     ZSTDGPU_SRT(ComputeDestSequenceOffsets              , ZSTDGPU_COMPUTE_DEST_SEQUENCE_OFFSETS_SRT())
 
+#define ZSTDGPU_RO_RAW_BUFFER_DECL(name, index)                        RawBufferSrvU32                            in##name;
 #define ZSTDGPU_RO_BUFFER_DECL(type, name, index)                      ZSTDGPU_RO_BUFFER(type)                    in##name;
 #define ZSTDGPU_RW_BUFFER_DECL(type, name, index)                      ZSTDGPU_RW_BUFFER(type)                    inout##name;
 #define ZSTDGPU_RW_BUFFER_DECL_GLC(type, name, index)                  ZSTDGPU_RW_BUFFER_GLC(type)                inout##name;
@@ -1549,5 +1567,6 @@ typedef struct zstdgpu_ComputeDestSequenceOffsets_SRT
 #undef ZSTDGPU_RW_BUFFER_DECL_GLC
 #undef ZSTDGPU_RW_BUFFER_DECL
 #undef ZSTDGPU_RO_BUFFER_DECL
+#undef ZSTDGPU_RO_RAW_BUFFER_DECL
 
 #endif // #define ZSTDGPU_STRUCTS_H

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -926,18 +926,16 @@ static inline uint32_t zstdgpu_Backward_BitBuffer_V0_Get_Huffman(ZSTDGPU_PARAM_I
     return result;
 }
 
-struct HuffmanStream {
+struct HuffmanStream
+{
     RawBufferSrvU32 buffer;
+    uint32_t lastByteOffset;
 
-    uint32_t dataSpare; // can be u32, even when data0 is u64
+    uint32_t dataSpare;
     uint32_t numBitsSpare;
 
     uint64_t data0;
     uint32_t numBits0;
-
-    // SRD from table is bounds-checked, or there should be at least 8 bytes before
-    // the start of compressed literals between the zstd-frame begin and first block(?).
-    uint32_t lastByteOffset;
 
     uint32_t maxBitsPerCode;
     uint32_t _32MinusMaxBitsPerCode;
@@ -947,40 +945,36 @@ static inline void zstdgpu_HuffmanStream_InitWithSegment(
     ZSTDGPU_PARAM_INOUT(HuffmanStream)      stream,
     ZSTDGPU_PARAM_IN(RawBufferSrvU32)       buffer,
     ZSTDGPU_PARAM_IN(zstdgpu_OffsetAndSize) segment,
-    ZSTDGPU_PARAM_IN(uint32_t) maxBitsPerCode)
+    ZSTDGPU_PARAM_IN(uint32_t)              maxBitsPerCode)
 {
-    const uint32_t lastByteIdx = (segment.offs + segment.size) - 1; // NOTE: - 1, not end
+    const uint32_t lastByteIdx = (segment.offs + segment.size) - 1; // Byte index containing the flag.
+    const uint32_t lastByteOffsetForU64 = lastByteIdx & -8;
+    uint64_t data64 = LoadU64AtByteOffset(buffer, lastByteOffsetForU64);
 
-    const uint32_t lastByteOffsetForDword = lastByteIdx & -4;
+    // How many extra bytes we read.
+    const uint32_t oobByteCount = 7 - (lastByteIdx & 7);
+    // Shift left by [0:56] to put the byte with the flag on top.
+    const uint32_t oobBitCount = oobByteCount * 8;
+    data64 <<= oobBitCount;
+    // Count number of leading zero bits above the flag (result in [0:7]).
+    // There is no 64-bit version of v_clz_i32_u32 and uint32_t(data64 >> 32) is free since U64 is a pair of VGPRs.
+    // Add one (reverse-subtract by 32, not 31) to also shift out the flag itself.
+    const uint32_t nonDataBitCount = 32 - zstdgpu_FindFirstBitHiU32(uint32_t(data64 >> 32));
+    data64 <<= nonDataBitCount;
 
-    // Doing U64 loads in the loop, but do U32 for init since its maybe simpler.
-    uint32_t data = LoadU32AtByteOffset(buffer, lastByteOffsetForDword);
-    uint32_t goodBitCount = (lastByteIdx % 4u) * 8 + 8;      // byte index within DWORD of 0 yeilds 8
-    data &= ~0u >> (32 - goodBitCount);                      // keep {1,2,3,4} * 8 low bits
-    goodBitCount = zstdgpu_FindFirstBitHiU32(data);          // NOTE: could become zero, in [0:31]
-
-    // When goodBitCount is 0, data will be 0x1 and should be cleared to 0x0,
-    // but we can't shift by 32, so do this in two steps:
-    data <<= 1;
-    data <<= (31 - goodBitCount);
-
-    // Only loaded U32 for init.
-    uint64_t data64 = uint64_t(data) << 32;
-
-    stream.buffer = buffer;
+    stream.buffer         = buffer;
+    stream.lastByteOffset = lastByteOffsetForU64;
 
     stream.dataSpare    = 0;
     stream.numBitsSpare = 0;
 
-    stream.data0        = data64;
-    stream.numBits0     = goodBitCount;
+    stream.data0    = data64;
+    stream.numBits0 = 64 - (oobBitCount + nonDataBitCount); // How many bits we kept (could be 0).
 
-    stream.lastByteOffset = lastByteOffsetForDword;
-
-    stream.maxBitsPerCode = maxBitsPerCode;
+    stream.maxBitsPerCode         = maxBitsPerCode;
     stream._32MinusMaxBitsPerCode = 32 - maxBitsPerCode;
 
-    ZSTDGPU_ASSERT(11 >= maxBitsPerCode);
+    ZSTDGPU_ASSERT(1 <= maxBitsPerCode && maxBitsPerCode <= 11);
 }
 
 static inline void zstdgpu_HuffmanStream_Refill(ZSTDGPU_PARAM_INOUT(HuffmanStream) stream)
@@ -991,7 +985,7 @@ static inline void zstdgpu_HuffmanStream_Refill(ZSTDGPU_PARAM_INOUT(HuffmanStrea
         stream.dataSpare    = uint32_t(stream.data0 >> 32);
         stream.numBitsSpare = stream.numBits0;
         stream.numBits0     = 64;
-        stream.data0        = LoadU64AtByteOffset(stream.buffer, stream.lastByteOffset -= sizeof(uint64_t));
+        stream.data0        = LoadU64AtByteOffset(stream.buffer, stream.lastByteOffset -= sizeof(uint64_t)); // NOTE: -=
     }
 }
 

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -902,21 +902,28 @@ static inline uint32_t zstdgpu_Backward_BitBuffer_V0_Get_Huffman(ZSTDGPU_PARAM_I
     return result;
 }
 
+static inline uint64_t LoadU32x2(ZSTDGPU_RO_BUFFER(uint32_t) buffer32, uint32_t lowDwordIndex)
+{
+    // ByteAddressBuffer (raw buffer) will gen buffer_load_b64? Change loop term conds and increment.
+    // Or make it StructuredBuffer<uint64_t>. In both cases API says descriptors need larger alignment than 4 though.
+    return uint64_t(buffer32[lowDwordIndex + 1]) << 32 | buffer32[lowDwordIndex];
+}
+
 struct HuffmanStream {
     ZSTDGPU_RO_BUFFER(uint32_t) buffer;
 
-    uint32_t dataSpare;
+    uint32_t dataSpare; // can be u32, even when data0 is u64
     uint32_t numBitsSpare;
 
-    uint32_t data0;
+    uint64_t data0;
     uint32_t numBits0;
 
     // uint32_t baseDwordIdx; SRD from table is bounds-checked, or there should be at least 8 bytes before
-    // the start of compressed literals between the zstd-frame begin and first block.
+    // the start of compressed literals between the zstd-frame begin and first block(?).
     uint32_t lastDwordIdx;
 
     uint32_t maxBitsPerCode;
-    uint32_t bwMinusMaxBitsPerCode;
+    uint32_t _32MinusMaxBitsPerCode;
 };
 
 static inline void zstdgpu_HuffmanStream_InitWithSegment(
@@ -927,28 +934,36 @@ static inline void zstdgpu_HuffmanStream_InitWithSegment(
 {
     const uint32_t lastByteIdx = (segment.offs + segment.size) - 1; // NOTE: - 1, not end
 
-    // const uint32_t baseDwordIdx = segment.offs / 4u;
     const uint32_t lastDwordIdx = lastByteIdx / 4u;
 
+    // For experiment with U64 _loads_ in the loop, still do U32 for init since its maybe simpler.
     uint32_t data = buffer[lastDwordIdx];
     uint32_t goodBitCount = (lastByteIdx % 4u) * 8 + 8;      // byte index within DWORD of 0 yeilds 8
     data &= ~0u >> (32 - goodBitCount);                      // keep {1,2,3,4} * 8 low bits
     goodBitCount = zstdgpu_FindFirstBitHiU32(data);          // NOTE: could become zero, in [0:31]
 
-    data <<= ((32 - goodBitCount) & 31); // lets first try/see how keeping bits at MSB looks
+    // When goodBitCount is 0, data will be 0x1 and should be cleared to 0x0,
+    // but we can't shift by 32, so do this in two steps:
+    data <<= 1;
+    data <<= (31 - goodBitCount);
+
+    // Only loaded U32 for init.
+    uint64_t data64 = uint64_t(data) << 32;
 
     stream.buffer = buffer;
 
     stream.dataSpare    = 0;
     stream.numBitsSpare = 0;
 
-    stream.data0        = data;
+    stream.data0        = data64;
     stream.numBits0     = goodBitCount;
 
     stream.lastDwordIdx = lastDwordIdx;
 
     stream.maxBitsPerCode = maxBitsPerCode;
-    stream.bwMinusMaxBitsPerCode = 32 - maxBitsPerCode;
+    stream._32MinusMaxBitsPerCode = 32 - maxBitsPerCode;
+
+    ZSTDGPU_ASSERT(11 >= maxBitsPerCode);
 }
 
 static inline void zstdgpu_HuffmanStream_Refill(ZSTDGPU_PARAM_INOUT(HuffmanStream) stream)
@@ -956,22 +971,26 @@ static inline void zstdgpu_HuffmanStream_Refill(ZSTDGPU_PARAM_INOUT(HuffmanStrea
     if (stream.numBits0 < stream.maxBitsPerCode)
     {
         ZSTDGPU_ASSERT(stream.numBitsSpare == 0);
-        stream.dataSpare    = stream.data0;
+        stream.dataSpare    = uint32_t(stream.data0 >> 32);
         stream.numBitsSpare = stream.numBits0;
-        stream.numBits0     = 32;
-        stream.data0 = stream.buffer[--stream.lastDwordIdx];
+        stream.numBits0     = 64;
+        stream.data0        = LoadU32x2(stream.buffer, stream.lastDwordIdx -= 2);
     }
 }
 
 static inline uint32_t zstdgpu_HuffmanStream_Peek(ZSTDGPU_PARAM_INOUT(HuffmanStream) stream)
 {
-    const uint32_t k = stream.bwMinusMaxBitsPerCode;
+    const uint32_t k = stream._32MinusMaxBitsPerCode;
+    ZSTDGPU_ASSERT(k + stream.numBitsSpare < 32u);
+     // "Free" since U64 is a pair of VGPRs. Do to avoid U64 shift. Works because Max bits is <= 11:
+    const uint32_t data0_hi = uint32_t(stream.data0 >> 32);
     return (stream.dataSpare >> k) |
-           (stream.data0 >> (k + stream.numBitsSpare));
+           (data0_hi >> (k + stream.numBitsSpare));
 }
 
 static inline void zstdgpu_HuffmanStream_Consume(ZSTDGPU_PARAM_INOUT(HuffmanStream) stream, ZSTDGPU_PARAM_IN(int) actualBitCount)
 {
+    ZSTDGPU_ASSERT(stream.maxBitsPerCode >= uint32_t(actualBitCount));
     int ns = stream.numBitsSpare;
     uint32_t data0Consumed = zstdgpu_MaxI32(0, actualBitCount - ns);
     stream.numBitsSpare    = zstdgpu_MaxI32(0, ns - actualBitCount);

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -342,24 +342,28 @@ static inline void InterlockedMax(uint32_t & dst, uint32_t x) { dst = dst > x ? 
 static inline void InterlockedAdd(uint32_t & dst, uint32_t x, uint32_t & ret) { ret = dst; dst += x; }
 static inline void InterlockedCompareStore(uint32_t & dst, uint32_t compare, uint32_t x) { if (dst == compare) dst = x; }
 
-using RawBufferSrvU32 = const uint32_t*;
-static inline uint32_t LoadU32AtByteOffset(RawBufferSrvU32 buffer, uint32_t offset)
+using zstdgpu_RawBufferSrvU32 = const uint32_t*;
+
+static inline uint32_t zstdgpu_RawLoadU32AtByteOffset(zstdgpu_RawBufferSrvU32 buffer, uint32_t offset)
 {
     return *reinterpret_cast<const uint32_t*>(reinterpret_cast<const char*>(buffer) + offset);
 }
-static inline uint64_t LoadU64AtByteOffset(RawBufferSrvU32 buffer, uint32_t offset)
+
+static inline uint64_t zstdgpu_RawLoadU64AtByteOffset(zstdgpu_RawBufferSrvU32 buffer, uint32_t offset)
 {
     return *reinterpret_cast<const uint64_t* __unaligned>(reinterpret_cast<const char*>(buffer) + offset);
 }
 
 #else
 
-#define RawBufferSrvU32 ByteAddressBuffer
-static inline uint32_t LoadU32AtByteOffset(RawBufferSrvU32 buffer, uint32_t offset)
+#define zstdgpu_RawBufferSrvU32 ByteAddressBuffer
+
+static inline uint32_t zstdgpu_RawLoadU32AtByteOffset(zstdgpu_RawBufferSrvU32 buffer, uint32_t offset)
 {
     return buffer.Load(offset);
 }
-static inline uint64_t LoadU64AtByteOffset(RawBufferSrvU32 buffer, uint32_t offset)
+
+static inline uint64_t zstdgpu_RawLoadU64AtByteOffset(zstdgpu_RawBufferSrvU32 buffer, uint32_t offset)
 {
     uint2 v = buffer.Load2(offset);
     return v.x | (uint64_t(v.y) << 32);
@@ -776,9 +780,6 @@ static inline void zstdgpu_Forward_BitBuffer_ByteAlign(ZSTDGPU_PARAM_INOUT(zstdg
     zstdgpu_Forward_BitBuffer_Pop(inoutBuffer, inoutBuffer.bitcnt & 7);
 }
 
-// #define ZSTDGPU_USE_REVERSED_BIT_BUFFER_BITBUF 1 // reversebits/v_bfrev_b32 idea, doesn't compile because of bitcntLast
-// #define ZSTDGPU_USE_REVERSED_BIT_BUFFER_OFFSET 1 // doesn't seem to matter
-
 typedef struct zstdgpu_Backward_BitBuffer_V0
 {
     ZSTDGPU_RO_BUFFER(uint32_t) buffer;
@@ -907,33 +908,48 @@ static inline void zstdgpu_Backward_BitBuffer_V0_Pop(ZSTDGPU_PARAM_INOUT(zstdgpu
 
 ZSTDGPU_BITBUF_DEFINE_STANDARD_METHODS(Backward_BitBuffer_V0)
 
-static inline uint32_t zstdgpu_Backward_BitBuffer_V0_Get_Huffman(ZSTDGPU_PARAM_INOUT(zstdgpu_Backward_BitBuffer_V0) inoutBuffer, uint32_t bitcnt, uint32_t extrabits)
+// Possible debugging method when trying different bitbuffer ideas:
+// keep an older working implementation around and call them side by side, e.g:
+//
+// void func(...)
+// {   ...
+//     old_Init(old_stream);
+//     new_Init(new_stream);
+//     for (...)
+//     {
+//         old_state = old_RefillAndPeak(old_stream);
+//         new_state = new_RefillAndPeak(new_stream);
+//         if (old_state != new_state)
+//             __debugbreak();
+//         ...
+//         old_state = old_Consume(...);
+//         new_state = new_Consume(...);
+//     }
+//     ...
+// }
+
+// NOTE(jweinste):
+//
+// Backwards bitstream that loads aligned 64-bit elements (instead of 32-bit elements).
+// That was the main goal, and the rest of how this work is what felt "natural".
+//
+// These functions do not check if the source stream was fully consumed, calling code must determine when to stop looping.
+//
+// This style of bitstream could perhaps be used for other things in the future.
+struct zstdgpu_HuffmanStream
 {
-    // Always true when doing test-in-loop-middle on Regenerated_Size:
-    // if (inoutBuffer.hadlastrefill == false)
-    {
-        zstdgpu_Backward_BitBuffer_V0_Refill(inoutBuffer, bitcnt);
-    }
+    zstdgpu_RawBufferSrvU32 buffer;
+    uint32_t                lastByteOffset;
 
-    if (inoutBuffer.bitcnt < bitcnt)
-    {
-        inoutBuffer.bitcnt += extrabits;    // simply increment counter because upper bits are zeros
-        inoutBuffer.bitbuf <<= extrabits;
-    }
-
-    uint32_t result = zstdgpu_Backward_BitBuffer_V0_Top(inoutBuffer, bitcnt);
-    zstdgpu_Backward_BitBuffer_V0_Pop(inoutBuffer, bitcnt);
-    return result;
-}
-
-struct HuffmanStream
-{
-    RawBufferSrvU32 buffer;
-    uint32_t lastByteOffset;
-
+    // Used to juggle bits we still have but need to load another U64.
+    // This juggling means there is a decent amount of ALU (including one 64-bit shift) per Peek+Consume,
+    // but doing fewer loads (by loading U64 over U32) seems worth it (since loads might be immediately waited on).
+    // The refill condition may be non-uniform though, making things not clear-cut.
     uint32_t dataSpare;
-    uint32_t numBitsSpare;
+    uint32_t numBitsSpare; // always strictly < maxBitsPerCode
 
+    // Remaining bits are kept in _high_ bits.
+    // If there is one 5-bit code left (numBits0 = 5) with value 0b11111, then data0 = 0xF800'0000'0000'0000, NOT 0x1F or anything else.
     uint64_t data0;
     uint32_t numBits0;
 
@@ -942,14 +958,20 @@ struct HuffmanStream
 };
 
 static inline void zstdgpu_HuffmanStream_InitWithSegment(
-    ZSTDGPU_PARAM_INOUT(HuffmanStream)      stream,
-    ZSTDGPU_PARAM_IN(RawBufferSrvU32)       buffer,
+    ZSTDGPU_PARAM_INOUT(zstdgpu_HuffmanStream)      stream,
+    ZSTDGPU_PARAM_IN(zstdgpu_RawBufferSrvU32)       buffer,
     ZSTDGPU_PARAM_IN(zstdgpu_OffsetAndSize) segment,
     ZSTDGPU_PARAM_IN(uint32_t)              maxBitsPerCode)
 {
+    // NOTE(jweinste): we could just load a single DWORD here to reduce codesize/ALU here in InitWithSegment(),
+    // but we want to ensure that the DWORDx2 loads in RefillAndPeek() are 8-byte aligned.
+    // Alignment might improve cache behavior, but it is mainly to remove OOB concerns,
+    // assuming the _first_ frame in a "file" is at least 4-byte aligned,
+    // since a frame is at least 2 bytes and a block has a 3-byte header.
+
     const uint32_t lastByteIdx = (segment.offs + segment.size) - 1; // Byte index containing the flag.
     const uint32_t lastByteOffsetForU64 = lastByteIdx & -8;
-    uint64_t data64 = LoadU64AtByteOffset(buffer, lastByteOffsetForU64);
+    uint64_t data64 = zstdgpu_RawLoadU64AtByteOffset(buffer, lastByteOffsetForU64);
 
     // How many extra bytes we read.
     const uint32_t oobByteCount = 7 - (lastByteIdx & 7);
@@ -977,31 +999,32 @@ static inline void zstdgpu_HuffmanStream_InitWithSegment(
     ZSTDGPU_ASSERT(1 <= maxBitsPerCode && maxBitsPerCode <= 11);
 }
 
-static inline void zstdgpu_HuffmanStream_Refill(ZSTDGPU_PARAM_INOUT(HuffmanStream) stream)
+static inline uint32_t zstdgpu_HuffmanStream_RefillAndPeek(ZSTDGPU_PARAM_INOUT(zstdgpu_HuffmanStream) stream)
 {
+    // Need refill?
     if (stream.numBits0 < stream.maxBitsPerCode)
     {
+        // Do refill.
         ZSTDGPU_ASSERT(stream.numBitsSpare == 0);
         stream.dataSpare    = uint32_t(stream.data0 >> 32);
         stream.numBitsSpare = stream.numBits0;
         stream.numBits0     = 64;
-        stream.data0        = LoadU64AtByteOffset(stream.buffer, stream.lastByteOffset -= sizeof(uint64_t)); // NOTE: -=
+        stream.data0        = zstdgpu_RawLoadU64AtByteOffset(stream.buffer, stream.lastByteOffset -= sizeof(uint64_t)); // NOTE: -=
     }
-}
 
-static inline uint32_t zstdgpu_HuffmanStream_Peek(ZSTDGPU_PARAM_INOUT(HuffmanStream) stream)
-{
+    // Peak.
     const uint32_t k = stream._32MinusMaxBitsPerCode;
     ZSTDGPU_ASSERT(k + stream.numBitsSpare < 32u);
-     // "Free" since U64 is a pair of VGPRs. Do to avoid U64 shift. Works because Max bits is <= 11:
+    // Extracting high U32 is "free" since U64 is a pair of VGPRs. Avoid slower U64 shift. Works because maxBitsPerCode bits is <= 11.
     const uint32_t data0_hi = uint32_t(stream.data0 >> 32);
     return (stream.dataSpare >> k) |
            (data0_hi >> (k + stream.numBitsSpare));
 }
 
-static inline void zstdgpu_HuffmanStream_Consume(ZSTDGPU_PARAM_INOUT(HuffmanStream) stream, ZSTDGPU_PARAM_IN(int) actualBitCount)
+static inline void zstdgpu_HuffmanStream_Consume(ZSTDGPU_PARAM_INOUT(zstdgpu_HuffmanStream) stream, ZSTDGPU_PARAM_IN(int) actualBitCount)
 {
     ZSTDGPU_ASSERT(stream.maxBitsPerCode >= uint32_t(actualBitCount));
+
     int ns = stream.numBitsSpare;
     uint32_t data0Consumed = zstdgpu_MaxI32(0, actualBitCount - ns);
     stream.numBitsSpare    = zstdgpu_MaxI32(0, ns - actualBitCount);
@@ -1472,7 +1495,7 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
     ZSTDGPU_SRT(ExecuteSequences                        , ZSTDGPU_EXECUTE_SEQUENCES_SRT())                          \
     ZSTDGPU_SRT(ComputeDestSequenceOffsets              , ZSTDGPU_COMPUTE_DEST_SEQUENCE_OFFSETS_SRT())
 
-#define ZSTDGPU_RO_RAW_BUFFER_DECL(name, index)                        RawBufferSrvU32                            in##name;
+#define ZSTDGPU_RO_RAW_BUFFER_DECL(name, index)                        zstdgpu_RawBufferSrvU32                    in##name;
 #define ZSTDGPU_RO_BUFFER_DECL(type, name, index)                      ZSTDGPU_RO_BUFFER(type)                    in##name;
 #define ZSTDGPU_RW_BUFFER_DECL(type, name, index)                      ZSTDGPU_RW_BUFFER(type)                    inout##name;
 #define ZSTDGPU_RW_BUFFER_DECL_GLC(type, name, index)                  ZSTDGPU_RW_BUFFER_GLC(type)                inout##name;

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -743,21 +743,19 @@ static inline void zstdgpu_Forward_BitBuffer_ByteAlign(ZSTDGPU_PARAM_INOUT(zstdg
     zstdgpu_Forward_BitBuffer_Pop(inoutBuffer, inoutBuffer.bitcnt & 7);
 }
 
-//#define ZSTDGPU_USE_REVERSED_BIT_BUFFER_BITBUF 1
-#define ZSTDGPU_USE_REVERSED_BIT_BUFFER_OFFSET 1
+// #define ZSTDGPU_USE_REVERSED_BIT_BUFFER_BITBUF 1 // reversebits/v_bfrev_b32 idea, doesn't compile because of bitcntLast
+// #define ZSTDGPU_USE_REVERSED_BIT_BUFFER_OFFSET 1 // doesn't seem to matter
 
 typedef struct zstdgpu_Backward_BitBuffer_V0
 {
     ZSTDGPU_RO_BUFFER(uint32_t) buffer;
 
     uint64_t bitbuf;    // VGPRs storing valid bits that are not consumed yet
-    uint32_t nextDword; // VGPR storing the offset in dwords to the start of the next dword fetch
+    uint32_t lastReadDword;
     uint32_t bitcnt;    // VGPR storing the number of valid bits in `bitbuf`
     uint32_t bitcntLast;
-    uint32_t lastDword;   // VGPR as it store any memory block size varying per lane
     uint32_t baseDword;
     bool     hadlastrefill;
-    bool     hadlastrefillHuffman;
 } zstdgpu_Backward_BitBuffer_V0;
 
 typedef struct zstdgpu_Backward_BitBuffer
@@ -803,10 +801,6 @@ static inline void zstdgpu_Backward_BitBuffer_V0_InitWithSegment(ZSTDGPU_PARAM_I
 
     // Secondly, we search for the highest set bit to see how many bits are valid
     bitcnt = zstdgpu_FindFirstBitHiU32(bitbuf);
-#ifdef ZSTDGPU_USE_REVERSED_BIT_BUFFER_BITBUF
-    bitbuf <<= 32u - bitcnt;
-    bitbuf = reversebits(bitbuf);
-#else
     //bitmsk = ~0u >> (32u - bitcnt);
     bitmsk = (1u << bitcnt) - 1u;
     bitbuf &= bitmsk;
@@ -817,22 +811,14 @@ static inline void zstdgpu_Backward_BitBuffer_V0_InitWithSegment(ZSTDGPU_PARAM_I
         bitcnt  -= lobitcnt;
         bitbuf >>= lobitcnt;
     }
-#endif
 
     outBuffer.buffer = buffer;
     outBuffer.bitbuf = (uint64_t)bitbuf;
-#ifdef ZSTDGPU_USE_REVERSED_BIT_BUFFER_OFFSET
-    // in "reversed" offset mode we only increment "nextDword"
-    outBuffer.nextDword = 0;
-#else
-    outBuffer.nextDword = lastDword;
-#endif
+    outBuffer.lastReadDword = lastDword;
     outBuffer.bitcnt = bitcnt;
     outBuffer.bitcntLast = bitcntLast;
-    outBuffer.lastDword = lastDword;
     outBuffer.baseDword = baseDword;
     outBuffer.hadlastrefill = baseDword == lastDword;
-    outBuffer.hadlastrefillHuffman = false;
     //outBuffer.bytesz = bytesz;
 }
 
@@ -857,26 +843,14 @@ static inline void zstdgpu_Backward_BitBuffer_V0_Refill(ZSTDGPU_PARAM_INOUT(zstd
     if (inoutBuffer.bitcnt < bitcnt)
     {
         ZSTDGPU_ASSERT(inoutBuffer.hadlastrefill == false);
-
-#ifdef ZSTDGPU_USE_REVERSED_BIT_BUFFER_OFFSET
-        inoutBuffer.nextDword += 1;
-        const uint32_t nextDword = inoutBuffer.lastDword - inoutBuffer.nextDword;
-#else
-        ZSTDGPU_ASSERT(inoutBuffer.nextDword > 0);
-        inoutBuffer.nextDword -= 1;
-        const uint32_t nextDword = inoutBuffer.nextDword;
-#endif
-        ZSTDGPU_ASSERT(nextDword >= inoutBuffer.baseDword);
+        ZSTDGPU_ASSERT(inoutBuffer.baseDword < inoutBuffer.lastReadDword);
+        const uint32_t nextDword = --inoutBuffer.lastReadDword;
 
         // how many bits we need to remove
         const uint32_t lobitcnt = nextDword > inoutBuffer.baseDword ? 0u : inoutBuffer.bitcntLast;
         const uint32_t hibitcnt = 32u - lobitcnt;
 
-        #ifdef ZSTDGPU_USE_REVERSED_BIT_BUFFER_BITBUF
-            inoutBuffer.bitbuf |= (uint64_t)reversebits(inoutBuffer.buffer[nextDword]) << inoutBuffer.bitcnt;
-        #else
-            inoutBuffer.bitbuf = (inoutBuffer.bitbuf << hibitcnt) | (inoutBuffer.buffer[nextDword] >> lobitcnt);
-        #endif
+        inoutBuffer.bitbuf = (inoutBuffer.bitbuf << hibitcnt) | (inoutBuffer.buffer[nextDword] >> lobitcnt);
 
         inoutBuffer.bitcnt += hibitcnt;
         inoutBuffer.hadlastrefill = !(nextDword > inoutBuffer.baseDword);
@@ -886,63 +860,24 @@ static inline void zstdgpu_Backward_BitBuffer_V0_Refill(ZSTDGPU_PARAM_INOUT(zstd
 static inline uint32_t zstdgpu_Backward_BitBuffer_V0_Top(ZSTDGPU_PARAM_IN(zstdgpu_Backward_BitBuffer_V0) inBuffer, uint32_t bitcnt)
 {
     ZSTDGPU_ASSERT(inBuffer.bitcnt >= bitcnt);
-#ifdef ZSTDGPU_USE_REVERSED_BIT_BUFFER_BITBUF
-    // EXPERIMENT: store "bitbuf" reversed (by employing "v_bfrev_b32" on AMD)
-    // potentially two v_and_b32 on AMD because "bitcnt" is folded into a literal mask
-    return (uint32_t)(inBuffer.bitbuf & ~(~0ull << bitcnt));
-#else
     // potentially v_lshrrev_b64 + v_sub_nc_b32 on AMD
     return (uint32_t)(inBuffer.bitbuf >> (inBuffer.bitcnt - bitcnt));
-#endif
 }
 
 static inline void zstdgpu_Backward_BitBuffer_V0_Pop(ZSTDGPU_PARAM_INOUT(zstdgpu_Backward_BitBuffer_V0) inoutBuffer, uint32_t bitcnt)
 {
     ZSTDGPU_ASSERT(inoutBuffer.bitcnt >= bitcnt);
-#ifdef ZSTDGPU_USE_REVERSED_BIT_BUFFER_BITBUF
-    // EXPERIMENT: store "bitbuf" reversed (by employing "v_bfrev_b32" on AMD)
-    // potentially v_lshrrev_b64 + v_sub_nc_b32 on AMD
-    inoutBuffer.bitbuf >>= bitcnt;
-    inoutBuffer.bitcnt  -= bitcnt;
-#else
     // potentially v_sub_nc_b32 + v_lshrrev_b64 + two v_and_b32 on AMD because there's no v_bfm_b64 for mask
     inoutBuffer.bitbuf &= ~(~0ull << (inoutBuffer.bitcnt - bitcnt));
     inoutBuffer.bitcnt  -= bitcnt;
-#endif
 }
 
 ZSTDGPU_BITBUF_DEFINE_STANDARD_METHODS(Backward_BitBuffer_V0)
 
-static inline bool zstdgpu_Backward_BitBuffer_V0_CanRefill_Huffman(ZSTDGPU_PARAM_IN(zstdgpu_Backward_BitBuffer_V0) inBuffer, uint32_t bitcnt)
-{
-    ZSTDGPU_ASSERT(bitcnt <= 32);
-    if (inBuffer.bitcnt >= bitcnt)
-    {
-        return true;
-    }
-    else
-    {
-        return !inBuffer.hadlastrefillHuffman;
-    }
-}
-
-static inline void zstdgpu_Backward_BitBuffer_V0_Refill_Huffman(ZSTDGPU_PARAM_INOUT(zstdgpu_Backward_BitBuffer_V0) inoutBuffer, uint32_t bitcnt, uint32_t extrabits)
-{
-    if (inoutBuffer.hadlastrefill == false)
-    {
-        zstdgpu_Backward_BitBuffer_V0_Refill(inoutBuffer, bitcnt);
-    }
-
-    if (inoutBuffer.bitcnt < bitcnt)
-    {
-        inoutBuffer.bitcnt += extrabits;    // simply increment counter because upper bits are zeros
-        inoutBuffer.hadlastrefillHuffman = true;
-    }
-}
-
 static inline uint32_t zstdgpu_Backward_BitBuffer_V0_Get_Huffman(ZSTDGPU_PARAM_INOUT(zstdgpu_Backward_BitBuffer_V0) inoutBuffer, uint32_t bitcnt, uint32_t extrabits)
 {
-    if (inoutBuffer.hadlastrefill == false)
+    // Always true when doing test-in-loop-middle on Regenerated_Size:
+    // if (inoutBuffer.hadlastrefill == false)
     {
         zstdgpu_Backward_BitBuffer_V0_Refill(inoutBuffer, bitcnt);
     }
@@ -951,7 +886,6 @@ static inline uint32_t zstdgpu_Backward_BitBuffer_V0_Get_Huffman(ZSTDGPU_PARAM_I
     {
         inoutBuffer.bitcnt += extrabits;    // simply increment counter because upper bits are zeros
         inoutBuffer.bitbuf <<= extrabits;
-        inoutBuffer.hadlastrefillHuffman = true;
     }
 
     uint32_t result = zstdgpu_Backward_BitBuffer_V0_Top(inoutBuffer, bitcnt);

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -313,6 +313,8 @@ static const uint32_t kzstdgpu_TgSizeX_ExecuteSequences = 32;
 #endif
 
 #ifndef __hlsl_dx_compiler
+typedef const uint32_t* zstdgpu_RawBufferSrvU32;
+
 typedef struct uint32_t4
 {
     uint32_t x, y, z, w;
@@ -341,35 +343,20 @@ static inline void InterlockedMin(uint32_t & dst, uint32_t x) { dst = dst < x ? 
 static inline void InterlockedMax(uint32_t & dst, uint32_t x) { dst = dst > x ? dst : x; }
 static inline void InterlockedAdd(uint32_t & dst, uint32_t x, uint32_t & ret) { ret = dst; dst += x; }
 static inline void InterlockedCompareStore(uint32_t & dst, uint32_t compare, uint32_t x) { if (dst == compare) dst = x; }
-
-using zstdgpu_RawBufferSrvU32 = const uint32_t*;
-
-static inline uint32_t zstdgpu_RawLoadU32AtByteOffset(zstdgpu_RawBufferSrvU32 buffer, uint32_t offset)
-{
-    return *reinterpret_cast<const uint32_t*>(reinterpret_cast<const char*>(buffer) + offset);
-}
-
-static inline uint64_t zstdgpu_RawLoadU64AtByteOffset(zstdgpu_RawBufferSrvU32 buffer, uint32_t offset)
-{
-    return *reinterpret_cast<const uint64_t* __unaligned>(reinterpret_cast<const char*>(buffer) + offset);
-}
-
 #else
-
-#define zstdgpu_RawBufferSrvU32 ByteAddressBuffer
-
-static inline uint32_t zstdgpu_RawLoadU32AtByteOffset(zstdgpu_RawBufferSrvU32 buffer, uint32_t offset)
-{
-    return buffer.Load(offset);
-}
+typedef ByteAddressBuffer zstdgpu_RawBufferSrvU32;
+#endif
 
 static inline uint64_t zstdgpu_RawLoadU64AtByteOffset(zstdgpu_RawBufferSrvU32 buffer, uint32_t offset)
 {
+#ifdef __hlsl_dx_compiler
     uint2 v = buffer.Load2(offset);
     return v.x | (uint64_t(v.y) << 32);
-}
-
+#else
+    const uint32_t* p32 = reinterpret_cast<const uint32_t*>(reinterpret_cast<const char*>(buffer) + offset);
+    return p32[0] | (uint64_t(p32[1]) << 32);
 #endif
+}
 
 static inline uint32_t zstdgpu_BitFieldExtractU32(uint32_t x, uint32_t start, uint32_t count)
 {
@@ -994,7 +981,7 @@ static inline uint32_t zstdgpu_HuffmanStream_RefillAndPeek(ZSTDGPU_PARAM_INOUT(z
     // Do Peek.
     const uint32_t k = stream._32MinusMaxBitsPerCode;
     const uint32_t data0_hiShift = k + stream.numBitsSpare;
-    const uint32_t data0_hi = uint32_t(stream.data0 >> 32); // High U32 extract is free. U64 shift is slow. maxBitsPerCode is <= 11.
+    const uint32_t data0_hi = uint32_t(stream.data0 >> 32); // High U32 extract is free. U64 shift slower than U32. maxBitsPerCode <= 11.
     ZSTDGPU_ASSERT(data0_hiShift < 32u);
     return (stream.dataSpare >> k) | (data0_hi >> data0_hiShift);
 }

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -908,48 +908,26 @@ static inline void zstdgpu_Backward_BitBuffer_V0_Pop(ZSTDGPU_PARAM_INOUT(zstdgpu
 
 ZSTDGPU_BITBUF_DEFINE_STANDARD_METHODS(Backward_BitBuffer_V0)
 
-// Possible debugging method when trying different bitbuffer ideas:
-// keep an older working implementation around and call them side by side, e.g:
-//
-// void func(...)
-// {   ...
-//     old_Init(old_stream);
-//     new_Init(new_stream);
-//     for (...)
-//     {
-//         old_state = old_RefillAndPeak(old_stream);
-//         new_state = new_RefillAndPeak(new_stream);
-//         if (old_state != new_state)
-//             __debugbreak();
-//         ...
-//         old_state = old_Consume(...);
-//         new_state = new_Consume(...);
-//     }
-//     ...
-// }
-
-// NOTE(jweinste):
-//
-// Backwards bitstream that loads aligned 64-bit elements (instead of 32-bit elements).
-// That was the main goal, and the rest of how this work is what felt "natural".
-//
-// These functions do not check if the source stream was fully consumed, calling code must determine when to stop looping.
-//
-// This style of bitstream could perhaps be used for other things in the future.
+// NOTE(jweinste): Backwards bitstream that loads aligned 64-bit elements (instead of 32-bit elements) per-lane needing refill.
 struct zstdgpu_HuffmanStream
 {
     zstdgpu_RawBufferSrvU32 buffer;
+    uint32_t                finalByteOffset;
     uint32_t                lastByteOffset;
 
-    // Used to juggle bits we still have but need to load another U64.
-    // This juggling means there is a decent amount of ALU (including one 64-bit shift) per Peek+Consume,
-    // but doing fewer loads (by loading U64 over U32) seems worth it (since loads might be immediately waited on).
-    // The refill condition may be non-uniform though, making things not clear-cut.
     uint32_t dataSpare;
     uint32_t numBitsSpare; // always strictly < maxBitsPerCode
 
-    // Remaining bits are kept in _high_ bits.
-    // If there is one 5-bit code left (numBits0 = 5) with value 0b11111, then data0 = 0xF800'0000'0000'0000, NOT 0x1F or anything else.
+    // Available bits are stored against the high-end of the U64.
+    // This initially felt natural since the bitstream is read from MSB to LSB,
+    // and it allows for Peek() to not need a 64-bit shift (although there might be more ALU elsewhere).
+    //
+    // Example: if there is one 5-bit code left (numBits0 = 5) with value 0b11111, then data0 = 0xF800'0000'0000'0000 (not 0x1F).
+    //
+    // @last_peek: On the (potentially more than just the) last call to RefillAndPeek(), there might be < maxBitsPerCode available
+    // (only the actual number of bits for the last code), but every U64 that at contains at least one useful byte would already have
+    // been loaded. When that last U64 is read (which may be in InitWithSegment()), we set numBits0 to UINT_MAX so the next
+    // (and any subsequent reasonable amount) of RefillAndPeek() do not emit a load.
     uint64_t data0;
     uint32_t numBits0;
 
@@ -957,19 +935,14 @@ struct zstdgpu_HuffmanStream
     uint32_t _32MinusMaxBitsPerCode;
 };
 
-static inline void zstdgpu_HuffmanStream_InitWithSegment(
-    ZSTDGPU_PARAM_INOUT(zstdgpu_HuffmanStream)      stream,
-    ZSTDGPU_PARAM_IN(zstdgpu_RawBufferSrvU32)       buffer,
-    ZSTDGPU_PARAM_IN(zstdgpu_OffsetAndSize) segment,
-    ZSTDGPU_PARAM_IN(uint32_t)              maxBitsPerCode)
+static inline void zstdgpu_HuffmanStream_InitWithSegment(ZSTDGPU_PARAM_INOUT(zstdgpu_HuffmanStream) stream, zstdgpu_RawBufferSrvU32 buffer, ZSTDGPU_PARAM_IN(zstdgpu_OffsetAndSize) segment, ZSTDGPU_PARAM_IN(uint32_t) maxBitsPerCode)
 {
     // NOTE(jweinste): we could just load a single DWORD here to reduce codesize/ALU here in InitWithSegment(),
     // but we want to ensure that the DWORDx2 loads in RefillAndPeek() are 8-byte aligned.
-    // Alignment might improve cache behavior, but it is mainly to remove OOB concerns,
-    // assuming the _first_ frame in a "file" is at least 4-byte aligned,
-    // since a frame is at least 2 bytes and a block has a 3-byte header.
+    // Alignment might improve cache behavior, but it is mainly to potentially limit how many "OOB" bytes we read.
 
     const uint32_t lastByteIdx = (segment.offs + segment.size) - 1; // Byte index containing the flag.
+    const uint32_t finalByteOffsetForU64 = segment.offs & -8;
     const uint32_t lastByteOffsetForU64 = lastByteIdx & -8;
     uint64_t data64 = zstdgpu_RawLoadU64AtByteOffset(buffer, lastByteOffsetForU64);
 
@@ -983,15 +956,17 @@ static inline void zstdgpu_HuffmanStream_InitWithSegment(
     // Add one (reverse-subtract by 32, not 31) to also shift out the flag itself.
     const uint32_t nonDataBitCount = 32 - zstdgpu_FindFirstBitHiU32(uint32_t(data64 >> 32));
     data64 <<= nonDataBitCount;
+    const uint32_t keptBitCount = 64 - (oobBitCount + nonDataBitCount); // could be 0
 
-    stream.buffer         = buffer;
-    stream.lastByteOffset = lastByteOffsetForU64;
+    stream.buffer          = buffer;
+    stream.finalByteOffset = finalByteOffsetForU64;
+    stream.lastByteOffset  = lastByteOffsetForU64;
 
     stream.dataSpare    = 0;
     stream.numBitsSpare = 0;
 
     stream.data0    = data64;
-    stream.numBits0 = 64 - (oobBitCount + nonDataBitCount); // How many bits we kept (could be 0).
+    stream.numBits0 = (finalByteOffsetForU64 == lastByteOffsetForU64) ? uint32_t(-1) : keptBitCount; // see @last_peek comment
 
     stream.maxBitsPerCode         = maxBitsPerCode;
     stream._32MinusMaxBitsPerCode = 32 - maxBitsPerCode;
@@ -1004,21 +979,24 @@ static inline uint32_t zstdgpu_HuffmanStream_RefillAndPeek(ZSTDGPU_PARAM_INOUT(z
     // Need refill?
     if (stream.numBits0 < stream.maxBitsPerCode)
     {
-        // Do refill.
         ZSTDGPU_ASSERT(stream.numBitsSpare == 0);
-        stream.dataSpare    = uint32_t(stream.data0 >> 32);
-        stream.numBitsSpare = stream.numBits0;
-        stream.numBits0     = 64;
-        stream.data0        = zstdgpu_RawLoadU64AtByteOffset(stream.buffer, stream.lastByteOffset -= sizeof(uint64_t)); // NOTE: -=
+        ZSTDGPU_ASSERT(((stream.finalByteOffset | stream.lastByteOffset) & 7) == 0);
+        ZSTDGPU_ASSERT(stream.finalByteOffset < stream.lastByteOffset);
+        // Do refill.
+        const uint32_t loadByteOffset = stream.lastByteOffset - sizeof(uint64_t);
+        stream.dataSpare      = uint32_t(stream.data0 >> 32);
+        stream.numBitsSpare   = stream.numBits0;
+        stream.lastByteOffset = loadByteOffset;
+        stream.data0          = zstdgpu_RawLoadU64AtByteOffset(stream.buffer, loadByteOffset);
+        stream.numBits0       = (stream.finalByteOffset == loadByteOffset) ? uint32_t(-1) : 64; // see @last_peek comment
     }
 
-    // Peak.
+    // Do Peek.
     const uint32_t k = stream._32MinusMaxBitsPerCode;
-    ZSTDGPU_ASSERT(k + stream.numBitsSpare < 32u);
-    // Extracting high U32 is "free" since U64 is a pair of VGPRs. Avoid slower U64 shift. Works because maxBitsPerCode bits is <= 11.
-    const uint32_t data0_hi = uint32_t(stream.data0 >> 32);
-    return (stream.dataSpare >> k) |
-           (data0_hi >> (k + stream.numBitsSpare));
+    const uint32_t data0_hiShift = k + stream.numBitsSpare;
+    const uint32_t data0_hi = uint32_t(stream.data0 >> 32); // High U32 extract is free. U64 shift is slow. maxBitsPerCode is <= 11.
+    ZSTDGPU_ASSERT(data0_hiShift < 32u);
+    return (stream.dataSpare >> k) | (data0_hi >> data0_hiShift);
 }
 
 static inline void zstdgpu_HuffmanStream_Consume(ZSTDGPU_PARAM_INOUT(zstdgpu_HuffmanStream) stream, ZSTDGPU_PARAM_IN(int) actualBitCount)

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -767,14 +767,18 @@ static inline void zstdgpu_Forward_BitBuffer_ByteAlign(ZSTDGPU_PARAM_INOUT(zstdg
     zstdgpu_Forward_BitBuffer_Pop(inoutBuffer, inoutBuffer.bitcnt & 7);
 }
 
+//#define ZSTDGPU_USE_REVERSED_BIT_BUFFER_BITBUF 1
+#define ZSTDGPU_USE_REVERSED_BIT_BUFFER_OFFSET 1
+
 typedef struct zstdgpu_Backward_BitBuffer_V0
 {
     ZSTDGPU_RO_BUFFER(uint32_t) buffer;
 
     uint64_t bitbuf;    // VGPRs storing valid bits that are not consumed yet
-    uint32_t lastReadDword;
+    uint32_t nextDword; // VGPR storing the offset in dwords to the start of the next dword fetch
     uint32_t bitcnt;    // VGPR storing the number of valid bits in `bitbuf`
     uint32_t bitcntLast;
+    uint32_t lastDword;   // VGPR as it store any memory block size varying per lane
     uint32_t baseDword;
     bool     hadlastrefill;
 } zstdgpu_Backward_BitBuffer_V0;
@@ -822,6 +826,10 @@ static inline void zstdgpu_Backward_BitBuffer_V0_InitWithSegment(ZSTDGPU_PARAM_I
 
     // Secondly, we search for the highest set bit to see how many bits are valid
     bitcnt = zstdgpu_FindFirstBitHiU32(bitbuf);
+#ifdef ZSTDGPU_USE_REVERSED_BIT_BUFFER_BITBUF
+    bitbuf <<= 32u - bitcnt;
+    bitbuf = reversebits(bitbuf);
+#else
     //bitmsk = ~0u >> (32u - bitcnt);
     bitmsk = (1u << bitcnt) - 1u;
     bitbuf &= bitmsk;
@@ -832,12 +840,19 @@ static inline void zstdgpu_Backward_BitBuffer_V0_InitWithSegment(ZSTDGPU_PARAM_I
         bitcnt  -= lobitcnt;
         bitbuf >>= lobitcnt;
     }
+#endif
 
     outBuffer.buffer = buffer;
     outBuffer.bitbuf = (uint64_t)bitbuf;
-    outBuffer.lastReadDword = lastDword;
+#ifdef ZSTDGPU_USE_REVERSED_BIT_BUFFER_OFFSET
+    // in "reversed" offset mode we only increment "nextDword"
+    outBuffer.nextDword = 0;
+#else
+    outBuffer.nextDword = lastDword;
+#endif
     outBuffer.bitcnt = bitcnt;
     outBuffer.bitcntLast = bitcntLast;
+    outBuffer.lastDword = lastDword;
     outBuffer.baseDword = baseDword;
     outBuffer.hadlastrefill = baseDword == lastDword;
     //outBuffer.bytesz = bytesz;
@@ -864,14 +879,26 @@ static inline void zstdgpu_Backward_BitBuffer_V0_Refill(ZSTDGPU_PARAM_INOUT(zstd
     if (inoutBuffer.bitcnt < bitcnt)
     {
         ZSTDGPU_ASSERT(inoutBuffer.hadlastrefill == false);
-        ZSTDGPU_ASSERT(inoutBuffer.baseDword < inoutBuffer.lastReadDword);
-        const uint32_t nextDword = --inoutBuffer.lastReadDword;
+
+#ifdef ZSTDGPU_USE_REVERSED_BIT_BUFFER_OFFSET
+        inoutBuffer.nextDword += 1;
+        const uint32_t nextDword = inoutBuffer.lastDword - inoutBuffer.nextDword;
+#else
+        ZSTDGPU_ASSERT(inoutBuffer.nextDword > 0);
+        inoutBuffer.nextDword -= 1;
+        const uint32_t nextDword = inoutBuffer.nextDword;
+#endif
+        ZSTDGPU_ASSERT(nextDword >= inoutBuffer.baseDword);
 
         // how many bits we need to remove
         const uint32_t lobitcnt = nextDword > inoutBuffer.baseDword ? 0u : inoutBuffer.bitcntLast;
         const uint32_t hibitcnt = 32u - lobitcnt;
 
-        inoutBuffer.bitbuf = (inoutBuffer.bitbuf << hibitcnt) | (inoutBuffer.buffer[nextDword] >> lobitcnt);
+        #ifdef ZSTDGPU_USE_REVERSED_BIT_BUFFER_BITBUF
+            inoutBuffer.bitbuf |= (uint64_t)reversebits(inoutBuffer.buffer[nextDword]) << inoutBuffer.bitcnt;
+        #else
+            inoutBuffer.bitbuf = (inoutBuffer.bitbuf << hibitcnt) | (inoutBuffer.buffer[nextDword] >> lobitcnt);
+        #endif
 
         inoutBuffer.bitcnt += hibitcnt;
         inoutBuffer.hadlastrefill = !(nextDword > inoutBuffer.baseDword);
@@ -881,16 +908,29 @@ static inline void zstdgpu_Backward_BitBuffer_V0_Refill(ZSTDGPU_PARAM_INOUT(zstd
 static inline uint32_t zstdgpu_Backward_BitBuffer_V0_Top(ZSTDGPU_PARAM_IN(zstdgpu_Backward_BitBuffer_V0) inBuffer, uint32_t bitcnt)
 {
     ZSTDGPU_ASSERT(inBuffer.bitcnt >= bitcnt);
+#ifdef ZSTDGPU_USE_REVERSED_BIT_BUFFER_BITBUF
+    // EXPERIMENT: store "bitbuf" reversed (by employing "v_bfrev_b32" on AMD)
+    // potentially two v_and_b32 on AMD because "bitcnt" is folded into a literal mask
+    return (uint32_t)(inBuffer.bitbuf & ~(~0ull << bitcnt));
+#else
     // potentially v_lshrrev_b64 + v_sub_nc_b32 on AMD
     return (uint32_t)(inBuffer.bitbuf >> (inBuffer.bitcnt - bitcnt));
+#endif
 }
 
 static inline void zstdgpu_Backward_BitBuffer_V0_Pop(ZSTDGPU_PARAM_INOUT(zstdgpu_Backward_BitBuffer_V0) inoutBuffer, uint32_t bitcnt)
 {
     ZSTDGPU_ASSERT(inoutBuffer.bitcnt >= bitcnt);
+#ifdef ZSTDGPU_USE_REVERSED_BIT_BUFFER_BITBUF
+    // EXPERIMENT: store "bitbuf" reversed (by employing "v_bfrev_b32" on AMD)
+    // potentially v_lshrrev_b64 + v_sub_nc_b32 on AMD
+    inoutBuffer.bitbuf >>= bitcnt;
+    inoutBuffer.bitcnt  -= bitcnt;
+#else
     // potentially v_sub_nc_b32 + v_lshrrev_b64 + two v_and_b32 on AMD because there's no v_bfm_b64 for mask
     inoutBuffer.bitbuf &= ~(~0ull << (inoutBuffer.bitcnt - bitcnt));
     inoutBuffer.bitcnt  -= bitcnt;
+#endif
 }
 
 ZSTDGPU_BITBUF_DEFINE_STANDARD_METHODS(Backward_BitBuffer_V0)

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -152,6 +152,7 @@ static const int16_t kzstdgpuFseProbsDefault[] =
 
 #include "zstdgpu_resources.h"
 
+#define ZSTDGPU_RO_RAW_BUFFER_DECL(name, index)                        srt.in##name    = resources.name;
 #define ZSTDGPU_RO_BUFFER_DECL(type, name, index)                      srt.in##name    = resources.name;
 #define ZSTDGPU_RW_BUFFER_DECL(type, name, index)                      srt.inout##name = resources.name;
 #define ZSTDGPU_RW_BUFFER_DECL_GLC(type, name, index)                  srt.inout##name = resources.name;
@@ -213,6 +214,7 @@ static void zstdgpu_Init_FinaliseSequenceOffsets_SRT(zstdgpu_FinaliseSequenceOff
 #undef ZSTDGPU_RW_BUFFER_DECL_GLC
 #undef ZSTDGPU_RW_BUFFER_DECL
 #undef ZSTDGPU_RO_BUFFER_DECL
+#undef ZSTDGPU_RO_RAW_BUFFER_DECL
 
 #define STRINGIZE(x) STRINGIZE2(x)
 #define STRINGIZE2(x) #x

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -152,7 +152,7 @@ static const int16_t kzstdgpuFseProbsDefault[] =
 
 #include "zstdgpu_resources.h"
 
-#define ZSTDGPU_RO_RAW_BUFFER_DECL(name, index)                        srt.in##name    = resources.name;
+#define ZSTDGPU_RO_RAW_BUFFER_DECL(type, name, index)                  srt.in##name    = resources.name;
 #define ZSTDGPU_RO_BUFFER_DECL(type, name, index)                      srt.in##name    = resources.name;
 #define ZSTDGPU_RW_BUFFER_DECL(type, name, index)                      srt.inout##name = resources.name;
 #define ZSTDGPU_RW_BUFFER_DECL_GLC(type, name, index)                  srt.inout##name = resources.name;


### PR DESCRIPTION
Add a backwards-bitbuffer used for Huffman compressed literals. The main difference about it is it does a 64-bit load (for each lane needing a refill) instead of 32-bit load, but at the cost of more ALU. I didn't give much thought to if the ALU could be reduced.

This PR also adds "`zstdgpu_RawBufferSrvU32`". I was hesitant to use a `StructuredBuffer<uint64_t>` through the existing `ZSTDGPU_RO_BUFFER_DECL` macros because of multiple instances of things like
`uint32_t* tmp = gpuReadbackRes.CompressedData;` in `main.cpp`. Raw buffer descriptor creation is specified specified in terms of `R32_TYPELESS` elements, so maybe its okay that `zstdgpu_RawBufferSrvU32` is just `typedef`'d to `const uint32_t *` on the CPU (its `ByteAddressBuffer` in HLSL). Raw buffers could also be useful for something else; two adjacent `StructuredBuffer<uint32_t>` loads may not be merged into a single load (e.g.: one `buffer_load_b64` on RDNA3) due to OOB-semantics.

The D3D API says raw buffers need to be created with a 16-byte aligned offset into a resource, but I think that is okay as it seems we create the buffer at the very start of the resource containing the zst "file".

Some performance data:
- .zst file: a ~825K archive of 3 processed and concatenated BCn textures.
- GPU: RX 7900 XTX
- PIX timings with "peak" clocks via the plugin.
- Before -> After duration of `[Init Huffman Table and Decompress Literals]`: 330 us -> 280 us.

I also have a much larger (maybe unrealistic) file that happens to see similar ~15% duration reduction.

Its possible a backwards-bitbuffer like this may improve performance in the FSE areas too, but I'm not quite familiar there currently. I also had a further potential "`s_waitcnt`-optimization" that I can't quantify now as the compiled GPU code was not what I was after.