### PR TITLE
 Pulls up sequence decompression shader variant into a separate file, makes it default and creates permutations

### DIFF
--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences.hlsl
@@ -19,11 +19,7 @@
 #define __XBOX_ENABLE_WAVE32 1
 #endif
 
-#if kzstdgpu_TgSizeX_DecompressSequences == 1
-#define USE_LDS_FSE_CACHE 1
-#else
 //#define USE_LDS_OUT_CACHE 1
-#endif
 
 #ifdef USE_LDS_OUT_CACHE
 #define SEQ_CACHE_LEN 128
@@ -31,41 +27,48 @@
 
 #include "../zstdgpu_shaders.h"
 
+struct Consts
+{
+    uint32_t tgOffset;
+};
+
+ConstantBuffer<Consts> Constants : register(b0);
+
 #include "../zstdgpu_srt_decl_bind.h"
 ZSTDGPU_DECOMPRESS_SEQUENCES_SRT()
 #include "../zstdgpu_srt_decl_undef.h"
 
-#ifdef USE_LDS_FSE_CACHE
-groupshared uint32_t Lds[kzstdgpu_DecompressSequences_LdsFseCache_LdsSize];
-#define ZSTDGPU_LDS Lds
-#include "../zstdgpu_lds_hlsl.h"
-#endif
-
-#ifdef USE_LDS_OUT_CACHE
+#if defined(USE_LDS_OUT_CACHE)
 groupshared uint32_t Lds[kzstdgpu_DecompressSequences_LdsOutCache_LdsSize];
 #define ZSTDGPU_LDS Lds
 #include "../zstdgpu_lds_hlsl.h"
 #endif
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=8), UAV(u0, numDescriptors=7))")]
-#if defined(USE_LDS_FSE_CACHE) || defined(USE_LDS_OUT_CACHE)
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=8), UAV(u0, numDescriptors=7)), RootConstants(b0, num32BitConstants=1)")]
+#ifdef USE_LDS_OUT_CACHE
 #define NUM_THREADS 32
 [numthreads(NUM_THREADS, 1, 1)]
-void main(uint32_t groupId : SV_GroupId, uint i : SV_GroupThreadId)
 #else
 [numthreads(kzstdgpu_TgSizeX_DecompressSequences, 1, 1)]
-void main(uint i : SV_DispatchThreadId)
 #endif
+void main(uint32_t2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
 {
+#if defined(__XBOX_SCARLETT) || defined(__XBOX_ONE)
+    const uint32_t groupId = groupId2.x;
+#else
+    const uint32_t groupId = Constants.tgOffset + groupId2.y * 65535 + groupId2.x;
+#endif
+
+#ifndef USE_LDS_OUT_CACHE
+    i += groupId * kzstdgpu_TgSizeX_DecompressSequences;
+#endif
     zstdgpu_DecompressSequences_SRT srt;
 
     #include "../zstdgpu_srt_decl_copy.h"
     ZSTDGPU_DECOMPRESS_SEQUENCES_SRT()
     #include "../zstdgpu_srt_decl_undef.h"
 
-#if defined(USE_LDS_FSE_CACHE)
-    zstdgpu_ShaderEntry_DecompressSequences_LdsFseCache(srt, groupId, i, NUM_THREADS);
-#elif defined(USE_LDS_OUT_CACHE)
+#if defined(USE_LDS_OUT_CACHE)
     zstdgpu_ShaderEntry_DecompressSequences_LdsOutCache(srt, groupId, i);
 #else
     zstdgpu_ShaderEntry_DecompressSequences(srt, i);

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_LdsFseCache.hlsli
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_LdsFseCache.hlsli
@@ -1,0 +1,72 @@
+/**
+ * ZstdGpuDecompressSequences_LdsFseCache.hlsli
+ *
+ * A compute shader that decompresses FSE-compressed sequences.
+ * It preloads FSE tables into LDS for faster access. The threadgroup processes only one sequence.
+ *
+ * Because of this, this shader must be compiled as a small threadgroup as possible.
+ *
+ * However, because D3D12 doesn't allow to query on C++ side the size of the actual wave the compiler
+ * have chosen for a threadgroup, on hardware with multiple supported wave sizes -- it's not possible
+ * to make exact choice of the permutation with the 'numthreads' matching wave size.
+ * We can't use WaveSize in HLSL either because it would require SM 6.5.
+ *
+ * Therefore 'kzstdgpu_TgSizeX_DecompressSequences_LdsFseCache' must be defined before including this file,
+ * It controls threadgroup size which on hardware with multiple wave size equals to the size of the largest
+ * wave that could be created. We determine the actual wave size in the threadgroup by using `WaveLaneCount()`
+ * intrinsic and early out waves that are no longer needed.
+ * This has an potential overhead of launching unused waves/more constrained(multiple waves) threadgroups
+ *
+ * Copyright (c) Microsoft. All rights reserved.
+ * This code is licensed under the MIT License (MIT).
+ * THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+ * ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+ * IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+ *
+ * Advanced Technology Group (ATG)
+ * Author(s):   Pavel Martishevsky (pamartis@microsoft.com)
+ */
+
+#ifdef __XBOX_SCARLETT
+#define __XBOX_ENABLE_WAVE32 1
+#endif
+
+#include "../zstdgpu_shaders.h"
+
+struct Consts
+{
+    uint32_t tgOffset;
+};
+
+ConstantBuffer<Consts> Constants : register(b0);
+
+#include "../zstdgpu_srt_decl_bind.h"
+ZSTDGPU_DECOMPRESS_SEQUENCES_SRT()
+#include "../zstdgpu_srt_decl_undef.h"
+
+groupshared uint32_t Lds[kzstdgpu_DecompressSequences_LdsFseCache_LdsSize];
+#define ZSTDGPU_LDS Lds
+#include "../zstdgpu_lds_hlsl.h"
+
+#ifndef kzstdgpu_TgSizeX_DecompressSequences_LdsFseCache
+#   error 'kzstdgpu_TgSizeX_DecompressSequences_LdsFseCache' must be defined before including this '.hlsli'
+#endif
+
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=8), UAV(u0, numDescriptors=7)), RootConstants(b0, num32BitConstants=1)")]
+[numthreads(kzstdgpu_TgSizeX_DecompressSequences_LdsFseCache, 1, 1)]
+void main(uint32_t2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
+{
+#if defined(__XBOX_SCARLETT) || defined(__XBOX_ONE)
+    const uint32_t groupId = groupId2.x;
+#else
+    const uint32_t groupId = Constants.tgOffset + groupId2.y * 65535 + groupId2.x;
+#endif
+    zstdgpu_DecompressSequences_SRT srt;
+
+    #include "../zstdgpu_srt_decl_copy.h"
+    ZSTDGPU_DECOMPRESS_SEQUENCES_SRT()
+    #include "../zstdgpu_srt_decl_undef.h"
+
+    zstdgpu_ShaderEntry_DecompressSequences_LdsFseCache(srt, groupId, i, kzstdgpu_TgSizeX_DecompressSequences_LdsFseCache);
+}

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_LdsFseCache128.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_LdsFseCache128.hlsl
@@ -1,0 +1,20 @@
+/**
+ * ZstdGpuDecompressSequences_LdsFseCache128.hlsl
+ *
+ * A variant of the compute shader decompressessing FSE-compressed sequences with
+ * FSE tables being pre-cached into LDS that targets hardware with maximal supported
+ * wave size of 128 lanes.
+ *
+ * Copyright (c) Microsoft. All rights reserved.
+ * This code is licensed under the MIT License (MIT).
+ * THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+ * ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+ * IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+ *
+ * Advanced Technology Group (ATG)
+ * Author(s):   Pavel Martishevsky (pamartis@microsoft.com)
+ */
+
+#define kzstdgpu_TgSizeX_DecompressSequences_LdsFseCache 128
+#include "ZstdGpuDecompressSequences_LdsFseCache.hlsli"

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_LdsFseCache32.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_LdsFseCache32.hlsl
@@ -1,0 +1,20 @@
+/**
+ * ZstdGpuDecompressSequences_LdsFseCache32.hlsl
+ *
+ * A variant of the compute shader decompressessing FSE-compressed sequences with
+ * FSE tables being pre-cached into LDS that targets hardware with maximal supported
+ * wave size of 32 lanes.
+ *
+ * Copyright (c) Microsoft. All rights reserved.
+ * This code is licensed under the MIT License (MIT).
+ * THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+ * ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+ * IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+ *
+ * Advanced Technology Group (ATG)
+ * Author(s):   Pavel Martishevsky (pamartis@microsoft.com)
+ */
+
+#define kzstdgpu_TgSizeX_DecompressSequences_LdsFseCache 32
+#include "ZstdGpuDecompressSequences_LdsFseCache.hlsli"

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_LdsFseCache64.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_LdsFseCache64.hlsl
@@ -1,0 +1,20 @@
+/**
+ * ZstdGpuDecompressSequences_LdsFseCache64.hlsl
+ *
+ * A variant of the compute shader decompressessing FSE-compressed sequences with
+ * FSE tables being pre-cached into LDS that targets hardware with maximal supported
+ * wave size of 64 lanes.
+ *
+ * Copyright (c) Microsoft. All rights reserved.
+ * This code is licensed under the MIT License (MIT).
+ * THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+ * ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+ * IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+ *
+ * Advanced Technology Group (ATG)
+ * Author(s):   Pavel Martishevsky (pamartis@microsoft.com)
+ */
+
+#define kzstdgpu_TgSizeX_DecompressSequences_LdsFseCache 64
+#include "ZstdGpuDecompressSequences_LdsFseCache.hlsli"

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -40,6 +40,9 @@
 #include "ZstdGpuDecompressHuffmanWeights.h"
 #include "ZstdGpuDecompressLiterals.h"
 #include "ZstdGpuDecompressSequences.h"
+#include "ZstdGpuDecompressSequences_LdsFseCache128.h"
+#include "ZstdGpuDecompressSequences_LdsFseCache64.h"
+#include "ZstdGpuDecompressSequences_LdsFseCache32.h"
 #include "ZstdGpuExecuteSequences128.h"
 #include "ZstdGpuExecuteSequences64.h"
 #include "ZstdGpuExecuteSequences32.h"
@@ -306,6 +309,9 @@ static void zstdgpu_ReCreate_SRTs(zstdgpu_SRTs & srts, ID3D12Device *device, con
     ZSTDGPU_KERNEL(DecompressHuffmanWeights                 , L"Decompress FSE-compressed Huffman Weights")                         \
     ZSTDGPU_KERNEL(DecompressLiterals                       , L"Decompress Literals")                                               \
     ZSTDGPU_KERNEL(DecompressSequences                      , L"Decompress Sequences")                                              \
+    ZSTDGPU_KERNEL(DecompressSequences_LdsFseCache128      , L"Decompress Sequences (LDS FSE Cache 128)")                           \
+    ZSTDGPU_KERNEL(DecompressSequences_LdsFseCache64       , L"Decompress Sequences (LDS FSE Cache 64)")                            \
+    ZSTDGPU_KERNEL(DecompressSequences_LdsFseCache32       , L"Decompress Sequences (LDS FSE Cache 32)")                            \
     ZSTDGPU_KERNEL(ExecuteSequences128                      , L"Execute Sequences 128")                                             \
     ZSTDGPU_KERNEL(ExecuteSequences64                       , L"Execute Sequences 64")                                              \
     ZSTDGPU_KERNEL(ExecuteSequences32                       , L"Execute Sequences 32")                                              \
@@ -391,6 +397,7 @@ struct zstdgpu_PerRequestContextImpl
         ZSTDGPU_KERNEL_LIST()
     #undef ZSTDGPU_KERNEL
     d3d12aid_ComputeRsPs    ExecuteSequences;
+    d3d12aid_ComputeRsPs    DecompressSequences_LdsFseCache;
 
     zstdgpu_SRTs            srts;
     zstdgpu_ResourceDataGpu resData;
@@ -551,22 +558,29 @@ zstdgpu_Status zstdgpu_CreatePerRequestContext(zstdgpu_PerRequestContext *outPer
         #undef ZSTDGPU_KERNEL
 #ifdef _GAMING_XBOX_SCARLETT
         context->ExecuteSequences = context->ExecuteSequences64;
+        context->DecompressSequences_LdsFseCache = context->DecompressSequences_LdsFseCache32;
 #else
         if (persistentContext->maxLaneCount == 128)
         {
             context->ExecuteSequences = context->ExecuteSequences128;
+            context->DecompressSequences_LdsFseCache = context->DecompressSequences_LdsFseCache128;
         }
         else if (persistentContext->maxLaneCount == 64)
         {
             context->ExecuteSequences = context->ExecuteSequences64;
+            context->DecompressSequences_LdsFseCache = context->DecompressSequences_LdsFseCache64;
         }
         else
         {
             context->ExecuteSequences = context->ExecuteSequences32;
+            context->DecompressSequences_LdsFseCache = context->DecompressSequences_LdsFseCache32;
         }
 #endif
         context->ExecuteSequences.rs->AddRef();
         context->ExecuteSequences.ps->AddRef();
+
+        context->DecompressSequences_LdsFseCache.rs->AddRef();
+        context->DecompressSequences_LdsFseCache.ps->AddRef();
 
         context->srts.heap = NULL;
         context->srts.heapOffset = 0;
@@ -631,6 +645,7 @@ zstdgpu_Status zstdgpu_DestroyPerRequestContext(void **outMemoryBlock, uint32_t 
         D3D12AID_SAFE_RELEASE(inPerRequestContext->srts.heap);
 
         d3d12aid_ComputeRsPs_Release(&inPerRequestContext->ExecuteSequences);
+        d3d12aid_ComputeRsPs_Release(&inPerRequestContext->DecompressSequences_LdsFseCache);
         #define ZSTDGPU_KERNEL(name, desc) d3d12aid_ComputeRsPs_Release(&inPerRequestContext->name);
             ZSTDGPU_KERNEL_LIST()
         #undef ZSTDGPU_KERNEL
@@ -1692,11 +1707,13 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     if (req->zstdCmpBlockCount > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Decompress Sequences]");
-        BIND_RS_PS_SRT(DecompressSequences);
+        d3d12aid_ComputeRsPs_Set(&req->DecompressSequences_LdsFseCache, cmdList);
+        cmdList->SetDescriptorHeaps(1, &req->srts.heap);
+        cmdList->SetComputeRootDescriptorTable(0, req->srts.DecompressSequencesGpuHandle);
 
-        ID3D12Resource* argBuf = req->resData.gpuOnly.Counters;
+        const uint32_t tgCount = ZSTDGPU_TG_COUNT(req->zstdSeqStreamCount, 1); /** 1 - because we choose _LdsFseCache shader that process 1 stream per threadgroup */
         ZSTDGPU_KERNEL_SCOPE(DecompressSequences, cmdList,
-            cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_DecompressSequencesGroups * sizeof(uint32_t), NULL, 0);
+            zstdgpu_Dispatch32Bit(cmdList, tgCount, 1, 0);
         );
         PIXEndEvent(cmdList);
     }

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -3573,6 +3573,17 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsFseCache(ZSTDGPU_PARAM_IN
     ZSTDGPU_PRELOAD_FSE_INTO_LDS(Offs)
     ZSTDGPU_PRELOAD_FSE_INTO_LDS(MLen)
 
+    #if !defined(__XBOX_SCARLETT)
+    if (tgSize > WaveGetLaneCount())
+    {
+        GroupMemoryBarrierWithGroupSync();
+    }
+    if (threadId >= WaveGetLaneCount())
+    {
+        return;
+    }
+    #endif
+
     #define ZSTDGPU_INIT_FSE_STATE(name)                                                                    \
         uint32_t state##name = 0;                                                                           \
         if (seqRef.fse##name < kzstdgpu_FseProbTableIndex_MinRLE)                                           \


### PR DESCRIPTION
This PR 
1. Moves a variant of the shader decompressing sequences that uses LDS as FSE table cache into a separate file
2. Adds appropriate permutations that attempt not to limit chosen wave size (on hardware that supports multiple wave sizes) by a threadgroup size
3. Handles D3D12 limitation not allowing sufficient number of threadgroup (say 32-bit) per dispatch dimension
4. Enables mentioned shader variant as the default choice.