### PR TITLE
zstd: Misc optimizations and refactoring in DecompressSequences_LdsFseCache.

### DIFF
--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -560,20 +560,19 @@ zstdgpu_Status zstdgpu_CreatePerRequestContext(zstdgpu_PerRequestContext *outPer
         context->ExecuteSequences = context->ExecuteSequences64;
         context->DecompressSequences_LdsFseCache = context->DecompressSequences_LdsFseCache32;
 #else
-        if (persistentContext->minLaneCount == 128)
+        if (persistentContext->maxLaneCount == 128)
         {
             context->ExecuteSequences = context->ExecuteSequences128;
             context->DecompressSequences_LdsFseCache = context->DecompressSequences_LdsFseCache128;
         }
-        else if (persistentContext->minLaneCount == 64)
+        else if (persistentContext->maxLaneCount == 64)
         {
             context->ExecuteSequences = context->ExecuteSequences64;
             context->DecompressSequences_LdsFseCache = context->DecompressSequences_LdsFseCache64;
         }
         else
         {
-            context->ExecuteSequences = (persistentContext->maxLaneCount >= 64) ? context->ExecuteSequences64
-                                                                                : context->ExecuteSequences32;
+            context->ExecuteSequences = context->ExecuteSequences32;
             context->DecompressSequences_LdsFseCache = context->DecompressSequences_LdsFseCache32;
         }
 #endif

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -560,19 +560,20 @@ zstdgpu_Status zstdgpu_CreatePerRequestContext(zstdgpu_PerRequestContext *outPer
         context->ExecuteSequences = context->ExecuteSequences64;
         context->DecompressSequences_LdsFseCache = context->DecompressSequences_LdsFseCache32;
 #else
-        if (persistentContext->maxLaneCount == 128)
+        if (persistentContext->minLaneCount == 128)
         {
             context->ExecuteSequences = context->ExecuteSequences128;
             context->DecompressSequences_LdsFseCache = context->DecompressSequences_LdsFseCache128;
         }
-        else if (persistentContext->maxLaneCount == 64)
+        else if (persistentContext->minLaneCount == 64)
         {
             context->ExecuteSequences = context->ExecuteSequences64;
             context->DecompressSequences_LdsFseCache = context->DecompressSequences_LdsFseCache64;
         }
         else
         {
-            context->ExecuteSequences = context->ExecuteSequences32;
+            context->ExecuteSequences = (persistentContext->maxLaneCount >= 64) ? context->ExecuteSequences64
+                                                                                : context->ExecuteSequences32;
             context->DecompressSequences_LdsFseCache = context->DecompressSequences_LdsFseCache32;
         }
 #endif

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -3030,39 +3030,43 @@ void zstdgpu_DecompressHuffmanCompressedLiterals(ZSTDGPU_RO_RAW_BUFFER(uint32_t)
 
         zstdgpu_LitStreamInfo compressedLiteral = LitRefs[literalStreamId];
 
-#if 0
-        zstdgpu_Backward_BitBuffer_V0 bitBuffer;
-        zstdgpu_Backward_BitBuffer_V0_InitWithSegment(bitBuffer, CompressedData, compressedLiteral.src);
-
-        uint32_t state = zstdgpu_Backward_BitBuffer_V0_Get_Huffman(bitBuffer, bitsMax, bitsMax);
-        uint32_t decodedByteCnt = 0;
-        while (decodedByteCnt < compressedLiteral.dst.size)
+        if (compressedLiteral.dst.size != 0) // derived from block Regenerated_Size
         {
-            uint32_t symbol = 0;
-            uint32_t bitcnt = 0;
-            zstdgpu_SampleHuffmanSymbolAndBitcnt(symbol, bitcnt, state, GS_HuffmanTable);
+            uint32_t decodedByteCnt = 0;
 
-            // FIXME/TODO(pamartis): Experiment with storing data to LDS first (we have some allocated but unused)
-            // and then to memory. At least try small LDS cache of 32-dwords per literal
-            zstdgpu_TypedStoreU8(DecompressedLiterals, compressedLiteral.dst.offs + decodedByteCnt++, symbol);
+            // This more original way won't compile since Backward_BitBuffer_V0 expects StructuredBuffer<uint32_t>
+            // but CompressedData is ByteAddressBuffer. We could remove all raw-buffer usage and reintroduce it later;
+            // one 64-bit load isn't much better than two (on AMD: s_claused'd) 32-bit loads.
+            //
+            // Benefits of raw-buffers over StructuredBuffer<uint32_t> is any of Load{1,2,3,4} can be used and
+            // when applicable, they are nicer for SMEM (s_buffer_load does not use the SRD stride to compute the address).
+#if 0
+            zstdgpu_Backward_BitBuffer_V0 bitBuffer;
+            zstdgpu_Backward_BitBuffer_V0_InitWithSegment(bitBuffer, CompressedData, compressedLiteral.src);
 
-            if (zstdgpu_Backward_BitBuffer_V0_CanRefill_Huffman(bitBuffer, bitcnt))
+            uint32_t state = zstdgpu_Backward_BitBuffer_V0_Get_Huffman(bitBuffer, bitsMax, bitsMax);
+            uint32_t decodedByteCnt = 0;
+            for (;;)
             {
+                uint32_t symbol = 0;
+                uint32_t bitcnt = 0;
+                zstdgpu_SampleHuffmanSymbolAndBitcnt(symbol, bitcnt, state, GS_HuffmanTable);
+
+                // FIXME/TODO(pamartis): Experiment with storing data to LDS first (we have some allocated but unused)
+                // and then to memory. At least try small LDS cache of 32-dwords per literal
+                zstdgpu_TypedStoreU8(DecompressedLiterals, compressedLiteral.dst.offs + decodedByteCnt++, symbol);
+
+                if (decodedByteCnt == compressedLiteral.dst.size)
+                {
+                    break;
+                }
+
                 const uint32_t rest = zstdgpu_Backward_BitBuffer_V0_Get_Huffman(bitBuffer, bitcnt, bitsMax);
                 state = ((state << bitcnt) + rest) & maxBitcntMask;
             }
-            else
-            {
-                break;
-            }
-        }
 #else
-        if (compressedLiteral.dst.size != 0) // derived from block Regenerated_Size
-        {
             zstdgpu_HuffmanStream stream;
             zstdgpu_HuffmanStream_InitWithSegment(stream, CompressedData, compressedLiteral.src, bitsMax);
-
-            uint32_t decodedByteCnt = 0;
             do
             {
                 const uint32_t state = zstdgpu_HuffmanStream_RefillAndPeek(stream);
@@ -3076,8 +3080,8 @@ void zstdgpu_DecompressHuffmanCompressedLiterals(ZSTDGPU_RO_RAW_BUFFER(uint32_t)
                 // It could make sense to mid-break on (decodedByteCnt == compressedLiteral.dst.size) instead.
                 zstdgpu_HuffmanStream_Consume(stream, bitcnt);
             } while (decodedByteCnt < compressedLiteral.dst.size);
-        }
 #endif
+        }
     }
 }
 

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -3503,27 +3503,26 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsFseCache(ZSTDGPU_PARAM_IN
 
     const zstdgpu_SeqStreamInfo seqRef = srt.inSeqRefs[seqStreamIdx];
 
-#ifndef __hlsl_dx_compiler
-
-    const uint32_t SEQ_LITERAL_LENGTH_BASELINES[36] = {
-        0,  1,  2,   3,   4,   5,    6,    7,    8,    9,     10,    11,
-        12, 13, 14,  15,  16,  18,   20,   22,   24,   28,    32,    40,
-        48, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536};
-    const uint32_t SEQ_LITERAL_LENGTH_EXTRA_BITS[36] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  1,  1,
-        1, 1, 2, 2, 3, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
-
-    const uint32_t SEQ_MATCH_LENGTH_BASELINES[53] = {
-        3,  4,   5,   6,   7,    8,    9,    10,   11,    12,    13,   14, 15, 16,
-        17, 18,  19,  20,  21,   22,   23,   24,   25,    26,    27,   28, 29, 30,
-        31, 32,  33,  34,  35,   37,   39,   41,   43,    47,    51,   59, 67, 83,
-        99, 131, 259, 515, 1027, 2051, 4099, 8195, 16387, 32771, 65539 };
-
-    const uint32_t SEQ_MATCH_LENGTH_EXTRA_BITS[53] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  1,  1,  1, 1,
-        2, 2, 3, 3, 4, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
-#endif
+    // Extra bits are low 5 bits, rest are baseline.
+    // It could be better/simpler to not bitpack (use uint32_t2), but the LLVM-SROA pass in DXC might split that up; a single load is desired.
+    static const uint32_t SEQ_LITERAL_LENGTH_EXTRA_BITS_AND_BASELINES[36] =
+    {
+            0 << 5 |  0,     1 << 5 |  0,     2 << 5 |  0,     3 << 5 |  0,     4 << 5 |  0,     5 << 5 |  0,     6 << 5 |  0,     7 << 5 |  0,
+            8 << 5 |  0,     9 << 5 |  0,    10 << 5 |  0,    11 << 5 |  0,    12 << 5 |  0,    13 << 5 |  0,    14 << 5 |  0,    15 << 5 |  0,
+           16 << 5 |  1,    18 << 5 |  1,    20 << 5 |  1,    22 << 5 |  1,    24 << 5 |  2,    28 << 5 |  2,    32 << 5 |  3,    40 << 5 |  3,
+           48 << 5 |  4,    64 << 5 |  6,   128 << 5 |  7,   256 << 5 |  8,   512 << 5 |  9,  1024 << 5 | 10,  2048 << 5 | 11,  4096 << 5 | 12,
+         8192 << 5 | 13, 16384 << 5 | 14, 32768 << 5 | 15, 65536 << 5 | 16
+    };
+    static const uint32_t SEQ_MATCH_LENGTH_EXTRA_BITS_AND_BASELINES[53] =
+    {
+            3 << 5 |  0,     4 << 5 |  0,     5 << 5 |  0,     6 << 5 |  0,     7 << 5 |  0,     8 << 5 |  0,     9 << 5 |  0,    10 << 5 |  0,
+           11 << 5 |  0,    12 << 5 |  0,    13 << 5 |  0,    14 << 5 |  0,    15 << 5 |  0,    16 << 5 |  0,    17 << 5 |  0,    18 << 5 |  0,
+           19 << 5 |  0,    20 << 5 |  0,    21 << 5 |  0,    22 << 5 |  0,    23 << 5 |  0,    24 << 5 |  0,    25 << 5 |  0,    26 << 5 |  0,
+           27 << 5 |  0,    28 << 5 |  0,    29 << 5 |  0,    30 << 5 |  0,    31 << 5 |  0,    32 << 5 |  0,    33 << 5 |  0,    34 << 5 |  0,
+           35 << 5 |  1,    37 << 5 |  1,    39 << 5 |  1,    41 << 5 |  1,    43 << 5 |  2,    47 << 5 |  2,    51 << 5 |  3,    59 << 5 |  3,
+           67 << 5 |  4,    83 << 5 |  4,    99 << 5 |  5,   131 << 5 |  7,   259 << 5 |  8,   515 << 5 |  9,  1027 << 5 | 10,  2051 << 5 | 11,
+         4099 << 5 | 12,  8195 << 5 | 13, 16387 << 5 | 14, 32771 << 5 | 15, 65539 << 5 | 16
+    };
 
     // NOTE: the final block size will be computed as SUM(literalSize, totalMLen)
     const uint32_t literalSize = srt.inoutBlockSizePrefix[seqRef.blockId];
@@ -3622,17 +3621,19 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsFseCache(ZSTDGPU_PARAM_IN
             ZSTDGPU_ASSERT(symbolLLen < 36);                                                    \
             ZSTDGPU_ASSERT(symbolMLen < 53);                                                    \
                                                                                                 \
-            const uint32_t bitcntLLen = SEQ_LITERAL_LENGTH_EXTRA_BITS[symbolLLen];              \
+            const uint32_t literalLengthInfo = SEQ_LITERAL_LENGTH_EXTRA_BITS_AND_BASELINES[symbolLLen]; \
+            const uint32_t matchLengthInfo = SEQ_MATCH_LENGTH_EXTRA_BITS_AND_BASELINES[symbolMLen];     \
+            const uint32_t bitcntLLen = literalLengthInfo & 31;                                 \
             const uint32_t bitcntOffs = symbolOffs;                                             \
-            const uint32_t bitcntMLen = SEQ_MATCH_LENGTH_EXTRA_BITS[symbolMLen];                \
+            const uint32_t bitcntMLen = matchLengthInfo & 31;                                   \
                                                                                                 \
             const uint32_t bitsOffs = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntOffs);      \
             const uint32_t bitsMLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntMLen);      \
             const uint32_t bitsLLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntLLen);      \
                                                                                                 \
                   uint32_t offs = (1u << symbolOffs) + bitsOffs;                                \
-            const uint32_t mlen = SEQ_MATCH_LENGTH_BASELINES[symbolMLen] + bitsMLen;            \
-            const uint32_t llen = SEQ_LITERAL_LENGTH_BASELINES[symbolLLen] + bitsLLen;          \
+            const uint32_t mlen = (matchLengthInfo >> 5) + bitsMLen;                            \
+            const uint32_t llen = (literalLengthInfo >> 5) + bitsLLen;                          \
                                                                                                 \
             offs = zstdgpu_SequenceOffsets_Update2(offset1, offset2, offset3, offs, llen);      \
                                                                                                 \

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -3574,15 +3574,15 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsFseCache(ZSTDGPU_PARAM_IN
     ZSTDGPU_PRELOAD_FSE_INTO_LDS(MLen)
 
     #if !defined(__XBOX_SCARLETT)
-    if (tgSize > WaveGetLaneCount())
-    {
-        GroupMemoryBarrierWithGroupSync();
-    }
-    if (threadId >= WaveGetLaneCount())
+    GroupMemoryBarrierWithGroupSync();
+    #endif
+
+    // The rest of the shader should be scalar. Ideally the compiler should emit mostly scalar instructions,
+    // but this may help it, or deactivate unnecessary lanes for instructions with no scalar counterpart (LDS loads).
+    if (threadId != 0)
     {
         return;
     }
-    #endif
 
     #define ZSTDGPU_INIT_FSE_STATE(name)                                                                    \
         uint32_t state##name = 0;                                                                           \

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -3033,19 +3033,11 @@ void zstdgpu_DecompressHuffmanCompressedLiterals(ZSTDGPU_RO_RAW_BUFFER(uint32_t)
         if (compressedLiteral.dst.size != 0) // derived from block Regenerated_Size
         {
             uint32_t decodedByteCnt = 0;
-
-            // This more original way won't compile since Backward_BitBuffer_V0 expects StructuredBuffer<uint32_t>
-            // but CompressedData is ByteAddressBuffer. We could remove all raw-buffer usage and reintroduce it later;
-            // one 64-bit load isn't much better than two (on AMD: s_claused'd) 32-bit loads.
-            //
-            // Benefits of raw-buffers over StructuredBuffer<uint32_t> is any of Load{1,2,3,4} can be used and
-            // when applicable, they are nicer for SMEM (s_buffer_load does not use the SRD stride to compute the address).
 #if 0
             zstdgpu_Backward_BitBuffer_V0 bitBuffer;
             zstdgpu_Backward_BitBuffer_V0_InitWithSegment(bitBuffer, CompressedData, compressedLiteral.src);
 
             uint32_t state = zstdgpu_Backward_BitBuffer_V0_Get_Huffman(bitBuffer, bitsMax, bitsMax);
-            uint32_t decodedByteCnt = 0;
             for (;;)
             {
                 uint32_t symbol = 0;

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -3499,14 +3499,6 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsFseCache(ZSTDGPU_PARAM_IN
 
     const zstdgpu_SeqStreamInfo seqRef = srt.inSeqRefs[seqStreamIdx];
 
-    #ifdef ZSTDGPU_BACKWARD_BITBUF
-    #   error `ZSTDGPU_BACKWARD_BITBUF` must not be defined.
-    #endif
-
-    zstdgpu_Backward_BitBuffer_V0 bitBuffer;
-    #define ZSTDGPU_BACKWARD_BITBUF(method) zstdgpu_Backward_BitBuffer_V0_##method
-    ZSTDGPU_BACKWARD_BITBUF(InitWithSegment)(bitBuffer, srt.inCompressedData, seqRef.src);
-
 #ifndef __hlsl_dx_compiler
 
     const uint32_t SEQ_LITERAL_LENGTH_BASELINES[36] = {
@@ -3531,7 +3523,7 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsFseCache(ZSTDGPU_PARAM_IN
 
     // NOTE: the final block size will be computed as SUM(literalSize, totalMLen)
     const uint32_t literalSize = srt.inoutBlockSizePrefix[seqRef.blockId];
-    uint32_t totalSize = 0;
+    // uint32_t totalSize = 0;
     uint32_t totalMLen = 0;
 
     uint32_t offset1, offset2, offset3;
@@ -3542,8 +3534,6 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsFseCache(ZSTDGPU_PARAM_IN
     const uint32_t startMLen = seqRef.fseMLen * kzstdgpu_FseElemMaxCount_LLen;
 
     const zstdgpu_OffsetAndSize dst = zstdgpu_GetSequenceStartAndCount(srt, seqStreamIdx, seqStreamCnt);
-    const uint32_t outputStart = dst.offs;
-    const uint32_t outputEnd = outputStart + dst.size;
 
     #include "zstdgpu_lds_decl_base.h"
     ZSTDGPU_DECOMPRESS_SEQUENCES_LDS_FSE_CACHE_LDS(0, DecompressSequences_LdsFseCache);
@@ -3584,104 +3574,115 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsFseCache(ZSTDGPU_PARAM_IN
         return;
     }
 
-    #define ZSTDGPU_INIT_FSE_STATE(name)                                                                    \
-        uint32_t state##name = 0;                                                                           \
-        if (seqRef.fse##name < kzstdgpu_FseProbTableIndex_MinRLE)                                           \
-        {                                                                                                   \
-            const uint32_t initBitcnt = srt.inFseInfos[seqRef.fse##name].fseProbCountAndAccuracyLog2 >> 8;  \
-            state##name = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, initBitcnt);                              \
-        }
-
-    ZSTDGPU_INIT_FSE_STATE(LLen)
-    ZSTDGPU_INIT_FSE_STATE(Offs)
-    ZSTDGPU_INIT_FSE_STATE(MLen)
-    #undef ZSTDGPU_INIT_FSE_STATE
-
-    #define ZSTGPU_DECODE_SEQ(outIdx, outNState, outRestBitcnt)                             \
-    {                                                                                       \
-        const uint32_t packedFseElemLLen = WaveReadLaneFirst(zstdgpu_LdsLoadU32(GS_FsePackedLLen + stateLLen));\
-        const uint32_t packedFseElemOffs = WaveReadLaneFirst(zstdgpu_LdsLoadU32(GS_FsePackedOffs + stateOffs));\
-        const uint32_t packedFseElemMLen = WaveReadLaneFirst(zstdgpu_LdsLoadU32(GS_FsePackedMLen + stateMLen));\
-                                                                                            \
-        const uint32_t symbolLLen = packedFseElemLLen & 0xff;                               \
-        const uint32_t symbolOffs = packedFseElemOffs & 0xff;                               \
-        const uint32_t symbolMLen = packedFseElemMLen & 0xff;                               \
-                                                                                            \
-        outRestBitcnt##LLen = (packedFseElemLLen >> 8) & 0xff;                              \
-        outRestBitcnt##Offs = (packedFseElemOffs >> 8) & 0xff;                              \
-        outRestBitcnt##MLen = (packedFseElemMLen >> 8) & 0xff;                              \
-                                                                                            \
-        outNState##LLen = (packedFseElemLLen >> 16) & 0xffff;                               \
-        outNState##Offs = (packedFseElemOffs >> 16) & 0xffff;                               \
-        outNState##MLen = (packedFseElemMLen >> 16) & 0xffff;                               \
-                                                                                            \
-        ZSTDGPU_ASSERT(symbolLLen < 36);                                                    \
-        ZSTDGPU_ASSERT(symbolMLen < 53);                                                    \
-                                                                                            \
-        const uint32_t bitcntLLen = SEQ_LITERAL_LENGTH_EXTRA_BITS[symbolLLen];              \
-        const uint32_t bitcntOffs = symbolOffs;                                             \
-        const uint32_t bitcntMLen = SEQ_MATCH_LENGTH_EXTRA_BITS[symbolMLen];                \
-                                                                                            \
-        const uint32_t bitsOffs = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntOffs);      \
-        const uint32_t bitsMLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntMLen);      \
-        const uint32_t bitsLLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntLLen);      \
-                                                                                            \
-              uint32_t offs = (1u << symbolOffs) + bitsOffs;                                \
-        const uint32_t mlen = SEQ_MATCH_LENGTH_BASELINES[symbolMLen] + bitsMLen;            \
-        const uint32_t llen = SEQ_LITERAL_LENGTH_BASELINES[symbolLLen] + bitsLLen;          \
-                                                                                            \
-        offs = zstdgpu_SequenceOffsets_Update2(offset1, offset2, offset3, offs, llen);      \
-                                                                                            \
-        totalSize += llen + mlen;                                                           \
-        totalMLen += mlen;                                                                  \
-                                                                                            \
-        srt.inoutDecompressedSequenceLLen[outIdx] = llen;                                   \
-        srt.inoutDecompressedSequenceMLen[outIdx] = mlen;                                   \
-        srt.inoutDecompressedSequenceOffs[outIdx] = offs;                                   \
-    }
-
-
-    for (uint32_t i = outputStart; i < outputEnd - 1; ++i)
+    if (dst.size != 0)
     {
-        uint32_t restbitcntLLen, restbitcntOffs, restbitcntMLen;
-        uint32_t nstateLLen, nstateOffs, nstateMLen;
-        ZSTGPU_DECODE_SEQ(i, nstate, restbitcnt)
-
-        #if 0
-        const uint32_t restLLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcntLLen);
-        const uint32_t restMLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcntMLen);
-        const uint32_t restOffs = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcntOffs);
-        #else
-        // NOTE(pamartis): bit counts stored in FSE tables are equal to accuracy_log in worst case
-        // so it's 9 for LLen/MLen and 8 for offset, so we are not extracting more than 26 bits at once
-        uint32_t packedBits = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcntLLen + restbitcntMLen + restbitcntOffs);
-
-        const uint32_t restOffs = packedBits & ((1u << restbitcntOffs) - 1u);
-        packedBits >>= restbitcntOffs;
-
-        const uint32_t restMLen = packedBits & ((1u << restbitcntMLen) - 1u);
-        packedBits >>= restbitcntMLen;
-
-        const uint32_t restLLen = packedBits;
+        #ifdef ZSTDGPU_BACKWARD_BITBUF
+        #   error `ZSTDGPU_BACKWARD_BITBUF` must not be defined.
         #endif
 
-        stateLLen = nstateLLen + restLLen;
-        stateMLen = nstateMLen + restMLen;
-        stateOffs = nstateOffs + restOffs;
-    }
+        zstdgpu_Backward_BitBuffer_V0 bitBuffer;
+        #define ZSTDGPU_BACKWARD_BITBUF(method) zstdgpu_Backward_BitBuffer_V0_##method
+        ZSTDGPU_BACKWARD_BITBUF(InitWithSegment)(bitBuffer, srt.inCompressedData, seqRef.src);
 
-    uint32_t restbitcntLLen, restbitcntOffs, restbitcntMLen;
-    uint32_t nstateLLen, nstateOffs, nstateMLen;
-    ZSTGPU_DECODE_SEQ(outputEnd - 1, nstate, restbitcnt)
-    #undef ZSTDGPU_BACKWARD_BITBUF
+        #define ZSTDGPU_INIT_FSE_STATE(name)                                                                    \
+            uint32_t state##name = 0;                                                                           \
+            if (seqRef.fse##name < kzstdgpu_FseProbTableIndex_MinRLE)                                           \
+            {                                                                                                   \
+                const uint32_t initBitcnt = srt.inFseInfos[seqRef.fse##name].fseProbCountAndAccuracyLog2 >> 8;  \
+                state##name = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, initBitcnt);                              \
+            }
+
+        ZSTDGPU_INIT_FSE_STATE(LLen)
+        ZSTDGPU_INIT_FSE_STATE(Offs)
+        ZSTDGPU_INIT_FSE_STATE(MLen)
+        #undef ZSTDGPU_INIT_FSE_STATE
+
+        #define ZSTGPU_DECODE_SEQ(outIdx, outNState, outRestBitcnt)                             \
+        {                                                                                       \
+            const uint32_t packedFseElemLLen = WaveReadLaneFirst(zstdgpu_LdsLoadU32(GS_FsePackedLLen + stateLLen));\
+            const uint32_t packedFseElemOffs = WaveReadLaneFirst(zstdgpu_LdsLoadU32(GS_FsePackedOffs + stateOffs));\
+            const uint32_t packedFseElemMLen = WaveReadLaneFirst(zstdgpu_LdsLoadU32(GS_FsePackedMLen + stateMLen));\
+                                                                                                \
+            const uint32_t symbolLLen = packedFseElemLLen & 0xff;                               \
+            const uint32_t symbolOffs = packedFseElemOffs & 0xff;                               \
+            const uint32_t symbolMLen = packedFseElemMLen & 0xff;                               \
+                                                                                                \
+            outRestBitcnt##LLen = (packedFseElemLLen >> 8) & 0xff;                              \
+            outRestBitcnt##Offs = (packedFseElemOffs >> 8) & 0xff;                              \
+            outRestBitcnt##MLen = (packedFseElemMLen >> 8) & 0xff;                              \
+                                                                                                \
+            outNState##LLen = (packedFseElemLLen >> 16) & 0xffff;                               \
+            outNState##Offs = (packedFseElemOffs >> 16) & 0xffff;                               \
+            outNState##MLen = (packedFseElemMLen >> 16) & 0xffff;                               \
+                                                                                                \
+            ZSTDGPU_ASSERT(symbolLLen < 36);                                                    \
+            ZSTDGPU_ASSERT(symbolMLen < 53);                                                    \
+                                                                                                \
+            const uint32_t bitcntLLen = SEQ_LITERAL_LENGTH_EXTRA_BITS[symbolLLen];              \
+            const uint32_t bitcntOffs = symbolOffs;                                             \
+            const uint32_t bitcntMLen = SEQ_MATCH_LENGTH_EXTRA_BITS[symbolMLen];                \
+                                                                                                \
+            const uint32_t bitsOffs = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntOffs);      \
+            const uint32_t bitsMLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntMLen);      \
+            const uint32_t bitsLLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntLLen);      \
+                                                                                                \
+                  uint32_t offs = (1u << symbolOffs) + bitsOffs;                                \
+            const uint32_t mlen = SEQ_MATCH_LENGTH_BASELINES[symbolMLen] + bitsMLen;            \
+            const uint32_t llen = SEQ_LITERAL_LENGTH_BASELINES[symbolLLen] + bitsLLen;          \
+                                                                                                \
+            offs = zstdgpu_SequenceOffsets_Update2(offset1, offset2, offset3, offs, llen);      \
+                                                                                                \
+            /*totalSize += llen + mlen;*/                                                           \
+            totalMLen += mlen;                                                                  \
+                                                                                                \
+            srt.inoutDecompressedSequenceLLen[outIdx] = llen;                                   \
+            srt.inoutDecompressedSequenceMLen[outIdx] = mlen;                                   \
+            srt.inoutDecompressedSequenceOffs[outIdx] = offs;                                   \
+        }
+
+              uint32_t i         = dst.offs;
+        const uint32_t outputEnd = dst.offs + dst.size;
+        for (;;)
+        {
+            uint32_t restbitcntLLen, restbitcntOffs, restbitcntMLen;
+            uint32_t nstateLLen, nstateOffs, nstateMLen;
+            ZSTGPU_DECODE_SEQ(i, nstate, restbitcnt)
+            if (++i == outputEnd)
+            {
+                break;
+            }
+
+            #if 0
+            const uint32_t restLLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcntLLen);
+            const uint32_t restMLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcntMLen);
+            const uint32_t restOffs = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcntOffs);
+            #else
+            // NOTE(pamartis): bit counts stored in FSE tables are equal to accuracy_log in worst case
+            // so it's 9 for LLen/MLen and 8 for offset, so we are not extracting more than 26 bits at once
+            uint32_t packedBits = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcntLLen + restbitcntMLen + restbitcntOffs);
+
+            const uint32_t restOffs = packedBits & ((1u << restbitcntOffs) - 1u);
+            packedBits >>= restbitcntOffs;
+
+            const uint32_t restMLen = packedBits & ((1u << restbitcntMLen) - 1u);
+            packedBits >>= restbitcntMLen;
+
+            const uint32_t restLLen = packedBits;
+            #endif
+
+            stateLLen = nstateLLen + restLLen;
+            stateMLen = nstateMLen + restMLen;
+            stateOffs = nstateOffs + restOffs;
+        }
+        ZSTDGPU_ASSERT(bitBuffer.hadlastrefill && bitBuffer.bitcnt == 0);
+        #undef ZSTDGPU_BACKWARD_BITBUF
+    }
 
     // NOTE(pamartis): update block size adding `totalMLen` bytes on top
     srt.inoutBlockSizePrefix[seqRef.blockId] = totalMLen + literalSize;
     srt.inoutPerSeqStreamFinalOffset1[seqStreamIdx] = offset1;
     srt.inoutPerSeqStreamFinalOffset2[seqStreamIdx] = offset2;
     srt.inoutPerSeqStreamFinalOffset3[seqStreamIdx] = offset3;
-
-    ZSTDGPU_ASSERT(bitBuffer.hadlastrefill && bitBuffer.bitcnt == 0);
 }
 
 // LDS partitioning macro lists for sequence decompression with in-LDS caching

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -370,7 +370,16 @@ static inline void InterlockedAdd(uint32_t & dst, uint32_t x, uint32_t & ret) { 
 static inline void InterlockedCompareStore(uint32_t & dst, uint32_t compare, uint32_t x) { if (dst == compare) dst = x; }
 #endif
 
-static inline uint64_t zstdgpu_RawLoadU64AtByteOffset(ZSTDGPU_RO_RAW_BUFFER(uint32_t) buffer, uint32_t offset)
+static inline uint32_t zstdgpu_ByteOffsetLoadU32(ZSTDGPU_RO_RAW_BUFFER(uint32_t) buffer, uint32_t offset)
+{
+#ifdef __hlsl_dx_compiler
+    return buffer.Load(offset);
+#else
+    return *reinterpret_cast<const uint32_t*>(reinterpret_cast<const char*>(buffer) + offset);
+#endif
+}
+
+static inline uint64_t zstdgpu_ByteOffsetLoadU64(ZSTDGPU_RO_RAW_BUFFER(uint32_t) buffer, uint32_t offset)
 {
 #ifdef __hlsl_dx_compiler
     uint2 v = buffer.Load2(offset);
@@ -817,24 +826,22 @@ static inline void zstdgpu_Forward_BitBuffer_ByteAlign(ZSTDGPU_PARAM_INOUT(zstdg
 }
 
 //#define ZSTDGPU_USE_REVERSED_BIT_BUFFER_BITBUF 1
-#define ZSTDGPU_USE_REVERSED_BIT_BUFFER_OFFSET 1
 
 typedef struct zstdgpu_Backward_BitBuffer_V0
 {
-    ZSTDGPU_RO_BUFFER(uint32_t) buffer;
+    ZSTDGPU_RO_RAW_BUFFER(uint32_t) buffer;
 
     uint64_t bitbuf;    // VGPRs storing valid bits that are not consumed yet
-    uint32_t nextDword; // VGPR storing the offset in dwords to the start of the next dword fetch
     uint32_t bitcnt;    // VGPR storing the number of valid bits in `bitbuf`
     uint32_t bitcntLast;
-    uint32_t lastDword;   // VGPR as it store any memory block size varying per lane
-    uint32_t baseDword;
+    uint32_t lastByteOffset;    // offset of last load (pre-decrement before next load)
+    uint32_t baseByteOffset;
     bool     hadlastrefill;
 } zstdgpu_Backward_BitBuffer_V0;
 
 typedef struct zstdgpu_Backward_BitBuffer
 {
-    ZSTDGPU_RO_BUFFER(uint32_t) buffer;
+    ZSTDGPU_RO_RAW_BUFFER(uint32_t) buffer;
 
     uint64_t    bitbuf;
     uint32_t    offset;
@@ -861,17 +868,17 @@ static inline uint32_t reversebits(uint32_t x)
 
 #endif
 
-static inline void zstdgpu_Backward_BitBuffer_V0_InitWithSegment(ZSTDGPU_PARAM_INOUT(zstdgpu_Backward_BitBuffer_V0) outBuffer, ZSTDGPU_RO_BUFFER(uint32_t) buffer, ZSTDGPU_PARAM_IN(zstdgpu_OffsetAndSize) segment)
+static inline void zstdgpu_Backward_BitBuffer_V0_InitWithSegment(ZSTDGPU_PARAM_INOUT(zstdgpu_Backward_BitBuffer_V0) outBuffer, ZSTDGPU_RO_RAW_BUFFER(uint32_t) buffer, ZSTDGPU_PARAM_IN(zstdgpu_OffsetAndSize) segment)
 {
     const uint32_t datasz = segment.offs + segment.size;
 
-    const uint32_t baseDword = segment.offs >> 2u;
-    const uint32_t lastDword = (datasz - 1u) >> 2u;
+    const uint32_t baseByteOffset = segment.offs & -4;
+    const uint32_t lastByteOffset = (datasz - 1u) & -4;
 
     // Firstly, we assume that all the bytes read from the last dword are valid and drop only highest bits
     uint32_t bitcnt = (datasz & 3u) << 3u; // Possible: 0, 8, 16, 24
     uint32_t bitmsk = ~0u >> (32u - bitcnt);
-    uint32_t bitbuf = buffer[lastDword] & bitmsk;
+    uint32_t bitbuf = zstdgpu_ByteOffsetLoadU32(buffer, lastByteOffset) & bitmsk;
 
     // Secondly, we search for the highest set bit to see how many bits are valid
     bitcnt = zstdgpu_FindFirstBitHiU32_Nonzero(bitbuf);
@@ -885,7 +892,7 @@ static inline void zstdgpu_Backward_BitBuffer_V0_InitWithSegment(ZSTDGPU_PARAM_I
 
     const uint32_t bitcntLast = (segment.offs & 0x3u) << 3u;
     {
-        const uint32_t lobitcnt = baseDword == lastDword ? bitcntLast : 0;
+        const uint32_t lobitcnt = baseByteOffset == lastByteOffset ? bitcntLast : 0;
         bitcnt  -= lobitcnt;
         bitbuf >>= lobitcnt;
     }
@@ -893,17 +900,11 @@ static inline void zstdgpu_Backward_BitBuffer_V0_InitWithSegment(ZSTDGPU_PARAM_I
 
     outBuffer.buffer = buffer;
     outBuffer.bitbuf = (uint64_t)bitbuf;
-#ifdef ZSTDGPU_USE_REVERSED_BIT_BUFFER_OFFSET
-    // in "reversed" offset mode we only increment "nextDword"
-    outBuffer.nextDword = 0;
-#else
-    outBuffer.nextDword = lastDword;
-#endif
     outBuffer.bitcnt = bitcnt;
     outBuffer.bitcntLast = bitcntLast;
-    outBuffer.lastDword = lastDword;
-    outBuffer.baseDword = baseDword;
-    outBuffer.hadlastrefill = baseDword == lastDword;
+    outBuffer.lastByteOffset = lastByteOffset;
+    outBuffer.baseByteOffset = baseByteOffset;
+    outBuffer.hadlastrefill = baseByteOffset == lastByteOffset;
     //outBuffer.bytesz = bytesz;
 }
 
@@ -929,28 +930,24 @@ static inline void zstdgpu_Backward_BitBuffer_V0_Refill(ZSTDGPU_PARAM_INOUT(zstd
     {
         ZSTDGPU_ASSERT(inoutBuffer.hadlastrefill == false);
 
-#ifdef ZSTDGPU_USE_REVERSED_BIT_BUFFER_OFFSET
-        inoutBuffer.nextDword += 1;
-        const uint32_t nextDword = inoutBuffer.lastDword - inoutBuffer.nextDword;
-#else
-        ZSTDGPU_ASSERT(inoutBuffer.nextDword > 0);
-        inoutBuffer.nextDword -= 1;
-        const uint32_t nextDword = inoutBuffer.nextDword;
-#endif
-        ZSTDGPU_ASSERT(nextDword >= inoutBuffer.baseDword);
+        ZSTDGPU_ASSERT(inoutBuffer.lastByteOffset >= 4);
+        inoutBuffer.lastByteOffset -= 4;
+        const uint32_t nextByteOffset = inoutBuffer.lastByteOffset;
+        ZSTDGPU_ASSERT(nextByteOffset >= inoutBuffer.baseByteOffset);
 
         // how many bits we need to remove
-        const uint32_t lobitcnt = nextDword > inoutBuffer.baseDword ? 0u : inoutBuffer.bitcntLast;
+        const uint32_t lobitcnt = nextByteOffset > inoutBuffer.baseByteOffset ? 0u : inoutBuffer.bitcntLast;
         const uint32_t hibitcnt = 32u - lobitcnt;
 
+        const uint32_t loadValue = zstdgpu_ByteOffsetLoadU32(inoutBuffer.buffer, nextByteOffset);
         #ifdef ZSTDGPU_USE_REVERSED_BIT_BUFFER_BITBUF
-            inoutBuffer.bitbuf |= (uint64_t)reversebits(inoutBuffer.buffer[nextDword]) << inoutBuffer.bitcnt;
+            inoutBuffer.bitbuf |= (uint64_t)reversebits(loadValue) << inoutBuffer.bitcnt;
         #else
-            inoutBuffer.bitbuf = (inoutBuffer.bitbuf << hibitcnt) | (inoutBuffer.buffer[nextDword] >> lobitcnt);
+            inoutBuffer.bitbuf = (inoutBuffer.bitbuf << hibitcnt) | (loadValue >> lobitcnt);
         #endif
 
         inoutBuffer.bitcnt += hibitcnt;
-        inoutBuffer.hadlastrefill = !(nextDword > inoutBuffer.baseDword);
+        inoutBuffer.hadlastrefill = !(nextByteOffset > inoutBuffer.baseByteOffset);
     }
 }
 
@@ -1051,7 +1048,7 @@ static inline void zstdgpu_HuffmanStream_InitWithSegment(ZSTDGPU_PARAM_INOUT(zst
     const uint32_t lastByteIdx = (segment.offs + segment.size) - 1; // Byte index containing the flag.
     const uint32_t finalByteOffsetForU64 = segment.offs & -8;
     const uint32_t lastByteOffsetForU64 = lastByteIdx & -8;
-    uint64_t data64 = zstdgpu_RawLoadU64AtByteOffset(buffer, lastByteOffsetForU64);
+    uint64_t data64 = zstdgpu_ByteOffsetLoadU64(buffer, lastByteOffsetForU64);
 
     // How many extra bytes we read.
     const uint32_t oobByteCount = 7 - (lastByteIdx & 7);
@@ -1094,7 +1091,7 @@ static inline uint32_t zstdgpu_HuffmanStream_RefillAndPeek(ZSTDGPU_PARAM_INOUT(z
         stream.dataSpare      = uint32_t(stream.data0 >> 32);
         stream.numBitsSpare   = stream.numBits0;
         stream.lastByteOffset = loadByteOffset;
-        stream.data0          = zstdgpu_RawLoadU64AtByteOffset(stream.buffer, loadByteOffset);
+        stream.data0          = zstdgpu_ByteOffsetLoadU64(stream.buffer, loadByteOffset);
         stream.numBits0       = (stream.finalByteOffset == loadByteOffset) ? uint32_t(-1) : 64; // see @last_peek comment
     }
 
@@ -1119,13 +1116,13 @@ static inline void zstdgpu_HuffmanStream_Consume(ZSTDGPU_PARAM_INOUT(zstdgpu_Huf
     stream.data0 <<= data0Consumed;
 }
 
-static inline void zstdgpu_Backward_BitBuffer_Init(ZSTDGPU_PARAM_INOUT(zstdgpu_Backward_BitBuffer) outBitBuffer, ZSTDGPU_RO_BUFFER(uint32_t) buffer, ZSTDGPU_PARAM_IN(zstdgpu_OffsetAndSize) segment)
+static inline void zstdgpu_Backward_BitBuffer_Init(ZSTDGPU_PARAM_INOUT(zstdgpu_Backward_BitBuffer) outBitBuffer, ZSTDGPU_RO_RAW_BUFFER(uint32_t) buffer, ZSTDGPU_PARAM_IN(zstdgpu_OffsetAndSize) segment)
 {
     const uint32_t endbyte = segment.offs + segment.size - 1u;
 
     outBitBuffer.buffer = buffer;
-    outBitBuffer.offset = endbyte >> 2u;
-    outBitBuffer.bitbuf = buffer[outBitBuffer.offset];
+    outBitBuffer.offset = endbyte & -4;
+    outBitBuffer.bitbuf = zstdgpu_ByteOffsetLoadU32(buffer, outBitBuffer.offset);
     outBitBuffer.bitpos = 56u - ((endbyte & 3u) << 3u);
 }
 
@@ -1146,7 +1143,7 @@ static inline void zstdgpu_Backward_BitBuffer_Refill(ZSTDGPU_PARAM_INOUT(zstdgpu
 
     // advance the offset by the number of full uints consumed in `bitbuf`
     // which is determined by the number of consumed bits in `bitpos`
-    inoutBuffer.offset -= inoutBuffer.bitpos >> 5u;
+    inoutBuffer.offset -= (inoutBuffer.bitpos >> 5u) * 4;
 
     // we mask `bitpos` so that it's either `32` or `0` to determine how many bits should be replaced
     // by newer bits loaded into lower 32-bits, then we load lower bits unconditionally,
@@ -1157,7 +1154,7 @@ static inline void zstdgpu_Backward_BitBuffer_Refill(ZSTDGPU_PARAM_INOUT(zstdgpu
     //
     // TODO (pamartis): Because of the above, try storing bitbuf as 2 VGPRs as 2 explicit uint32_t values,
     // so "left shift" and "or" are avoided.
-    inoutBuffer.bitbuf = (inoutBuffer.bitbuf << (inoutBuffer.bitpos & ~31u)) | inoutBuffer.buffer[inoutBuffer.offset];
+    inoutBuffer.bitbuf = (inoutBuffer.bitbuf << (inoutBuffer.bitpos & ~31u)) | zstdgpu_ByteOffsetLoadU32(inoutBuffer.buffer, inoutBuffer.offset);
 
     // we update `bitpos` so that it contains <= `31` bit
     inoutBuffer.bitpos &= 31u;
@@ -1181,7 +1178,7 @@ static inline void zstdgpu_Backward_BitBuffer_Pop(ZSTDGPU_PARAM_INOUT(zstdgpu_Ba
     inoutBuffer.bitpos += bitcnt;
 }
 
-static inline void zstdgpu_Backward_BitBuffer_InitWithSegment(ZSTDGPU_PARAM_INOUT(zstdgpu_Backward_BitBuffer) outBitBuffer, ZSTDGPU_RO_BUFFER(uint32_t) buffer, ZSTDGPU_PARAM_IN(zstdgpu_OffsetAndSize) segment)
+static inline void zstdgpu_Backward_BitBuffer_InitWithSegment(ZSTDGPU_PARAM_INOUT(zstdgpu_Backward_BitBuffer) outBitBuffer, ZSTDGPU_RO_RAW_BUFFER(uint32_t) buffer, ZSTDGPU_PARAM_IN(zstdgpu_OffsetAndSize) segment)
 {
     zstdgpu_Backward_BitBuffer_Init(outBitBuffer, buffer, segment);
 
@@ -1210,7 +1207,7 @@ ZSTDGPU_BITBUF_DEFINE_STANDARD_METHODS(Backward_BitBuffer)
 #   error `ZSTDGPU_BACKWARD_BITBUF_TST` must not be defined.
 #endif
 
-static inline void zstdgpu_Backward_CmpBitBuffer_InitWithSegment(ZSTDGPU_PARAM_INOUT(zstdgpu_Backward_CmpBitBuffer) outBuffer, ZSTDGPU_RO_BUFFER(uint32_t) buffer, ZSTDGPU_PARAM_IN(zstdgpu_OffsetAndSize) segment)
+static inline void zstdgpu_Backward_CmpBitBuffer_InitWithSegment(ZSTDGPU_PARAM_INOUT(zstdgpu_Backward_CmpBitBuffer) outBuffer, ZSTDGPU_RO_RAW_BUFFER(uint32_t) buffer, ZSTDGPU_PARAM_IN(zstdgpu_OffsetAndSize) segment)
 {
     ZSTDGPU_BACKWARD_BITBUF_REF(InitWithSegment)(outBuffer.bbref, buffer, segment);
     ZSTDGPU_BACKWARD_BITBUF_TST(InitWithSegment)(outBuffer.bbtst, buffer, segment);
@@ -1465,7 +1462,7 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
 
 #define ZSTDGPU_DECOMPRESS_HUFFMAN_WEIGHTS_SRT()                                                        \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , Counters                      , 0)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , CompressedData                , 1)    \
+    ZSTDGPU_RO_RAW_BUFFER_DECL(uint32_t                         , CompressedData                , 1)    \
     ZSTDGPU_RO_BUFFER_DECL(zstdgpu_OffsetAndSize                , HufRefs                       , 2)    \
     ZSTDGPU_RO_BUFFER_DECL(zstdgpu_FseInfo                      , FseInfos                      , 3)    \
     \
@@ -1521,7 +1518,7 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
 
 #define ZSTDGPU_DECOMPRESS_SEQUENCES_SRT()                                                              \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , Counters                      , 0)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , CompressedData                , 1)    \
+    ZSTDGPU_RO_RAW_BUFFER_DECL(uint32_t                         , CompressedData                , 1)    \
     ZSTDGPU_RO_BUFFER_DECL(zstdgpu_SeqStreamInfo                , SeqRefs                       , 2)    \
     ZSTDGPU_RO_BUFFER_DECL(zstdgpu_FseInfo                      , FseInfos                      , 3)    \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , PerSeqStreamSeqStart          , 4)    \

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -453,7 +453,7 @@ static inline uint32_t zstdgpu_FindFirstBitHiU32_Nonzero(uint32_t v)
     //          v_clz_i32_u32   v0, s10             // input s10 is scalar, but didn't use SALU s_clz_i32_u32
     //          v_sub_nc_u32    v1, 31, v0
     //          v_cmp_ne_i32    vcc_lo, -1, v0
-    //          v_cndmask_b32   v0, -1, v1, vcc_lo  // final result in v10
+    //          v_cndmask_b32   v0, -1, v1, vcc_lo  // final result in v0
     // The following formulation gets us:
     //          s_brev_b32    s13, s10
     //          s_ctz_i32_b32 s13, s13
@@ -465,7 +465,7 @@ static inline uint32_t zstdgpu_FindFirstBitHiU32_Nonzero(uint32_t v)
     unsigned long index = 0;
     uint32_t found = _BitScanReverse(&index, v);
     ZSTDGPU_ASSERT(0 != found);
-    return found ? (uint32_t)index : 32u; // found should be true, but due this to match GPU behavior
+    return found ? (uint32_t)index : 32u; // found should be true, but do this to match GPU behavior
 #endif
 }
 

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -804,7 +804,6 @@ typedef struct zstdgpu_Backward_BitBuffer_V0
     uint32_t lastDword;   // VGPR as it store any memory block size varying per lane
     uint32_t baseDword;
     bool     hadlastrefill;
-    bool     hadlastrefillHuffman;
 } zstdgpu_Backward_BitBuffer_V0;
 
 typedef struct zstdgpu_Backward_BitBuffer
@@ -879,7 +878,6 @@ static inline void zstdgpu_Backward_BitBuffer_V0_InitWithSegment(ZSTDGPU_PARAM_I
     outBuffer.lastDword = lastDword;
     outBuffer.baseDword = baseDword;
     outBuffer.hadlastrefill = baseDword == lastDword;
-    outBuffer.hadlastrefillHuffman = false;
     //outBuffer.bytesz = bytesz;
 }
 
@@ -960,19 +958,6 @@ static inline void zstdgpu_Backward_BitBuffer_V0_Pop(ZSTDGPU_PARAM_INOUT(zstdgpu
 
 ZSTDGPU_BITBUF_DEFINE_STANDARD_METHODS(Backward_BitBuffer_V0)
 
-static inline bool zstdgpu_Backward_BitBuffer_V0_CanRefill_Huffman(ZSTDGPU_PARAM_IN(zstdgpu_Backward_BitBuffer_V0) inBuffer, uint32_t bitcnt)
-{
-    ZSTDGPU_ASSERT(bitcnt <= 32);
-    if (inBuffer.bitcnt >= bitcnt)
-    {
-        return true;
-    }
-    else
-    {
-        return !inBuffer.hadlastrefillHuffman;
-    }
-}
-
 static inline void zstdgpu_Backward_BitBuffer_V0_Refill_Huffman(ZSTDGPU_PARAM_INOUT(zstdgpu_Backward_BitBuffer_V0) inoutBuffer, uint32_t bitcnt, uint32_t extrabits)
 {
     if (inoutBuffer.hadlastrefill == false)
@@ -983,7 +968,6 @@ static inline void zstdgpu_Backward_BitBuffer_V0_Refill_Huffman(ZSTDGPU_PARAM_IN
     if (inoutBuffer.bitcnt < bitcnt)
     {
         inoutBuffer.bitcnt += extrabits;    // simply increment counter because upper bits are zeros
-        inoutBuffer.hadlastrefillHuffman = true;
     }
 }
 
@@ -998,7 +982,6 @@ static inline uint32_t zstdgpu_Backward_BitBuffer_V0_Get_Huffman(ZSTDGPU_PARAM_I
     {
         inoutBuffer.bitcnt += extrabits;    // simply increment counter because upper bits are zeros
         inoutBuffer.bitbuf <<= extrabits;
-        inoutBuffer.hadlastrefillHuffman = true;
     }
 
     uint32_t result = zstdgpu_Backward_BitBuffer_V0_Top(inoutBuffer, bitcnt);

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -443,6 +443,32 @@ static inline uint32_t zstdgpu_FindFirstBitHiU32(uint32_t v)
 #endif
 }
 
+static inline uint32_t zstdgpu_FindFirstBitHiU32_Nonzero(uint32_t v)
+{
+#ifdef __hlsl_dx_compiler
+    // On AMD RDNA3, {v,s}_clz_i32_u32 return -1 for an input of 0, instead of returning 32.
+    // So firstbithigh can't directly be implemented as 31 - {v,s}_clz_i32_u32;
+    // there are additional fixup instructions, currently even when or-ing the input with 1.
+    // The current AMD driver compiler does not do a great job with uniform firstbithigh:
+    //          v_clz_i32_u32   v0, s10             // input s10 is scalar, but didn't use SALU s_clz_i32_u32
+    //          v_sub_nc_u32    v1, 31, v0
+    //          v_cmp_ne_i32    vcc_lo, -1, v0
+    //          v_cndmask_b32   v0, -1, v1, vcc_lo  // final result in v10
+    // The following formulation gets us:
+    //          s_brev_b32    s13, s10
+    //          s_ctz_i32_b32 s13, s13
+    //          s_sub_u32     s13, 31, s13          // final result in s13
+    // Which isn't identical when v==0, so only use this when v!=0.
+    // If input is non-uniform (VALU), we still save an instruction.
+    return 31 - firstbitlow(reversebits(v));
+#else
+    unsigned long index = 0;
+    uint32_t found = _BitScanReverse(&index, v);
+    ZSTDGPU_ASSERT(0 != found);
+    return found ? (uint32_t)index : 32u; // found should be true, but due this to match GPU behavior
+#endif
+}
+
 static inline uint32_t zstdgpu_FindFirstBitHiU64(uint64_t x)
 {
 #if defined(__hlsl_dx_compiler)
@@ -848,7 +874,7 @@ static inline void zstdgpu_Backward_BitBuffer_V0_InitWithSegment(ZSTDGPU_PARAM_I
     uint32_t bitbuf = buffer[lastDword] & bitmsk;
 
     // Secondly, we search for the highest set bit to see how many bits are valid
-    bitcnt = zstdgpu_FindFirstBitHiU32(bitbuf);
+    bitcnt = zstdgpu_FindFirstBitHiU32_Nonzero(bitbuf);
 #ifdef ZSTDGPU_USE_REVERSED_BIT_BUFFER_BITBUF
     bitbuf <<= 32u - bitcnt;
     bitbuf = reversebits(bitbuf);
@@ -1035,7 +1061,7 @@ static inline void zstdgpu_HuffmanStream_InitWithSegment(ZSTDGPU_PARAM_INOUT(zst
     // Count number of leading zero bits above the flag (result in [0:7]).
     // There is no 64-bit version of v_clz_i32_u32 and uint32_t(data64 >> 32) is free since U64 is a pair of VGPRs.
     // Add one (reverse-subtract by 32, not 31) to also shift out the flag itself.
-    const uint32_t nonDataBitCount = 32 - zstdgpu_FindFirstBitHiU32(uint32_t(data64 >> 32));
+    const uint32_t nonDataBitCount = 32 - zstdgpu_FindFirstBitHiU32_Nonzero(uint32_t(data64 >> 32));
     data64 <<= nonDataBitCount;
     const uint32_t keptBitCount = 64 - (oobBitCount + nonDataBitCount); // could be 0
 


### PR DESCRIPTION
Main changes in this PR:

1. Add a `if (threadId != 0) return` after the `ZSTDGPU_PRELOAD_FSE_INTO_LDS` and `GroupMemoryBarrierWithGroupSync` is done, since the rest of the shader is all (what the current compiler does is a different story) scalar. This greatly helps RDNA3 and RDNA4 because they end up picking wave64 for compute shaders often. This change turns the high 32-bits of exec off, making it so the typical second pass of a wave64 VALU/VMEM/LDS instruction is skipped. An input zst file of ~146MB ("insects") does a Dispatch(15299, 1, 1) that on an 7900 XTX (RDNA3) with SetStablePowerState has a duration change of 1.81 ms -> 1.50 ms. Using DecompressSequences_LdsFseCache32 seems to reduce that more (~1.44 ms), but with the other changes in this PR DecompressSequences_LdsFseCache{32,64} are pretty close on Navi31, and maybe the TG size of 64 could be better for other data sets, so keep the PSO variant selection the same now.
2. Restructure the loop condition to be in the middle so `ZSTGPU_DECODE_SEQ` is invoked just once. This is mainly for easier performance analysis; the runtime performance does not seem affected.
3. Do alternate firstbithigh for known nonzero input to workaround current AMD GPU compiler from not emitting scalar instructions. This tidies up the ISA a bit (the bitbuffer InitWithSegment part), but the loop is still an issue.
4. Merge/pack `SEQ_{LITERAL, MATCH}_LENGTH_BASELINES` and `SEQ_{LITERAL, MATCH}_LENGTH_EXTRA_BITS` arrays into one array. There was a separate s_load_b32 with its own waitcnt, and it also reduces duplicate indexing and OOB-handling code the compiler emits. Navi31 XTX SetStablePowerState duration for ~146MB "insects" archive: 1.44 ms -> 1.35 ms. See commit in the PR for the before/after ISA.
5. Raw-buffer-ize all backwards bitbuffers for consistency with `HuffmanStream`, and because ByteAddressBuffer is more friendly to SMEM (SMEM doesn't do stride-mul itself), though that last point may only be relevant after future compiler changes.

**Diff is best viewed when ignoring whitespace changes.**

This PR should probably be squashed if/when merged; I didn't force-push anything that would change commit hashes.