### PR TITLE
MAINTENANCE: Fixes code analysis warnings fixes and pulls up code into shared functions

### DIFF
--- a/zstd/platform/x64/zstdgpu_demo_platform.cpp
+++ b/zstd/platform/x64/zstdgpu_demo_platform.cpp
@@ -162,8 +162,11 @@ void zstdgpu_Demo_PlatformTerm(struct ID3D12Device *device)
 
         IDXGIDebug *dxgiDebug = NULL;
         LOAD_F(DXGIGetDebugInterface, L"dxgidebug.dll");
-        D3D12AID_CHECK(fnDXGIGetDebugInterface(D3D12AID_IID_PPV_ARGS(&dxgiDebug)));
-        dxgiDebug->ReportLiveObjects(DXGI_DEBUG_ALL, DXGI_DEBUG_RLO_ALL);
+        if (NULL != fnDXGIGetDebugInterface)
+        {
+            D3D12AID_CHECK(fnDXGIGetDebugInterface(D3D12AID_IID_PPV_ARGS(&dxgiDebug)));
+            dxgiDebug->ReportLiveObjects(DXGI_DEBUG_ALL, DXGI_DEBUG_RLO_ALL);
+        }
 
         D3D12AID_SAFE_RELEASE(device);
 

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -263,8 +263,8 @@ static void zstdgpu_ReCreate_SRTs(zstdgpu_SRTs & srts, ID3D12Device *device, con
     D3D12_CPU_DESCRIPTOR_HANDLE cpuStart = d3d12aid_DescriptorHeap_GetCpuStart(srts.heap);
     const uint32_t descSize = device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 
-    D3D12_CPU_DESCRIPTOR_HANDLE cpuDest = { cpuStart.ptr + srts.heapOffset * descSize };
-    D3D12_GPU_DESCRIPTOR_HANDLE gpuDest = { gpuStart.ptr + srts.heapOffset * descSize };
+    D3D12_CPU_DESCRIPTOR_HANDLE cpuDest = { cpuStart.ptr + (SIZE_T)srts.heapOffset * descSize };
+    D3D12_GPU_DESCRIPTOR_HANDLE gpuDest = { gpuStart.ptr + (SIZE_T)srts.heapOffset * descSize };
 
     D3D12_SHADER_RESOURCE_VIEW_DESC SRV;
     D3D12_UNORDERED_ACCESS_VIEW_DESC UAV;
@@ -463,7 +463,7 @@ struct zstdgpu_PerRequestContextImpl
 static uint32_t zstdgpu_GetStageCountFromSetupInputsType(ZSTDGPU_ENUM(SetupInputsType) type)
 {
     ZSTDGPU_UNUSED(type);
-    return 3u;
+    return ZSTDGPU_ENUM_CONST(ResourceAllocation_StageCount);
 }
 
 uint32_t zstdgpu_GetPersistentContextRequiredMemorySizeInBytes(void)
@@ -506,7 +506,7 @@ ZSTDGPU_ENUM(Status) zstdgpu_CreatePersistentContext(zstdgpu_PersistentContext *
         D3D12AID_CHECK(device->CreateCommandSignature(&dispatchCmdSigDesc, NULL, D3D12AID_IID_PPV_ARGS(&context->dispatchCmdSig)));
 
         D3D12_FEATURE_DATA_D3D12_OPTIONS1 featureOptions1;
-        D3D12AID_CHECK(device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS1, &featureOptions1, sizeof(featureOptions1)));
+        D3D12AID_CHECK(device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS1, ZSTDGPU_WARN_DISABLE_MSVC(6001, &featureOptions1), sizeof(featureOptions1)));
         context->minLaneCount = featureOptions1.WaveLaneCountMin;
         context->maxLaneCount = featureOptions1.WaveLaneCountMax;
 
@@ -814,7 +814,7 @@ ZSTDGPU_ENUM(Status) zstdgpu_GetGpuMemoryRequirement(uint32_t *outDefaultHeapByt
     proceed = proceed && (NULL != outUploadHeapByteCount);
     proceed = proceed && (NULL != outReadbackHeapByteCount);
     proceed = proceed && (NULL != outShaderVisibleDescriptorCount);
-    proceed = proceed && (stageIndex < stageCount);
+    proceed = proceed && (stageIndex < stageCount) && stageIndex < ZSTDGPU_ENUM_CONST(ResourceAllocation_StageCount);
     proceed = proceed && (req->thisMemoryBlock == (void *)req);
     proceed = proceed && (req->zstdFrameCount > 0);
     proceed = proceed && (req->zstdCompressedFramesByteCount > 0);
@@ -984,7 +984,7 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithInteralMemory(zstdgpu_PerRequestContext r
     proceed = proceed && (req->zstdCompressedFramesByteCount > 0);
     proceed = proceed && (req->zstdUncompressedFrameCount == req->zstdFrameCount);
     proceed = proceed && (req->zstdUncompressedFramesByteCount > 0);
-    proceed = proceed && (stageIndex < stageCount);
+    proceed = proceed && (stageIndex < stageCount) && (stageIndex < ZSTDGPU_ENUM_CONST(ResourceAllocation_StageCount));
     proceed = proceed && (NULL != cmdList);
     ZSTDGPU_ASSERT(proceed > 0);
 

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -457,10 +457,10 @@ struct zstdgpu_PerRequestContextImpl
     uint32_t                zstdUncompressedSequenceCount;
     uint32_t                zstdSeqStreamCount;
 
-    zstdgpu_SetupInputsType setupInputsType;
+    ZSTDGPU_ENUM(SetupInputsType) setupInputsType;
 };
 
-static uint32_t zstdgpu_GetStageCountFromSetupInputsType(zstdgpu_SetupInputsType type)
+static uint32_t zstdgpu_GetStageCountFromSetupInputsType(ZSTDGPU_ENUM(SetupInputsType) type)
 {
     ZSTDGPU_UNUSED(type);
     return 3u;
@@ -476,7 +476,7 @@ uint32_t zstdgpu_GetPerRequestContextRequiredMemorySizeInBytes(void)
     return sizeof(zstdgpu_PerRequestContextImpl);
 }
 
-zstdgpu_Status zstdgpu_CreatePersistentContext(zstdgpu_PersistentContext *outPersistentContext, ID3D12Device *device, void *memoryBlock, uint32_t memoryBlockSizeInBytes)
+ZSTDGPU_ENUM(Status) zstdgpu_CreatePersistentContext(zstdgpu_PersistentContext *outPersistentContext, ID3D12Device *device, void *memoryBlock, uint32_t memoryBlockSizeInBytes)
 {
     uint32_t proceed = 1;
 
@@ -520,13 +520,13 @@ zstdgpu_Status zstdgpu_CreatePersistentContext(zstdgpu_PersistentContext *outPer
         #undef ZSTDGPU_KERNEL
 
         *outPersistentContext = context;
-        return kzstdgpu_StatusSuccess;
+        return ZSTDGPU_ENUM_CONST(StatusSuccess);
     }
-    return kzstdgpu_StatusInvalidArgument;
+    return ZSTDGPU_ENUM_CONST(StatusInvalidArgument);
 }
 
 
-zstdgpu_Status zstdgpu_DestroyPersistentContext(void **outMemoryBlock, uint32_t *outMemoryBlockSizeInBytes, zstdgpu_PersistentContext inPersistentContext)
+ZSTDGPU_ENUM(Status) zstdgpu_DestroyPersistentContext(void **outMemoryBlock, uint32_t *outMemoryBlockSizeInBytes, zstdgpu_PersistentContext inPersistentContext)
 {
     const uint32_t proceed = inPersistentContext->thisMemoryBlock == (void *)inPersistentContext;
     ZSTDGPU_ASSERT(proceed > 0);
@@ -548,12 +548,12 @@ zstdgpu_Status zstdgpu_DestroyPersistentContext(void **outMemoryBlock, uint32_t 
 
         inPersistentContext->thisMemoryBlock = NULL;
 
-        return kzstdgpu_StatusSuccess;
+        return ZSTDGPU_ENUM_CONST(StatusSuccess);
     }
-    return kzstdgpu_StatusInvalidArgument;
+    return ZSTDGPU_ENUM_CONST(StatusInvalidArgument);
 }
 
-zstdgpu_Status zstdgpu_CreatePerRequestContext(zstdgpu_PerRequestContext *outPerRequestContext, zstdgpu_PersistentContext persistentContext, void *memoryBlock, uint32_t memoryBlockSizeInBytes)
+ZSTDGPU_ENUM(Status) zstdgpu_CreatePerRequestContext(zstdgpu_PerRequestContext *outPerRequestContext, zstdgpu_PersistentContext persistentContext, void *memoryBlock, uint32_t memoryBlockSizeInBytes)
 {
     uint32_t proceed = 1;
 
@@ -650,15 +650,15 @@ zstdgpu_Status zstdgpu_CreatePerRequestContext(zstdgpu_PerRequestContext *outPer
         context->zstdUncompressedLiteralsByteCount  = 0;
         context->zstdUncompressedSequenceCount      = 0;
         context->zstdSeqStreamCount                 = 0;
-        context->setupInputsType                    = kzstdgpu_SetupInputsType_Frames_Unknown;
+        context->setupInputsType                    = ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_Unknown);
 
         *outPerRequestContext = context;
-        return kzstdgpu_StatusSuccess;
+        return ZSTDGPU_ENUM_CONST(StatusSuccess);
     }
-    return kzstdgpu_StatusInvalidArgument;
+    return ZSTDGPU_ENUM_CONST(StatusInvalidArgument);
 }
 
-zstdgpu_Status zstdgpu_DestroyPerRequestContext(void **outMemoryBlock, uint32_t *outMemoryBlockSizeInBytes, zstdgpu_PerRequestContext inPerRequestContext)
+ZSTDGPU_ENUM(Status) zstdgpu_DestroyPerRequestContext(void **outMemoryBlock, uint32_t *outMemoryBlockSizeInBytes, zstdgpu_PerRequestContext inPerRequestContext)
 {
     const uint32_t proceed = inPerRequestContext->thisMemoryBlock == (void *)inPerRequestContext;
     ZSTDGPU_ASSERT(proceed > 0);
@@ -696,12 +696,12 @@ zstdgpu_Status zstdgpu_DestroyPerRequestContext(void **outMemoryBlock, uint32_t 
         if (NULL != outMemoryBlockSizeInBytes)
             *outMemoryBlockSizeInBytes = zstdgpu_GetPersistentContextRequiredMemorySizeInBytes();
 
-        return kzstdgpu_StatusSuccess;
+        return ZSTDGPU_ENUM_CONST(StatusSuccess);
     }
-    return kzstdgpu_StatusInvalidArgument;
+    return ZSTDGPU_ENUM_CONST(StatusInvalidArgument);
 }
 
-zstdgpu_Status zstdgpu_SetupInputsAsFramesInCpuMemory(uint32_t *outStageCount, zstdgpu_PerRequestContext inPerRequestContext, uint32_t frameCount, uint32_t framesMemorySizeInBytes, zstdgpu_UploadFrames *uploadCallback, void *uploadUserdata)
+ZSTDGPU_ENUM(Status) zstdgpu_SetupInputsAsFramesInCpuMemory(uint32_t *outStageCount, zstdgpu_PerRequestContext inPerRequestContext, uint32_t frameCount, uint32_t framesMemorySizeInBytes, zstdgpu_UploadFrames *uploadCallback, void *uploadUserdata)
 {
     uint32_t proceed = 1;
     proceed = proceed && (inPerRequestContext->thisMemoryBlock == (void *)inPerRequestContext);
@@ -714,7 +714,7 @@ zstdgpu_Status zstdgpu_SetupInputsAsFramesInCpuMemory(uint32_t *outStageCount, z
 
     if (proceed)
     {
-        if (kzstdgpu_SetupInputsType_Frames_GpuMemory == inPerRequestContext->setupInputsType)
+        if (ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_GpuMemory) == inPerRequestContext->setupInputsType)
         {
             // NOTE(pamartis): we only release ID3D12Resource with the PerRequest context.
             // ID3D12Resource within zstdgpu_ResourceDataGpu will be released with the zstdgpu_ResourceDataGpu_Term call.
@@ -729,15 +729,15 @@ zstdgpu_Status zstdgpu_SetupInputsAsFramesInCpuMemory(uint32_t *outStageCount, z
         inPerRequestContext->compressedFramesRefs           = NULL;
         inPerRequestContext->zstdFrameCount                 = frameCount;
         inPerRequestContext->zstdCompressedFramesByteCount  = framesMemorySizeInBytes;
-        inPerRequestContext->setupInputsType                = kzstdgpu_SetupInputsType_Frames_CpuMemory;
+        inPerRequestContext->setupInputsType                = ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_CpuMemory);
 
         *outStageCount = 3u;
-        return kzstdgpu_StatusSuccess;
+        return ZSTDGPU_ENUM_CONST(StatusSuccess);
     }
-    return kzstdgpu_StatusInvalidArgument;
+    return ZSTDGPU_ENUM_CONST(StatusInvalidArgument);
 }
 
-zstdgpu_Status zstdgpu_SetupInputsAsFramesInGpuMemory(uint32_t *outStageCount, zstdgpu_PerRequestContext inPerRequestContext, struct ID3D12Resource *framesMemory, uint32_t framesMemorySizeInBytes, struct ID3D12Resource *frames, uint32_t frameCount)
+ZSTDGPU_ENUM(Status) zstdgpu_SetupInputsAsFramesInGpuMemory(uint32_t *outStageCount, zstdgpu_PerRequestContext inPerRequestContext, struct ID3D12Resource *framesMemory, uint32_t framesMemorySizeInBytes, struct ID3D12Resource *frames, uint32_t frameCount)
 {
     uint32_t proceed = 1;
     proceed = proceed && (inPerRequestContext->thisMemoryBlock == (void *)inPerRequestContext);
@@ -750,7 +750,7 @@ zstdgpu_Status zstdgpu_SetupInputsAsFramesInGpuMemory(uint32_t *outStageCount, z
 
     if (proceed)
     {
-        if (kzstdgpu_SetupInputsType_Frames_GpuMemory == inPerRequestContext->setupInputsType)
+        if (ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_GpuMemory) == inPerRequestContext->setupInputsType)
         {
             // NOTE(pamartis): we only release ID3D12Resource with the PerRequest context.
             // ID3D12Resource within zstdgpu_ResourceDataGpu will be released with the zstdgpu_ResourceDataGpu_Term call.
@@ -767,15 +767,15 @@ zstdgpu_Status zstdgpu_SetupInputsAsFramesInGpuMemory(uint32_t *outStageCount, z
         inPerRequestContext->compressedFramesRefs->AddRef();
         inPerRequestContext->zstdFrameCount                 = frameCount;
         inPerRequestContext->zstdCompressedFramesByteCount  = framesMemorySizeInBytes;
-        inPerRequestContext->setupInputsType                = kzstdgpu_SetupInputsType_Frames_GpuMemory;
+        inPerRequestContext->setupInputsType                = ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_GpuMemory);
 
         *outStageCount = 3u;
-        return kzstdgpu_StatusSuccess;
+        return ZSTDGPU_ENUM_CONST(StatusSuccess);
     }
-    return kzstdgpu_StatusInvalidArgument;
+    return ZSTDGPU_ENUM_CONST(StatusInvalidArgument);
 }
 
-ZSTDGPU_API zstdgpu_Status zstdgpu_SetupOutputs(zstdgpu_PerRequestContext inPerRequestContext, struct ID3D12Resource *framesMemory, uint32_t framesMemorySizeInBytes, struct ID3D12Resource *frames, uint32_t frameCount)
+ZSTDGPU_API ZSTDGPU_ENUM(Status) zstdgpu_SetupOutputs(zstdgpu_PerRequestContext inPerRequestContext, struct ID3D12Resource *framesMemory, uint32_t framesMemorySizeInBytes, struct ID3D12Resource *frames, uint32_t frameCount)
 {
     uint32_t proceed = 1;
     proceed = proceed && (inPerRequestContext->thisMemoryBlock == (void *)inPerRequestContext);
@@ -800,12 +800,12 @@ ZSTDGPU_API zstdgpu_Status zstdgpu_SetupOutputs(zstdgpu_PerRequestContext inPerR
 
         inPerRequestContext->zstdUncompressedFrameCount         = frameCount;
         inPerRequestContext->zstdUncompressedFramesByteCount    = framesMemorySizeInBytes;
-        return kzstdgpu_StatusSuccess;
+        return ZSTDGPU_ENUM_CONST(StatusSuccess);
     }
-    return kzstdgpu_StatusInvalidArgument;
+    return ZSTDGPU_ENUM_CONST(StatusInvalidArgument);
 }
 
-zstdgpu_Status zstdgpu_GetGpuMemoryRequirement(uint32_t *outDefaultHeapByteCount, uint32_t *outUploadHeapByteCount, uint32_t *outReadbackHeapByteCount, uint32_t *outShaderVisibleDescriptorCount, zstdgpu_PerRequestContext req, uint32_t stageIndex)
+ZSTDGPU_ENUM(Status) zstdgpu_GetGpuMemoryRequirement(uint32_t *outDefaultHeapByteCount, uint32_t *outUploadHeapByteCount, uint32_t *outReadbackHeapByteCount, uint32_t *outShaderVisibleDescriptorCount, zstdgpu_PerRequestContext req, uint32_t stageIndex)
 {
     uint32_t proceed = 1;
     uint32_t stageCount = zstdgpu_GetStageCountFromSetupInputsType(req->setupInputsType);
@@ -827,7 +827,7 @@ zstdgpu_Status zstdgpu_GetGpuMemoryRequirement(uint32_t *outDefaultHeapByteCount
         #define CNTRS(name) req->resData.gpu2Cpu.CountersCpu[kzstdgpu_CounterIndex_##name]
         if (stageIndex == 0)
         {
-            zstdgpu_ResourceInfo_Stage_0_Init(&req->resInfo, req->zstdFrameCount, req->zstdCompressedFramesByteCount, kzstdgpu_SetupInputsType_Frames_GpuMemory == req->setupInputsType ? 1u : 0u);
+            zstdgpu_ResourceInfo_Stage_0_Init(&req->resInfo, req->zstdFrameCount, req->zstdCompressedFramesByteCount, ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_GpuMemory) == req->setupInputsType ? 1u : 0u);
         }
         else if (stageIndex == 1)
         {
@@ -861,16 +861,16 @@ zstdgpu_Status zstdgpu_GetGpuMemoryRequirement(uint32_t *outDefaultHeapByteCount
         *outShaderVisibleDescriptorCount    = zstdgpu_Count_SRTs();
 
         #undef CNTRS
-        return kzstdgpu_StatusSuccess;
+        return ZSTDGPU_ENUM_CONST(StatusSuccess);
     }
-    return kzstdgpu_StatusInvalidArgument;
+    return ZSTDGPU_ENUM_CONST(StatusInvalidArgument);
 }
 
 static void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext inPerRequestContext, ID3D12GraphicsCommandList *cmdList);
 static void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext inPerRequestContext, ID3D12GraphicsCommandList *cmdList);
 static void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext inPerRequestContext, ID3D12GraphicsCommandList *cmdList);
 
-zstdgpu_Status zstdgpu_SubmitWithExternalMemory(zstdgpu_PerRequestContext req,
+ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithExternalMemory(zstdgpu_PerRequestContext req,
                                                 uint32_t stageIndex,
                                                 struct ID3D12GraphicsCommandList *cmdList,
                                                 struct ID3D12Heap *defaultHeap,
@@ -888,7 +888,7 @@ zstdgpu_Status zstdgpu_SubmitWithExternalMemory(zstdgpu_PerRequestContext req,
     uint32_t uploadHeapMemReq = 0;
     uint32_t readbackHeapMemReq = 0;
     uint32_t shaderVisibleHeapDscCount = 0;
-    proceed = kzstdgpu_StatusSuccess == zstdgpu_GetGpuMemoryRequirement(&defaultHeapMemReq, &uploadHeapMemReq, &readbackHeapMemReq, &shaderVisibleHeapDscCount, req, stageIndex);
+    proceed = ZSTDGPU_ENUM_CONST(StatusSuccess) == zstdgpu_GetGpuMemoryRequirement(&defaultHeapMemReq, &uploadHeapMemReq, &readbackHeapMemReq, &shaderVisibleHeapDscCount, req, stageIndex);
     proceed = proceed && (req->thisMemoryBlock == (void *)req);
     proceed = proceed && (req->zstdFrameCount > 0);
     proceed = proceed && (req->zstdCompressedFramesByteCount > 0);
@@ -930,7 +930,7 @@ zstdgpu_Status zstdgpu_SubmitWithExternalMemory(zstdgpu_PerRequestContext req,
         req->resData.gpu2Cpu_HeapOffset[stageIndex] = readbackHeap_OffsetInBytes;
 
         zstdgpu_ResourceDataGpu_Init(&req->resData, &req->resInfo, req->device, stageIndex);
-        if (kzstdgpu_SetupInputsType_Frames_GpuMemory == req->setupInputsType && stageIndex == 0u)
+        if (ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_GpuMemory) == req->setupInputsType && stageIndex == 0u)
         {
             zstdgpu_ResourceDataGpu_ReInitInputExternal(&req->resData, req->compressedFramesData, req->compressedFramesRefs);
         }
@@ -943,7 +943,7 @@ zstdgpu_Status zstdgpu_SubmitWithExternalMemory(zstdgpu_PerRequestContext req,
         // NOTE(pamartis): we need to do call upload callback right after initialising resources of stage == 0
         if (stageIndex == 0)
         {
-            if (kzstdgpu_SetupInputsType_Frames_CpuMemory == req->setupInputsType)
+            if (ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_CpuMemory) == req->setupInputsType)
             {
                 req->uploadCallback(req->resData.cpu2Gpu.CompressedDataCpu, req->zstdCompressedFramesByteCount, req->resData.cpu2Gpu.FramesRefsCpu, req->zstdFrameCount, req->uploadUserdata);
             }
@@ -969,12 +969,12 @@ zstdgpu_Status zstdgpu_SubmitWithExternalMemory(zstdgpu_PerRequestContext req,
             zstdgpu_SubmitStage2(req, cmdList);
         }
 
-        return kzstdgpu_StatusSuccess;
+        return ZSTDGPU_ENUM_CONST(StatusSuccess);
     }
-    return kzstdgpu_StatusInvalidArgument;
+    return ZSTDGPU_ENUM_CONST(StatusInvalidArgument);
 }
 
-zstdgpu_Status zstdgpu_SubmitWithInteralMemory(zstdgpu_PerRequestContext req, uint32_t stageIndex, struct ID3D12GraphicsCommandList *cmdList)
+ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithInteralMemory(zstdgpu_PerRequestContext req, uint32_t stageIndex, struct ID3D12GraphicsCommandList *cmdList)
 {
     uint32_t proceed = 1;
     uint32_t stageCount = zstdgpu_GetStageCountFromSetupInputsType(req->setupInputsType);
@@ -995,7 +995,7 @@ zstdgpu_Status zstdgpu_SubmitWithInteralMemory(zstdgpu_PerRequestContext req, ui
         // NOTE(pamartis): Recompute memory information for a given stage
         if (stageIndex == 0)
         {
-            zstdgpu_ResourceInfo_Stage_0_Init(&req->resInfo, req->zstdFrameCount, req->zstdCompressedFramesByteCount, kzstdgpu_SetupInputsType_Frames_GpuMemory == req->setupInputsType ? 1u : 0u);
+            zstdgpu_ResourceInfo_Stage_0_Init(&req->resInfo, req->zstdFrameCount, req->zstdCompressedFramesByteCount, ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_GpuMemory) == req->setupInputsType ? 1u : 0u);
         }
         else if (stageIndex == 1)
         {
@@ -1035,7 +1035,7 @@ zstdgpu_Status zstdgpu_SubmitWithInteralMemory(zstdgpu_PerRequestContext req, ui
         // NOTE(pamartis): try re-creating heap and then resources (will trigger only if they were released or never created)
         zstdgpu_ResourceDataGpu_InitHeap(&req->resData, &req->resInfo, req->device, stageIndex);
         zstdgpu_ResourceDataGpu_Init(&req->resData, &req->resInfo, req->device, stageIndex);
-        if (kzstdgpu_SetupInputsType_Frames_GpuMemory == req->setupInputsType && stageIndex == 0u)
+        if (ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_GpuMemory) == req->setupInputsType && stageIndex == 0u)
         {
             zstdgpu_ResourceDataGpu_ReInitInputExternal(&req->resData, req->compressedFramesData, req->compressedFramesRefs);
         }
@@ -1048,7 +1048,7 @@ zstdgpu_Status zstdgpu_SubmitWithInteralMemory(zstdgpu_PerRequestContext req, ui
         // NOTE(pamartis): we need to do call upload callback right after initialising resources of stage == 0
         if (stageIndex == 0)
         {
-            if (kzstdgpu_SetupInputsType_Frames_CpuMemory == req->setupInputsType)
+            if (ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_CpuMemory) == req->setupInputsType)
             {
                 req->uploadCallback(req->resData.cpu2Gpu.CompressedDataCpu, req->zstdCompressedFramesByteCount, req->resData.cpu2Gpu.FramesRefsCpu, req->zstdFrameCount, req->uploadUserdata);
             }
@@ -1076,9 +1076,9 @@ zstdgpu_Status zstdgpu_SubmitWithInteralMemory(zstdgpu_PerRequestContext req, ui
             zstdgpu_SubmitStage2(req, cmdList);
         }
 
-        return kzstdgpu_StatusSuccess;
+        return ZSTDGPU_ENUM_CONST(StatusSuccess);
     }
-    return kzstdgpu_StatusInvalidArgument;
+    return ZSTDGPU_ENUM_CONST(StatusInvalidArgument);
 }
 
 #define setResourceState(barriers, index, resource, stateNameBefore, stateNameAfter)    \
@@ -1197,7 +1197,7 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
         #define zstdgpu_PushUpload(name) cmdList->CopyResource(req->resData.gpuOnly.name, req->resData.cpu2Gpu.name)
 
-        if (kzstdgpu_SetupInputsType_Frames_CpuMemory == req->setupInputsType)
+        if (ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_CpuMemory) == req->setupInputsType)
         {
             zstdgpu_PushUpload(CompressedData);
             zstdgpu_PushUpload(FramesRefs);
@@ -1207,7 +1207,7 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
         setResourceState(barriers, 0, req->resData.gpuOnly.FseProbsDefault, COPY_DEST, NON_PIXEL_SHADER_RESOURCE);
         uploadBarrierCount += 1;
-        if (kzstdgpu_SetupInputsType_Frames_CpuMemory == req->setupInputsType)
+        if (ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_CpuMemory) == req->setupInputsType)
         {
             setResourceState(barriers, 1, req->resData.gpuOnly.CompressedData, COPY_DEST, NON_PIXEL_SHADER_RESOURCE);
             setResourceState(barriers, 2, req->resData.gpuOnly.FramesRefs, COPY_DEST, NON_PIXEL_SHADER_RESOURCE);

--- a/zstd/zstdgpu/zstdgpu_reference_store.cpp
+++ b/zstd/zstdgpu/zstdgpu_reference_store.cpp
@@ -59,7 +59,7 @@ static uint32_t GUnCompressedHuffmanWeightCount = 0;
 static uint32_t GSequenceStreamCount = 0;
 static uint32_t GSequenceCount = 0;
 
-static zstdgpu_ReferenceStore_FseType GFseProbTableTypePending = kzstdgpu_ReferenceStore_FseForceInt;
+static ZSTDGPU_ENUM(ReferenceStore_FseType) GFseProbTableTypePending = ZSTDGPU_ENUM_CONST(ReferenceStore_FseForceInt);
 static uint32_t GCompressedBlockLiteralStreamIndex = 0;
 
 static inline uint32_t izstdgpu_ReferenceStore_PtrToOffs(const void *base)
@@ -128,7 +128,7 @@ static void zstdgpu_AppendLastBlockSize(uint32_t size)
 }
 
 
-void zstdgpu_ReferenceStore_Report_Block(const void *base, uint32_t size, zstdgpu_ReferenceStore_BlockType type)
+void zstdgpu_ReferenceStore_Report_Block(const void *base, uint32_t size, ZSTDGPU_ENUM(ReferenceStore_BlockType) type)
 {
 #define APPEND(TYPE, type, base, size)                                  \
     if (type == kzstdgpu_ReferenceStore_Block##TYPE)                          \
@@ -142,8 +142,8 @@ void zstdgpu_ReferenceStore_Report_Block(const void *base, uint32_t size, zstdgp
     APPEND(RLE, type, base, size);
     APPEND(CMP, type, base, size);
 #undef APPEND
-    uint32_t lastBlockIndex = zstdgpu_SetLastBlockSize(type == kzstdgpu_ReferenceStore_BlockCMP ? 0 : size);
-    if (type == kzstdgpu_ReferenceStore_BlockCMP)
+    uint32_t lastBlockIndex = zstdgpu_SetLastBlockSize(type == ZSTDGPU_ENUM_CONST(ReferenceStore_BlockCMP) ? 0 : size);
+    if (type == ZSTDGPU_ENUM_CONST(ReferenceStore_BlockCMP))
     {
         zstdgpu_Init_CompressedBlockData(GZstd.CompressedBlocks[GBlockIndexCMP - 1]);
         GCompressedBlockLiteralStreamIndex = 0;
@@ -254,9 +254,9 @@ void zstdgpu_ReferenceStore_Report_DecompressedLiteral(const uint8_t *literal, u
     GHufDecompressedLiteralDataOffset += size;
 }
 
-void zstdgpu_ReferenceStore_Report_FseProbTableType(zstdgpu_ReferenceStore_FseType type)
+void zstdgpu_ReferenceStore_Report_FseProbTableType(ZSTDGPU_ENUM(ReferenceStore_FseType) type)
 {
-    ZSTDGPU_ASSERT(type != kzstdgpu_ReferenceStore_FseForceInt);
+    ZSTDGPU_ASSERT(type != ZSTDGPU_ENUM_CONST(ReferenceStore_FseForceInt));
     GFseProbTableTypePending = type;
 }
 
@@ -753,15 +753,15 @@ void zstdgpu_ReferenceStore_Report_ResolvedOffset(size_t offset)
     GResolvedOffsetIndex += 1;
 }
 
-static zstdgpu_Validate_Result izstdgpu_ReferenceStore_Validate_OffsetAndSize(const zstdgpu_OffsetAndSize *ref, const zstdgpu_OffsetAndSize *tst)
+static ZSTDGPU_ENUM(Validate_Result) izstdgpu_ReferenceStore_Validate_OffsetAndSize(const zstdgpu_OffsetAndSize *ref, const zstdgpu_OffsetAndSize *tst)
 {
     if (ref->offs == tst->offs && ref->size == tst->size)
-        return kzstdgpu_Validate_Success;
+        return ZSTDGPU_ENUM_CONST(Validate_Success);
     else
-        return kzstdgpu_Validate_Failed;
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
 }
 
-static zstdgpu_Validate_Result izstdgpu_ReferenceStore_Validate_OffsetsAndSizes(const zstdgpu_OffsetAndSize *ref, uint32_t refCount, const zstdgpu_OffsetAndSize *tst, uint32_t tstCount)
+static ZSTDGPU_ENUM(Validate_Result) izstdgpu_ReferenceStore_Validate_OffsetsAndSizes(const zstdgpu_OffsetAndSize *ref, uint32_t refCount, const zstdgpu_OffsetAndSize *tst, uint32_t tstCount)
 {
     ZSTDGPU_ASSERT(refCount == tstCount);
 
@@ -770,39 +770,39 @@ static zstdgpu_Validate_Result izstdgpu_ReferenceStore_Validate_OffsetsAndSizes(
         // NOTE(pamartis): We iterate to find which reference is invalid.
         for (uint32_t i = 0; i < refCount; ++i)
         {
-            if (kzstdgpu_Validate_Success != izstdgpu_ReferenceStore_Validate_OffsetAndSize(&ref[i], &tst[i]))
-                return kzstdgpu_Validate_Failed;
+            if (ZSTDGPU_ENUM_CONST(Validate_Success) != izstdgpu_ReferenceStore_Validate_OffsetAndSize(&ref[i], &tst[i]))
+                return ZSTDGPU_ENUM_CONST(Validate_Failed);
         }
     }
-    return kzstdgpu_Validate_Success;
+    return ZSTDGPU_ENUM_CONST(Validate_Success);
 }
 
-zstdgpu_Validate_Result zstdgpu_ReferenceStore_Validate_Blocks(const zstdgpu_ResourceDataCpu *resourceDataCpu)
+ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_Blocks(const zstdgpu_ResourceDataCpu *resourceDataCpu)
 {
     if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_Blocks_RAW] != GBlockIndexRAW)
-        return kzstdgpu_Validate_Failed;
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
     if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_Blocks_RLE] != GBlockIndexRLE)
-        return kzstdgpu_Validate_Failed;
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
     if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_Blocks_CMP] != GBlockIndexCMP)
-        return kzstdgpu_Validate_Failed;
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
     #define VALIDATE_BLOCKS(name) \
         izstdgpu_ReferenceStore_Validate_OffsetsAndSizes(GZstd.Blocks##name##Refs, GBlockCount##name, resourceDataCpu->Blocks##name##Refs, resourceDataCpu->Counters[kzstdgpu_CounterIndex_Blocks_##name])
 
-        if (kzstdgpu_Validate_Success != VALIDATE_BLOCKS(RAW))
-            return kzstdgpu_Validate_Failed;
+        if (ZSTDGPU_ENUM_CONST(Validate_Success) != VALIDATE_BLOCKS(RAW))
+            return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
         //VALIDATE_BLOCKS(RLE);
-        if (kzstdgpu_Validate_Success != VALIDATE_BLOCKS(CMP))
-            return kzstdgpu_Validate_Failed;
+        if (ZSTDGPU_ENUM_CONST(Validate_Success) != VALIDATE_BLOCKS(CMP))
+            return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
     #undef VALIDATE_BLOCKS
-    return kzstdgpu_Validate_Success;
+    return ZSTDGPU_ENUM_CONST(Validate_Success);
 }
 
-static zstdgpu_Validate_Result izstdgpu_ReferenceStore_Validate_FseTable(uint32_t refFseTableIndex,
+static ZSTDGPU_ENUM(Validate_Result) izstdgpu_ReferenceStore_Validate_FseTable(uint32_t refFseTableIndex,
                                                                          uint32_t tstFseTableIndex,
                                                                          const zstdgpu_FseInfo *refFseInfos,
                                                                          const zstdgpu_FseInfo *tstFseInfos,
@@ -819,10 +819,10 @@ static zstdgpu_Validate_Result izstdgpu_ReferenceStore_Validate_FseTable(uint32_
     if (refFseTableIndex < kzstdgpu_FseProbTableIndex_MinRLE)
     {
         if (tstFseTableIndex >= kzstdgpu_FseProbTableIndex_MinRLE)
-            return kzstdgpu_Validate_Failed;
+            return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
         if (refFseInfos[refFseTableIndex].fseProbCountAndAccuracyLog2 != tstFseInfos[tstFseTableIndex].fseProbCountAndAccuracyLog2)
-            return kzstdgpu_Validate_Failed;
+            return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
         const uint32_t probCount = refFseInfos[refFseTableIndex].fseProbCountAndAccuracyLog2 & 0xff;
         const uint32_t symbolCount = 1u << (refFseInfos[refFseTableIndex].fseProbCountAndAccuracyLog2 >> 8u);
@@ -831,7 +831,7 @@ static zstdgpu_Validate_Result izstdgpu_ReferenceStore_Validate_FseTable(uint32_
         const uint32_t tstProbStart = tstFseTableIndex * kzstdgpu_MaxCount_FseProbs;
 
         if (0 != memcmp(&refFseProbs[refProbStart], &tstFseProbs[tstProbStart], probCount * sizeof(refFseProbs[0])))
-            return kzstdgpu_Validate_Failed;
+            return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
         if (NULL != tstFseSymbols)
         {
@@ -839,13 +839,13 @@ static zstdgpu_Validate_Result izstdgpu_ReferenceStore_Validate_FseTable(uint32_
             const uint32_t tstElemStart = tstFseTableIndex * kzstdgpu_FseElemMaxCount_LLen;
 
             if (0 != memcmp(&refFseSymbols[refElemStart], &tstFseSymbols[tstElemStart], symbolCount * sizeof(refFseSymbols[0])))
-                return kzstdgpu_Validate_Failed;
+                return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
             if (0 != memcmp(&refFseBitcnts[refElemStart], &tstFseBitcnts[tstElemStart], symbolCount * sizeof(refFseBitcnts[0])))
-                return kzstdgpu_Validate_Failed;
+                return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
             if (0 != memcmp(&refFseNStates[refElemStart], &tstFseNStates[tstElemStart], symbolCount * sizeof(refFseNStates[0])))
-                return kzstdgpu_Validate_Failed;
+                return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
         }
     }
@@ -853,35 +853,35 @@ static zstdgpu_Validate_Result izstdgpu_ReferenceStore_Validate_FseTable(uint32_
     else
     {
         if (refFseTableIndex == kzstdgpu_FseProbTableIndex_Repeat)
-            return kzstdgpu_Validate_Failed;
+            return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
         if (refFseTableIndex != tstFseTableIndex)
-            return kzstdgpu_Validate_Failed;
+            return ZSTDGPU_ENUM_CONST(Validate_Failed);
     }
-    return kzstdgpu_Validate_Success;
+    return ZSTDGPU_ENUM_CONST(Validate_Success);
 }
 
-zstdgpu_Validate_Result zstdgpu_ReferenceStore_Validate_FseTables(const zstdgpu_ResourceDataCpu *resourceDataCpu)
+ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_FseTables(const zstdgpu_ResourceDataCpu *resourceDataCpu)
 {
     const zstdgpu_ResourceDataCpu *ref = &GZstd;
     const zstdgpu_ResourceDataCpu *tst = resourceDataCpu;
 
     if (tst->Counters[kzstdgpu_CounterIndex_Blocks_CMP] != GBlockCountCMP)
-        return kzstdgpu_Validate_Failed;
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
     if (tst->Counters[kzstdgpu_CounterIndex_Blocks_CMP] != GBlockIndexCMP)
-        return kzstdgpu_Validate_Failed;
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
     if (tst->Counters[kzstdgpu_CounterIndex_FseHufW] != GFseProbTableIndexHufW)
-        return kzstdgpu_Validate_Failed;
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
     if (tst->Counters[kzstdgpu_CounterIndex_FseLLen] != GFseProbTableIndexLLen)
-        return kzstdgpu_Validate_Failed;
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
     if (tst->Counters[kzstdgpu_CounterIndex_FseOffs] != GFseProbTableIndexOffs)
-        return kzstdgpu_Validate_Failed;
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
     if (tst->Counters[kzstdgpu_CounterIndex_FseMLen] != GFseProbTableIndexMLen)
-        return kzstdgpu_Validate_Failed;
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
     if (tst->Counters[kzstdgpu_CounterIndex_FseHufW] != GFseCompressedHuffmanWeightCount)
-        return kzstdgpu_Validate_Failed;
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
     for (uint32_t i = 0; i < GBlockCountCMP; ++i)
     {
@@ -908,45 +908,45 @@ zstdgpu_Validate_Result zstdgpu_ReferenceStore_Validate_FseTables(const zstdgpu_
         if (ref->CompressedBlocks[i].fseTableIndexHufW < GFseProbTableIndexHufW)
         {
             if (!(tst->CompressedBlocks[i].fseTableIndexHufW < GFseProbTableIndexHufW))
-                return kzstdgpu_Validate_Failed;
+                return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
-            if (kzstdgpu_Validate_Success != VALIDATE_FSE_TABLE_CONTENT(HufW))
-                return kzstdgpu_Validate_Failed;
+            if (ZSTDGPU_ENUM_CONST(Validate_Success) != VALIDATE_FSE_TABLE_CONTENT(HufW))
+                return ZSTDGPU_ENUM_CONST(Validate_Failed);
         }
 
-        if (kzstdgpu_Validate_Success != VALIDATE_FSE_TABLE_CONTENT(LLen))
-            return kzstdgpu_Validate_Failed;
+        if (ZSTDGPU_ENUM_CONST(Validate_Success) != VALIDATE_FSE_TABLE_CONTENT(LLen))
+            return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
-        if (kzstdgpu_Validate_Success != VALIDATE_FSE_TABLE_CONTENT(Offs))
-            return kzstdgpu_Validate_Failed;
+        if (ZSTDGPU_ENUM_CONST(Validate_Success) != VALIDATE_FSE_TABLE_CONTENT(Offs))
+            return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
-        if (kzstdgpu_Validate_Success != VALIDATE_FSE_TABLE_CONTENT(MLen))
-            return kzstdgpu_Validate_Failed;
+        if (ZSTDGPU_ENUM_CONST(Validate_Success) != VALIDATE_FSE_TABLE_CONTENT(MLen))
+            return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
 
         #undef VALIDATE_FSE_TABLE_CONTENT
     }
-    return kzstdgpu_Validate_Success;
+    return ZSTDGPU_ENUM_CONST(Validate_Success);
 }
 
-zstdgpu_Validate_Result zstdgpu_ReferenceStore_Validate_CompressedBlocksData(const zstdgpu_ResourceDataCpu *resourceDataCpu)
+ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_CompressedBlocksData(const zstdgpu_ResourceDataCpu *resourceDataCpu)
 {
     if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_Blocks_CMP] != GBlockCountCMP)
-        return kzstdgpu_Validate_Failed;
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
     if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_Blocks_CMP] != GBlockIndexCMP)
-        return kzstdgpu_Validate_Failed;
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
     if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_FseHufW] != GFseProbTableIndexHufW)
-        return kzstdgpu_Validate_Failed;
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
     if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_FseLLen] != GFseProbTableIndexLLen)
-        return kzstdgpu_Validate_Failed;
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
     if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_FseOffs] != GFseProbTableIndexOffs)
-        return kzstdgpu_Validate_Failed;
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
     if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_FseMLen] != GFseProbTableIndexMLen)
-        return kzstdgpu_Validate_Failed;
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
     if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_FseHufW] != GFseCompressedHuffmanWeightCount)
-        return kzstdgpu_Validate_Failed;
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
     const zstdgpu_CompressedBlockData *refCmpBlocks = GZstd.CompressedBlocks;
     const zstdgpu_CompressedBlockData *tstCmpBlocks = resourceDataCpu->CompressedBlocks;
@@ -957,14 +957,14 @@ zstdgpu_Validate_Result zstdgpu_ReferenceStore_Validate_CompressedBlocksData(con
         {
             if (tstCmpBlocks[i].litStreamIndex == ~0u)
             {
-                if (kzstdgpu_Validate_Success != izstdgpu_ReferenceStore_Validate_OffsetAndSize(&refCmpBlocks[i].literal, &resourceDataCpu->CompressedBlocks[i].literal))
-                    return kzstdgpu_Validate_Failed;
+                if (ZSTDGPU_ENUM_CONST(Validate_Success) != izstdgpu_ReferenceStore_Validate_OffsetAndSize(&refCmpBlocks[i].literal, &resourceDataCpu->CompressedBlocks[i].literal))
+                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
             }
             else
             {
                 // Only the sizes must be identical, offset can be arbitrary due to randomness of allocation
                 if (refCmpBlocks[i].literal.size != tstCmpBlocks[i].literal.size)
-                    return kzstdgpu_Validate_Failed;
+                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
                 uint32_t refLiteralOffset = refCmpBlocks[i].litStreamIndex;
                 uint32_t tstLitaralOffset = tstCmpBlocks[i].litStreamIndex;
@@ -979,7 +979,7 @@ zstdgpu_Validate_Result zstdgpu_ReferenceStore_Validate_CompressedBlocksData(con
                 if (refCmpBlocks[i].literal.size == refHufLiteral[0].dst.size)
                 {
                     if (refHufLiteral[0].dst.size != tstHufLiteral[0].dst.size)
-                        return kzstdgpu_Validate_Failed;
+                        return ZSTDGPU_ENUM_CONST(Validate_Failed);
                 }
                 else
                 {
@@ -994,15 +994,15 @@ zstdgpu_Validate_Result zstdgpu_ReferenceStore_Validate_CompressedBlocksData(con
                                               + tstHufLiteral[3].dst.size;
 
                     if (refCmpBlocks[i].literal.size != refDstSize)
-                        return kzstdgpu_Validate_Failed;
+                        return ZSTDGPU_ENUM_CONST(Validate_Failed);
                     if (tstCmpBlocks[i].literal.size != tstDstSize)
-                        return kzstdgpu_Validate_Failed;
+                        return ZSTDGPU_ENUM_CONST(Validate_Failed);
                     if (refCmpBlocks[i].literal.size != tstCmpBlocks[i].literal.size)
-                        return kzstdgpu_Validate_Failed;
+                        return ZSTDGPU_ENUM_CONST(Validate_Failed);
                 }
 
-                if (kzstdgpu_Validate_Success != izstdgpu_ReferenceStore_Validate_OffsetAndSize(&refHufLiteral[0].src, &tstHufLiteral[0].src))
-                    return kzstdgpu_Validate_Failed;
+                if (ZSTDGPU_ENUM_CONST(Validate_Success) != izstdgpu_ReferenceStore_Validate_OffsetAndSize(&refHufLiteral[0].src, &tstHufLiteral[0].src))
+                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
             }
 
             // Validate offsets of Fse-compressed Huffman Weights
@@ -1011,27 +1011,27 @@ zstdgpu_Validate_Result zstdgpu_ReferenceStore_Validate_CompressedBlocksData(con
             if (refFseCompressedHuffmanWeightsIndex != kzstdgpu_FseProbTableIndex_Unused)
             {
                 if (refFseCompressedHuffmanWeightsIndex == kzstdgpu_FseProbTableIndex_Repeat)
-                    return kzstdgpu_Validate_Failed;
+                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
                 if (tstFseCompressedHuffmanWeightsIndex == kzstdgpu_FseProbTableIndex_Repeat)
-                    return kzstdgpu_Validate_Failed;
+                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
                 if (tstFseCompressedHuffmanWeightsIndex == kzstdgpu_FseProbTableIndex_Unused)
-                    return kzstdgpu_Validate_Failed;
+                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
-                if (kzstdgpu_Validate_Success != izstdgpu_ReferenceStore_Validate_OffsetAndSize(&GZstd.HufRefs[refFseCompressedHuffmanWeightsIndex], &resourceDataCpu->HufRefs[tstFseCompressedHuffmanWeightsIndex]))
-                    return kzstdgpu_Validate_Failed;
+                if (ZSTDGPU_ENUM_CONST(Validate_Success) != izstdgpu_ReferenceStore_Validate_OffsetAndSize(&GZstd.HufRefs[refFseCompressedHuffmanWeightsIndex], &resourceDataCpu->HufRefs[tstFseCompressedHuffmanWeightsIndex]))
+                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
             }
         }
     }
-    return kzstdgpu_Validate_Success;
+    return ZSTDGPU_ENUM_CONST(Validate_Success);
 }
 
-zstdgpu_Validate_Result zstdgpu_ReferenceStore_Validate_DecompressedHuffmanWeights(const zstdgpu_ResourceDataCpu *resourceDataCpu)
+ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_DecompressedHuffmanWeights(const zstdgpu_ResourceDataCpu *resourceDataCpu)
 {
     if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_Blocks_CMP] != GBlockCountCMP)
-        return kzstdgpu_Validate_Failed;
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
     if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_Blocks_CMP] != GBlockIndexCMP)
-        return kzstdgpu_Validate_Failed;
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
     const zstdgpu_ResourceDataCpu *ref = &GZstd;
     const zstdgpu_ResourceDataCpu *tst = resourceDataCpu;
@@ -1043,20 +1043,20 @@ zstdgpu_Validate_Result zstdgpu_ReferenceStore_Validate_DecompressedHuffmanWeigh
         uint32_t refHuffmanWeightStreamIndex = ref->CompressedBlocks[i].fseTableIndexHufW;
 
         if (refHuffmanWeightStreamIndex == kzstdgpu_FseProbTableIndex_Repeat)
-            return kzstdgpu_Validate_Failed;
+            return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
         if (refHuffmanWeightStreamIndex != kzstdgpu_FseProbTableIndex_Unused)
         {
             if (tstHuffmanWeightStreamIndex == kzstdgpu_FseProbTableIndex_Repeat)
-                return kzstdgpu_Validate_Failed;
+                return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
             if (tstHuffmanWeightStreamIndex == kzstdgpu_FseProbTableIndex_Unused)
-                return kzstdgpu_Validate_Failed;
+                return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
             if (refHuffmanWeightStreamIndex < GFseCompressedHuffmanWeightCount)
             {
                 if (tstHuffmanWeightStreamIndex >= GFseCompressedHuffmanWeightCount)
-                    return kzstdgpu_Validate_Failed;
+                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
                 uint32_t tstCount = tst->DecompressedHuffmanWeightCount[tstHuffmanWeightStreamIndex];
                 uint32_t refCount = ref->DecompressedHuffmanWeightCount[refHuffmanWeightStreamIndex];
@@ -1065,32 +1065,32 @@ zstdgpu_Validate_Result zstdgpu_ReferenceStore_Validate_DecompressedHuffmanWeigh
                 const uint8_t *refStart = &ref->DecompressedHuffmanWeights[refHuffmanWeightStreamIndex * kzstdgpu_MaxCount_HuffmanWeights];
 
                 if (refCount != tstCount)
-                    return kzstdgpu_Validate_Failed;
+                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
                 if (tstCount >= kzstdgpu_MaxCount_HuffmanWeights)
-                    return kzstdgpu_Validate_Failed;
+                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
                 if (0 != memcmp(refStart, tstStart, refCount))
-                    return kzstdgpu_Validate_Failed;
+                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
             }
         }
         else
         {
             // NOTE(pamartis): because ref is Unused, tst must be Unused too.
             if (tstHuffmanWeightStreamIndex != kzstdgpu_FseProbTableIndex_Unused)
-                return kzstdgpu_Validate_Failed;
+                return ZSTDGPU_ENUM_CONST(Validate_Failed);
         }
     }
-    return kzstdgpu_Validate_Success;
+    return ZSTDGPU_ENUM_CONST(Validate_Success);
 }
 
-zstdgpu_Validate_Result zstdgpu_ReferenceStore_Validate_DecodedHuffmanWeights(const zstdgpu_ResourceDataCpu * resourceDataCpu)
+ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_DecodedHuffmanWeights(const zstdgpu_ResourceDataCpu * resourceDataCpu)
 {
     if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_Blocks_CMP] != GBlockCountCMP)
-        return kzstdgpu_Validate_Failed;
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
     if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_Blocks_CMP] != GBlockIndexCMP)
-        return kzstdgpu_Validate_Failed;
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
 
     const zstdgpu_ResourceDataCpu *ref = &GZstd;
@@ -1103,21 +1103,21 @@ zstdgpu_Validate_Result zstdgpu_ReferenceStore_Validate_DecodedHuffmanWeights(co
         uint32_t refHuffmanWeightStreamIndex = ref->CompressedBlocks[i].fseTableIndexHufW;
 
         if (refHuffmanWeightStreamIndex == kzstdgpu_FseProbTableIndex_Repeat)
-            return kzstdgpu_Validate_Failed;
+            return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
         if (refHuffmanWeightStreamIndex != kzstdgpu_FseProbTableIndex_Unused)
         {
             if (tstHuffmanWeightStreamIndex == kzstdgpu_FseProbTableIndex_Repeat)
-                return kzstdgpu_Validate_Failed;
+                return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
             if (tstHuffmanWeightStreamIndex == kzstdgpu_FseProbTableIndex_Unused)
-                return kzstdgpu_Validate_Failed;
+                return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
 
             if (refHuffmanWeightStreamIndex >= GFseCompressedHuffmanWeightCount)
             {
                 if (tstHuffmanWeightStreamIndex < GFseCompressedHuffmanWeightCount)
-                    return kzstdgpu_Validate_Failed;
+                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
                 uint32_t tstCount = tst->DecompressedHuffmanWeightCount[tstHuffmanWeightStreamIndex];
                 uint32_t refCount = ref->DecompressedHuffmanWeightCount[refHuffmanWeightStreamIndex];
@@ -1126,26 +1126,26 @@ zstdgpu_Validate_Result zstdgpu_ReferenceStore_Validate_DecodedHuffmanWeights(co
                 const uint8_t* refStart = &ref->DecompressedHuffmanWeights[refHuffmanWeightStreamIndex * kzstdgpu_MaxCount_HuffmanWeights];
 
                 if (refCount != tstCount)
-                    return kzstdgpu_Validate_Failed;
+                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
                 if (tstCount >= kzstdgpu_MaxCount_HuffmanWeights)
-                    return kzstdgpu_Validate_Failed;
+                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
                 if (0 != memcmp(refStart, tstStart, refCount))
-                    return kzstdgpu_Validate_Failed;
+                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
             }
         }
         else
         {
             // NOTE(pamartis): because ref is Unused, tst must be Unused too.
             if (tstHuffmanWeightStreamIndex != kzstdgpu_FseProbTableIndex_Unused)
-                return kzstdgpu_Validate_Failed;
+                return ZSTDGPU_ENUM_CONST(Validate_Failed);
         }
     }
-    return kzstdgpu_Validate_Success;
+    return ZSTDGPU_ENUM_CONST(Validate_Success);
 }
 
-zstdgpu_Validate_Result zstdgpu_ReferenceStore_Validate_DecompressedLiterals(const zstdgpu_ResourceDataCpu *resourceDataCpu)
+ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_DecompressedLiterals(const zstdgpu_ResourceDataCpu *resourceDataCpu)
 {
     const zstdgpu_ResourceDataCpu *tstData = resourceDataCpu;
     const zstdgpu_ResourceDataCpu *refData = &GZstd;
@@ -1159,32 +1159,32 @@ zstdgpu_Validate_Result zstdgpu_ReferenceStore_Validate_DecompressedLiterals(con
         const uint32_t tstLitT = zstdgpu_DecodeLitOffsetType(tstLit->offs);
 
         if (refLitT != tstLitT)
-            return kzstdgpu_Validate_Failed;
+            return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
         // NOTE(pamartis): if the type of the offset not "compressed literal", then it's a non-compressed literal stored in the source data, so offsets are identical
         if (zstdgpu_CheckLitOffsetTypeCmp(refLitT) == 0)
         {
-            if (kzstdgpu_Validate_Success != izstdgpu_ReferenceStore_Validate_OffsetAndSize(refLit, tstLit))
-                return kzstdgpu_Validate_Failed;
+            if (ZSTDGPU_ENUM_CONST(Validate_Success) != izstdgpu_ReferenceStore_Validate_OffsetAndSize(refLit, tstLit))
+                return ZSTDGPU_ENUM_CONST(Validate_Failed);
         }
         else
         // NOTE(pamartis): if the type of the offset is "compressed literal", then it's a decompressed literal stored in `DecompressedLiterals`, so offsets are NOT identical
         {
             if (refLit->size != tstLit->size)
-                return kzstdgpu_Validate_Failed;
+                return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
             const uint8_t *refDecLit = refData->DecompressedLiterals + zstdgpu_DecodeLitOffset(refLit->offs);
             const uint8_t *tstDecLit = tstData->DecompressedLiterals + zstdgpu_DecodeLitOffset(tstLit->offs);
             if (0 != memcmp(refDecLit, tstDecLit, refLit->size))
             {
-                return kzstdgpu_Validate_Failed;
+                return ZSTDGPU_ENUM_CONST(Validate_Failed);
             }
         }
     }
-    return kzstdgpu_Validate_Success;
+    return ZSTDGPU_ENUM_CONST(Validate_Success);
 }
 
-zstdgpu_Validate_Result zstdgpu_ReferenceStore_Validate_DecompressedSequences(const struct zstdgpu_ResourceDataCpu *resourceDataCpu)
+ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_DecompressedSequences(const struct zstdgpu_ResourceDataCpu *resourceDataCpu)
 {
     const zstdgpu_ResourceDataCpu *tstData = resourceDataCpu;
     const zstdgpu_ResourceDataCpu *refData = &GZstd;
@@ -1192,17 +1192,17 @@ zstdgpu_Validate_Result zstdgpu_ReferenceStore_Validate_DecompressedSequences(co
     for (uint32_t i = 0; i < GBlockCountCMP; ++i)
     {
         if (refData->GlobalBlockIndexPerCmpBlock[i] != tstData->GlobalBlockIndexPerCmpBlock[i])
-            return kzstdgpu_Validate_Failed;
+            return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
         const uint32_t cmpBlockIndex = refData->GlobalBlockIndexPerCmpBlock[i];
 
         if (refData->BlockSizePrefix[cmpBlockIndex] != tstData->BlockSizePrefix[cmpBlockIndex])
-            return kzstdgpu_Validate_Failed;
+            return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
         if (refData->CompressedBlocks[i].seqStreamIndex == ~0u)
         {
             if (tstData->CompressedBlocks[i].seqStreamIndex != ~0u)
-                return kzstdgpu_Validate_Failed;
+                return ZSTDGPU_ENUM_CONST(Validate_Failed);
         }
         else
         {
@@ -1210,16 +1210,16 @@ zstdgpu_Validate_Result zstdgpu_ReferenceStore_Validate_DecompressedSequences(co
             const uint32_t tstSeqSteamIndex = tstData->CompressedBlocks[i].seqStreamIndex;
 
             if (tstSeqSteamIndex == ~0u)
-                return kzstdgpu_Validate_Failed;
+                return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
             if (refData->PerSeqStreamFinalOffset1[refSeqSteamIndex] != tstData->PerSeqStreamFinalOffset1[tstSeqSteamIndex])
-                return kzstdgpu_Validate_Failed;
+                return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
             if (refData->PerSeqStreamFinalOffset2[refSeqSteamIndex] != tstData->PerSeqStreamFinalOffset2[tstSeqSteamIndex])
-                return kzstdgpu_Validate_Failed;
+                return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
             if (refData->PerSeqStreamFinalOffset3[refSeqSteamIndex] != tstData->PerSeqStreamFinalOffset3[tstSeqSteamIndex])
-                return kzstdgpu_Validate_Failed;
+                return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
             const zstdgpu_SeqStreamInfo *refSeqRefs = &refData->SeqRefs[refSeqSteamIndex];
             const zstdgpu_SeqStreamInfo *tstSeqRefs = &tstData->SeqRefs[tstSeqSteamIndex];
@@ -1228,7 +1228,7 @@ zstdgpu_Validate_Result zstdgpu_ReferenceStore_Validate_DecompressedSequences(co
             const uint32_t tstSeqOffs = tstData->PerSeqStreamSeqStart[tstSeqSteamIndex];
 
             if (tstSeqOffs != refSeqOffs)
-                return kzstdgpu_Validate_Failed;
+                return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
             // NOTE: dst.offs can't be the same due to non-deterministic allocation
             //izstdgpu_ReferenceStore_Validate_OffsetAndSize(&refSeqRefs[refSeqSteamIndex].dst, &tstSeqRefs[tstSeqSteamIndex].dst);
@@ -1239,16 +1239,16 @@ zstdgpu_Validate_Result zstdgpu_ReferenceStore_Validate_DecompressedSequences(co
                 const uint32_t tstSeqCount = tstSeqOffsNext - tstSeqOffs;
 
                 if (refSeqCount != tstSeqCount)
-                    return kzstdgpu_Validate_Failed;
+                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
                 if (0 != memcmp(&refData->DecompressedSequenceLLen[refSeqOffs], &tstData->DecompressedSequenceLLen[tstSeqOffs], refSeqCount * sizeof(refData->DecompressedSequenceLLen[0])))
-                    return kzstdgpu_Validate_Failed;
+                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
                 if (0 != memcmp(&refData->DecompressedSequenceMLen[refSeqOffs], &tstData->DecompressedSequenceMLen[tstSeqOffs], refSeqCount * sizeof(refData->DecompressedSequenceMLen[0])))
-                    return kzstdgpu_Validate_Failed;
+                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
                 if (0 != memcmp(&refData->DecompressedSequenceOffs[refSeqOffs], &tstData->DecompressedSequenceOffs[tstSeqOffs], refSeqCount * sizeof(refData->DecompressedSequenceOffs[0])))
-                    return kzstdgpu_Validate_Failed;
+                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
             }
 
             // Validate FSE tables accessed through references are the same
@@ -1259,26 +1259,26 @@ zstdgpu_Validate_Result zstdgpu_ReferenceStore_Validate_DecompressedSequences(co
                 //ZSTDGPU_ASSERT(refSeqRefs[refSeqSteamIndex].fseMLen == tstSeqRefs[tstSeqSteamIndex].fseMLen);
 
                 if (refSeqRefs->fseLLen != refData->CompressedBlocks[i].fseTableIndexLLen)
-                    return kzstdgpu_Validate_Failed;
+                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
                 if (refSeqRefs->fseOffs != refData->CompressedBlocks[i].fseTableIndexOffs)
-                    return kzstdgpu_Validate_Failed;
+                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
                 if (refSeqRefs->fseMLen != refData->CompressedBlocks[i].fseTableIndexMLen)
-                    return kzstdgpu_Validate_Failed;
+                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
 
                 if (tstSeqRefs->fseLLen != tstData->CompressedBlocks[i].fseTableIndexLLen)
-                    return kzstdgpu_Validate_Failed;
+                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
                 if (tstSeqRefs->fseOffs != tstData->CompressedBlocks[i].fseTableIndexOffs)
-                    return kzstdgpu_Validate_Failed;
+                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
                 if (tstSeqRefs->fseMLen != tstData->CompressedBlocks[i].fseTableIndexMLen)
-                    return kzstdgpu_Validate_Failed;
+                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
             }
         }
     }
-    return kzstdgpu_Validate_Success;
+    return ZSTDGPU_ENUM_CONST(Validate_Success);
 }

--- a/zstd/zstdgpu/zstdgpu_resources.h
+++ b/zstd/zstdgpu/zstdgpu_resources.h
@@ -699,6 +699,10 @@ static void zstdgpu_ResourceDataGpu_Init(zstdgpu_ResourceDataGpu *outResData, co
 
 static void zstdgpu_ResourceDataGpu_Term(zstdgpu_ResourceDataGpu *outResData, uint32_t stageIndex)
 {
+    ZSTDGPU_ASSERT(stageIndex < kzstdgpu_ResourceAllocation_StageCount);
+    if (stageIndex >= kzstdgpu_ResourceAllocation_StageCount)
+        return;
+
     // release the resources
     #define ZSTDGPU_BUFFER(type, name) D3D12AID_SAFE_RELEASE(outResData->gpuOnly.name);
         if (stageIndex == 0)
@@ -804,7 +808,7 @@ static void dealloc(void *ptr)
     MEMORY_BASIC_INFORMATION info;
     SIZE_T size = VirtualQuery(ptr, &info, sizeof(info));
     ZSTDGPU_ASSERT(0 != size);
-    VirtualFree(info.BaseAddress, info.RegionSize, MEM_DECOMMIT | MEM_RELEASE);
+    VirtualFree(info.BaseAddress, 0, MEM_RELEASE);
 #else
     return free(ptr);
 #endif

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -3481,6 +3481,40 @@ static void zstdgpu_ReadSeqBitsAndDecompress(ZSTDGPU_PARAM_INOUT(zstdgpu_Backwar
     outLLen = (llenInfo >> 5) + bitsLLen;
 }
 
+static void zstdgpu_ReadExtraBitsAndUpdateState(ZSTDGPU_PARAM_INOUT(zstdgpu_DecompressSequences_SRT) srt,
+                                                ZSTDGPU_PARAM_INOUT(zstdgpu_Backward_BitBuffer_V0) bitBuffer,
+                                                ZSTDGPU_PARAM_INOUT(uint32_t) stateLLen,
+                                                ZSTDGPU_PARAM_INOUT(uint32_t) stateOffs,
+                                                ZSTDGPU_PARAM_INOUT(uint32_t) stateMLen)
+{
+    const uint32_t restbitcntLLen = srt.inFseBitcnts[stateLLen];
+    const uint32_t restbitcntMLen = srt.inFseBitcnts[stateMLen];
+    const uint32_t restbitcntOffs = srt.inFseBitcnts[stateOffs];
+
+    #if 0
+        // NOTE(pamartis): this version of extra bits reading is left for debugging purpose in case if restbitcnt are wrong somehow
+        const uint32_t restLLen = zstdgpu_Backward_BitBuffer_V0_Get(bitBuffer, restbitcntLLen);
+        const uint32_t restMLen = zstdgpu_Backward_BitBuffer_V0_Get(bitBuffer, restbitcntMLen);
+        const uint32_t restOffs = zstdgpu_Backward_BitBuffer_V0_Get(bitBuffer, restbitcntOffs);
+    #else
+        // NOTE(pamartis): bit counts stored in FSE tables are equal to accuracy_log in worst case
+        // so it's 9 for LLen/MLen and 8 for offset, so we are not extracting more than 26 bits at once
+        uint32_t packedBits = zstdgpu_Backward_BitBuffer_V0_Get(bitBuffer, restbitcntLLen + restbitcntMLen + restbitcntOffs);
+
+        const uint32_t restOffs = packedBits & ((1u << restbitcntOffs) - 1u);
+        packedBits >>= restbitcntOffs;
+
+        const uint32_t restMLen = packedBits & ((1u << restbitcntMLen) - 1u);
+        packedBits >>= restbitcntMLen;
+
+        const uint32_t restLLen = packedBits;
+    #endif
+
+    stateLLen = srt.inFseNStates[stateLLen] + restLLen;
+    stateMLen = srt.inFseNStates[stateMLen] + restMLen;
+    stateOffs = srt.inFseNStates[stateOffs] + restOffs;
+}
+
 static void zstdgpu_ShaderEntry_DecompressSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_DecompressSequences_SRT) srt, uint32_t threadId)
 {
     const uint32_t seqStreamIdx = threadId;
@@ -3562,17 +3596,7 @@ static void zstdgpu_ShaderEntry_DecompressSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_
                 break;
             }
 
-            const uint32_t restbitcntLLen = srt.inFseBitcnts[stateLLen];
-            const uint32_t restbitcntMLen = srt.inFseBitcnts[stateMLen];
-            const uint32_t restbitcntOffs = srt.inFseBitcnts[stateOffs];
-
-            const uint32_t restLLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcntLLen);
-            const uint32_t restMLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcntMLen);
-            const uint32_t restOffs = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcntOffs);
-
-            stateLLen = srt.inFseNStates[stateLLen] + restLLen;
-            stateMLen = srt.inFseNStates[stateMLen] + restMLen;
-            stateOffs = srt.inFseNStates[stateOffs] + restOffs;
+            zstdgpu_ReadExtraBitsAndUpdateState(srt, bitBuffer, stateLLen, stateOffs, stateMLen);
         }
     }
     else
@@ -3984,17 +4008,7 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsOutCache(ZSTDGPU_PARAM_IN
 
             if (threadId < groupSeqCount && (i + 1u < seqRefDst.size))
             {
-                const uint32_t restbitcntLLen = srt.inFseBitcnts[stateLLen];
-                const uint32_t restbitcntMLen = srt.inFseBitcnts[stateMLen];
-                const uint32_t restbitcntOffs = srt.inFseBitcnts[stateOffs];
-
-                const uint32_t restLLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcntLLen);
-                const uint32_t restMLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcntMLen);
-                const uint32_t restOffs = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcntOffs);
-
-                stateLLen = srt.inFseNStates[stateLLen] + restLLen;
-                stateMLen = srt.inFseNStates[stateMLen] + restMLen;
-                stateOffs = srt.inFseNStates[stateOffs] + restOffs;
+                zstdgpu_ReadExtraBitsAndUpdateState(srt, bitBuffer, stateLLen, stateOffs, stateMLen);
             }
         }
 
@@ -4081,17 +4095,7 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsOutCache(ZSTDGPU_PARAM_IN
                     break;
                 }
 
-                const uint32_t restbitcntLLen = srt.inFseBitcnts[stateLLen];
-                const uint32_t restbitcntMLen = srt.inFseBitcnts[stateMLen];
-                const uint32_t restbitcntOffs = srt.inFseBitcnts[stateOffs];
-
-                const uint32_t restLLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcntLLen);
-                const uint32_t restMLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcntMLen);
-                const uint32_t restOffs = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcntOffs);
-
-                stateLLen = srt.inFseNStates[stateLLen] + restLLen;
-                stateMLen = srt.inFseNStates[stateMLen] + restMLen;
-                stateOffs = srt.inFseNStates[stateOffs] + restOffs;
+                zstdgpu_ReadExtraBitsAndUpdateState(srt, bitBuffer, stateLLen, stateOffs, stateMLen);
             }
         }
         else

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -3476,6 +3476,54 @@ static zstdgpu_OffsetAndSize zstdgpu_GetSequenceStartAndCount(ZSTDGPU_PARAM_INOU
     return ref;
 }
 
+static void zstdgpu_ReadSeqBitsAndDecompress(ZSTDGPU_PARAM_INOUT(zstdgpu_Backward_BitBuffer_V0) bitBuffer,
+                                             ZSTDGPU_PARAM_IN(uint32_t) symbolLLen,
+                                             ZSTDGPU_PARAM_IN(uint32_t) symbolOffs,
+                                             ZSTDGPU_PARAM_IN(uint32_t) symbolMLen,
+                                             ZSTDGPU_PARAM_INOUT(uint32_t) outLLen,
+                                             ZSTDGPU_PARAM_INOUT(uint32_t) outOffs,
+                                             ZSTDGPU_PARAM_INOUT(uint32_t) outMLen)
+{
+    // Extra bits are low 5 bits, rest are baseline.
+    // It could be better/simpler to not bitpack (use uint32_t2), but the LLVM-SROA pass in DXC might split that up; a single load is desired.
+    static const uint32_t SEQ_LITERAL_LENGTH_EXTRA_BITS_AND_BASELINES[36] =
+    {
+            0 << 5 |  0,     1 << 5 |  0,     2 << 5 |  0,     3 << 5 |  0,     4 << 5 |  0,     5 << 5 |  0,     6 << 5 |  0,     7 << 5 |  0,
+            8 << 5 |  0,     9 << 5 |  0,    10 << 5 |  0,    11 << 5 |  0,    12 << 5 |  0,    13 << 5 |  0,    14 << 5 |  0,    15 << 5 |  0,
+           16 << 5 |  1,    18 << 5 |  1,    20 << 5 |  1,    22 << 5 |  1,    24 << 5 |  2,    28 << 5 |  2,    32 << 5 |  3,    40 << 5 |  3,
+           48 << 5 |  4,    64 << 5 |  6,   128 << 5 |  7,   256 << 5 |  8,   512 << 5 |  9,  1024 << 5 | 10,  2048 << 5 | 11,  4096 << 5 | 12,
+         8192 << 5 | 13, 16384 << 5 | 14, 32768 << 5 | 15, 65536 << 5 | 16
+    };
+
+    static const uint32_t SEQ_MATCH_LENGTH_EXTRA_BITS_AND_BASELINES[53] =
+    {
+            3 << 5 |  0,     4 << 5 |  0,     5 << 5 |  0,     6 << 5 |  0,     7 << 5 |  0,     8 << 5 |  0,     9 << 5 |  0,    10 << 5 |  0,
+           11 << 5 |  0,    12 << 5 |  0,    13 << 5 |  0,    14 << 5 |  0,    15 << 5 |  0,    16 << 5 |  0,    17 << 5 |  0,    18 << 5 |  0,
+           19 << 5 |  0,    20 << 5 |  0,    21 << 5 |  0,    22 << 5 |  0,    23 << 5 |  0,    24 << 5 |  0,    25 << 5 |  0,    26 << 5 |  0,
+           27 << 5 |  0,    28 << 5 |  0,    29 << 5 |  0,    30 << 5 |  0,    31 << 5 |  0,    32 << 5 |  0,    33 << 5 |  0,    34 << 5 |  0,
+           35 << 5 |  1,    37 << 5 |  1,    39 << 5 |  1,    41 << 5 |  1,    43 << 5 |  2,    47 << 5 |  2,    51 << 5 |  3,    59 << 5 |  3,
+           67 << 5 |  4,    83 << 5 |  4,    99 << 5 |  5,   131 << 5 |  7,   259 << 5 |  8,   515 << 5 |  9,  1027 << 5 | 10,  2051 << 5 | 11,
+         4099 << 5 | 12,  8195 << 5 | 13, 16387 << 5 | 14, 32771 << 5 | 15, 65539 << 5 | 16
+    };
+
+    ZSTDGPU_ASSERT(symbolLLen < 36);
+    ZSTDGPU_ASSERT(symbolMLen < 53);
+
+    const uint32_t llenInfo = SEQ_LITERAL_LENGTH_EXTRA_BITS_AND_BASELINES[symbolLLen];
+    const uint32_t mlenInfo = SEQ_MATCH_LENGTH_EXTRA_BITS_AND_BASELINES[symbolMLen];
+    const uint32_t bitcntLLen = llenInfo & 31;
+    const uint32_t bitcntOffs = symbolOffs;
+    const uint32_t bitcntMLen = mlenInfo & 31;
+
+    const uint32_t bitsOffs = zstdgpu_Backward_BitBuffer_V0_Get(bitBuffer, bitcntOffs);
+    const uint32_t bitsMLen = zstdgpu_Backward_BitBuffer_V0_Get(bitBuffer, bitcntMLen);
+    const uint32_t bitsLLen = zstdgpu_Backward_BitBuffer_V0_Get(bitBuffer, bitcntLLen);
+
+    outOffs = (1u << symbolOffs) + bitsOffs;
+    outMLen = (mlenInfo >> 5) + bitsMLen;
+    outLLen = (llenInfo >> 5) + bitsLLen;
+}
+
 static void zstdgpu_ShaderEntry_DecompressSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_DecompressSequences_SRT) srt, uint32_t threadId)
 {
     const uint32_t seqStreamIdx = threadId;
@@ -3494,33 +3542,11 @@ static void zstdgpu_ShaderEntry_DecompressSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_
     #   error `ZSTDGPU_BACKWARD_BITBUF` must not be defined.
     #endif
 
-    zstdgpu_Backward_BitBuffer bitBuffer;
-    #define ZSTDGPU_BACKWARD_BITBUF(method) zstdgpu_Backward_BitBuffer_##method
+    zstdgpu_Backward_BitBuffer_V0 bitBuffer;
+    #define ZSTDGPU_BACKWARD_BITBUF(method) zstdgpu_Backward_BitBuffer_V0_##method
 
     //zstdgpu_Backward_CmpBitBuffer bitBuffer;
     ZSTDGPU_BACKWARD_BITBUF(InitWithSegment)(bitBuffer, srt.inCompressedData, seqRef.src);
-
-#ifndef __hlsl_dx_compiler
-
-    const uint32_t SEQ_LITERAL_LENGTH_BASELINES[36] = {
-        0,  1,  2,   3,   4,   5,    6,    7,    8,    9,     10,    11,
-        12, 13, 14,  15,  16,  18,   20,   22,   24,   28,    32,    40,
-        48, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536};
-    const uint32_t SEQ_LITERAL_LENGTH_EXTRA_BITS[36] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  1,  1,
-        1, 1, 2, 2, 3, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
-
-    const uint32_t SEQ_MATCH_LENGTH_BASELINES[53] = {
-        3,  4,   5,   6,   7,    8,    9,    10,   11,    12,    13,   14, 15, 16,
-        17, 18,  19,  20,  21,   22,   23,   24,   25,    26,    27,   28, 29, 30,
-        31, 32,  33,  34,  35,   37,   39,   41,   43,    47,    51,   59, 67, 83,
-        99, 131, 259, 515, 1027, 2051, 4099, 8195, 16387, 32771, 65539 };
-
-    const uint32_t SEQ_MATCH_LENGTH_EXTRA_BITS[53] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  1,  1,  1, 1,
-        2, 2, 3, 3, 4, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
-#endif
 
     // NOTE: the final block size will be computed as SUM(literalSize, totalMLen)
     const uint32_t literalSize = srt.inoutBlockSizePrefix[seqRef.blockId];
@@ -3560,21 +3586,8 @@ static void zstdgpu_ShaderEntry_DecompressSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_
             const uint32_t symbolOffs = srt.inFseSymbols[stateOffs];
             const uint32_t symbolMLen = srt.inFseSymbols[stateMLen];
 
-            ZSTDGPU_ASSERT(symbolLLen < 36);
-            ZSTDGPU_ASSERT(symbolMLen < 53);
-
-            const uint32_t bitcntLLen = SEQ_LITERAL_LENGTH_EXTRA_BITS[symbolLLen];
-            const uint32_t bitcntOffs = symbolOffs;
-            const uint32_t bitcntMLen = SEQ_MATCH_LENGTH_EXTRA_BITS[symbolMLen];
-
-            const uint32_t bitsOffs = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntOffs);
-            const uint32_t bitsMLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntMLen);
-            const uint32_t bitsLLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntLLen);
-
-                  uint32_t offs = (1u << symbolOffs) + bitsOffs;
-            const uint32_t mlen = SEQ_MATCH_LENGTH_BASELINES[symbolMLen] + bitsMLen;
-            const uint32_t llen = SEQ_LITERAL_LENGTH_BASELINES[symbolLLen] + bitsLLen;
-
+            uint32_t llen = 0, offs = 0, mlen = 0;
+            zstdgpu_ReadSeqBitsAndDecompress(bitBuffer, symbolLLen, symbolOffs, symbolMLen, llen, offs, mlen);
             offs = zstdgpu_SequenceOffsets_Update2(offset1, offset2, offset3, offs, llen);
 
             // TODO: output totalSize per iteration to automatically compute prefix
@@ -3638,21 +3651,8 @@ static void zstdgpu_ShaderEntry_DecompressSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_
             ZSTDGPU_LOAD_FSE_SYMBOL(MLen)
             #undef ZSTDGPU_LOAD_FSE_SYMBOL
 
-            ZSTDGPU_ASSERT(symbolLLen < 36);
-            ZSTDGPU_ASSERT(symbolMLen < 53);
-
-            const uint32_t bitcntLLen = SEQ_LITERAL_LENGTH_EXTRA_BITS[symbolLLen];
-            const uint32_t bitcntOffs = symbolOffs;
-            const uint32_t bitcntMLen = SEQ_MATCH_LENGTH_EXTRA_BITS[symbolMLen];
-
-            const uint32_t bitsOffs = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntOffs);
-            const uint32_t bitsMLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntMLen);
-            const uint32_t bitsLLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntLLen);
-
-                  uint32_t offs = (1u << symbolOffs) + bitsOffs;
-            const uint32_t mlen = SEQ_MATCH_LENGTH_BASELINES[symbolMLen] + bitsMLen;
-            const uint32_t llen = SEQ_LITERAL_LENGTH_BASELINES[symbolLLen] + bitsLLen;
-
+            uint32_t llen = 0, offs = 0, mlen = 0;
+            zstdgpu_ReadSeqBitsAndDecompress(bitBuffer, symbolLLen, symbolOffs, symbolMLen, llen, offs, mlen);
             offs = zstdgpu_SequenceOffsets_Update2(offset1, offset2, offset3, offs, llen);
 
             // TODO: output totalSize per iteration to automatically compute prefix
@@ -3718,28 +3718,7 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsFseCache(ZSTDGPU_PARAM_IN
 
     const zstdgpu_SeqStreamInfo seqRef = srt.inSeqRefs[seqStreamIdx];
 
-    // Extra bits are low 5 bits, rest are baseline.
-    // It could be better/simpler to not bitpack (use uint32_t2), but the LLVM-SROA pass in DXC might split that up; a single load is desired.
-    static const uint32_t SEQ_LITERAL_LENGTH_EXTRA_BITS_AND_BASELINES[36] =
-    {
-            0 << 5 |  0,     1 << 5 |  0,     2 << 5 |  0,     3 << 5 |  0,     4 << 5 |  0,     5 << 5 |  0,     6 << 5 |  0,     7 << 5 |  0,
-            8 << 5 |  0,     9 << 5 |  0,    10 << 5 |  0,    11 << 5 |  0,    12 << 5 |  0,    13 << 5 |  0,    14 << 5 |  0,    15 << 5 |  0,
-           16 << 5 |  1,    18 << 5 |  1,    20 << 5 |  1,    22 << 5 |  1,    24 << 5 |  2,    28 << 5 |  2,    32 << 5 |  3,    40 << 5 |  3,
-           48 << 5 |  4,    64 << 5 |  6,   128 << 5 |  7,   256 << 5 |  8,   512 << 5 |  9,  1024 << 5 | 10,  2048 << 5 | 11,  4096 << 5 | 12,
-         8192 << 5 | 13, 16384 << 5 | 14, 32768 << 5 | 15, 65536 << 5 | 16
-    };
-    static const uint32_t SEQ_MATCH_LENGTH_EXTRA_BITS_AND_BASELINES[53] =
-    {
-            3 << 5 |  0,     4 << 5 |  0,     5 << 5 |  0,     6 << 5 |  0,     7 << 5 |  0,     8 << 5 |  0,     9 << 5 |  0,    10 << 5 |  0,
-           11 << 5 |  0,    12 << 5 |  0,    13 << 5 |  0,    14 << 5 |  0,    15 << 5 |  0,    16 << 5 |  0,    17 << 5 |  0,    18 << 5 |  0,
-           19 << 5 |  0,    20 << 5 |  0,    21 << 5 |  0,    22 << 5 |  0,    23 << 5 |  0,    24 << 5 |  0,    25 << 5 |  0,    26 << 5 |  0,
-           27 << 5 |  0,    28 << 5 |  0,    29 << 5 |  0,    30 << 5 |  0,    31 << 5 |  0,    32 << 5 |  0,    33 << 5 |  0,    34 << 5 |  0,
-           35 << 5 |  1,    37 << 5 |  1,    39 << 5 |  1,    41 << 5 |  1,    43 << 5 |  2,    47 << 5 |  2,    51 << 5 |  3,    59 << 5 |  3,
-           67 << 5 |  4,    83 << 5 |  4,    99 << 5 |  5,   131 << 5 |  7,   259 << 5 |  8,   515 << 5 |  9,  1027 << 5 | 10,  2051 << 5 | 11,
-         4099 << 5 | 12,  8195 << 5 | 13, 16387 << 5 | 14, 32771 << 5 | 15, 65539 << 5 | 16
-    };
-
-    // NOTE: the final block size will be computed as SUM(literalSize, totalMLen)
+     // NOTE: the final block size will be computed as SUM(literalSize, totalMLen)
     const uint32_t literalSize = srt.inoutBlockSizePrefix[seqRef.blockId];
     // uint32_t totalSize = 0;
     uint32_t totalMLen = 0;
@@ -3833,26 +3812,11 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsFseCache(ZSTDGPU_PARAM_IN
             outNState##Offs = (packedFseElemOffs >> 16) & 0xffff;                               \
             outNState##MLen = (packedFseElemMLen >> 16) & 0xffff;                               \
                                                                                                 \
-            ZSTDGPU_ASSERT(symbolLLen < 36);                                                    \
-            ZSTDGPU_ASSERT(symbolMLen < 53);                                                    \
-                                                                                                \
-            const uint32_t literalLengthInfo = SEQ_LITERAL_LENGTH_EXTRA_BITS_AND_BASELINES[symbolLLen]; \
-            const uint32_t matchLengthInfo = SEQ_MATCH_LENGTH_EXTRA_BITS_AND_BASELINES[symbolMLen];     \
-            const uint32_t bitcntLLen = literalLengthInfo & 31;                                 \
-            const uint32_t bitcntOffs = symbolOffs;                                             \
-            const uint32_t bitcntMLen = matchLengthInfo & 31;                                   \
-                                                                                                \
-            const uint32_t bitsOffs = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntOffs);      \
-            const uint32_t bitsMLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntMLen);      \
-            const uint32_t bitsLLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntLLen);      \
-                                                                                                \
-                  uint32_t offs = (1u << symbolOffs) + bitsOffs;                                \
-            const uint32_t mlen = (matchLengthInfo >> 5) + bitsMLen;                            \
-            const uint32_t llen = (literalLengthInfo >> 5) + bitsLLen;                          \
-                                                                                                \
+            uint32_t llen = 0, offs = 0, mlen = 0;                                              \
+            zstdgpu_ReadSeqBitsAndDecompress(bitBuffer, symbolLLen, symbolOffs, symbolMLen, llen, offs, mlen);   \
             offs = zstdgpu_SequenceOffsets_Update2(offset1, offset2, offset3, offs, llen);      \
                                                                                                 \
-            /*totalSize += llen + mlen;*/                                                           \
+            /*totalSize += llen + mlen;*/                                                       \
             totalMLen += mlen;                                                                  \
                                                                                                 \
             srt.inoutDecompressedSequenceLLen[outIdx] = llen;                                   \
@@ -3963,33 +3927,11 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsOutCache(ZSTDGPU_PARAM_IN
     #   error `ZSTDGPU_BACKWARD_BITBUF` must not be defined.
     #endif
 
-    zstdgpu_Backward_BitBuffer bitBuffer;
-    #define ZSTDGPU_BACKWARD_BITBUF(method) zstdgpu_Backward_BitBuffer_##method
+    zstdgpu_Backward_BitBuffer_V0 bitBuffer;
+    #define ZSTDGPU_BACKWARD_BITBUF(method) zstdgpu_Backward_BitBuffer_V0_##method
 
     //zstdgpu_Backward_CmpBitBuffer bitBuffer;
     ZSTDGPU_BACKWARD_BITBUF(InitWithSegment)(bitBuffer, srt.inCompressedData, seqRef.src);
-
-#ifndef __hlsl_dx_compiler
-
-    const uint32_t SEQ_LITERAL_LENGTH_BASELINES[36] = {
-        0,  1,  2,   3,   4,   5,    6,    7,    8,    9,     10,    11,
-        12, 13, 14,  15,  16,  18,   20,   22,   24,   28,    32,    40,
-        48, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536};
-    const uint32_t SEQ_LITERAL_LENGTH_EXTRA_BITS[36] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  1,  1,
-        1, 1, 2, 2, 3, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
-
-    const uint32_t SEQ_MATCH_LENGTH_BASELINES[53] = {
-        3,  4,   5,   6,   7,    8,    9,    10,   11,    12,    13,   14, 15, 16,
-        17, 18,  19,  20,  21,   22,   23,   24,   25,    26,    27,   28, 29, 30,
-        31, 32,  33,  34,  35,   37,   39,   41,   43,    47,    51,   59, 67, 83,
-        99, 131, 259, 515, 1027, 2051, 4099, 8195, 16387, 32771, 65539 };
-
-    const uint32_t SEQ_MATCH_LENGTH_EXTRA_BITS[53] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  1,  1,  1, 1,
-        2, 2, 3, 3, 4, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
-#endif
 
     // NOTE: the final block size will be computed as SUM(literalSize, totalMLen)
     const uint32_t literalSize = srt.inoutBlockSizePrefix[seqRef.blockId];
@@ -4029,21 +3971,8 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsOutCache(ZSTDGPU_PARAM_IN
                 const uint32_t symbolOffs = srt.inFseSymbols[stateOffs];
                 const uint32_t symbolMLen = srt.inFseSymbols[stateMLen];
 
-                ZSTDGPU_ASSERT(symbolLLen < 36);
-                ZSTDGPU_ASSERT(symbolMLen < 53);
-
-                const uint32_t bitcntLLen = SEQ_LITERAL_LENGTH_EXTRA_BITS[symbolLLen];
-                const uint32_t bitcntOffs = symbolOffs;
-                const uint32_t bitcntMLen = SEQ_MATCH_LENGTH_EXTRA_BITS[symbolMLen];
-
-                const uint32_t bitsOffs = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntOffs);
-                const uint32_t bitsMLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntMLen);
-                const uint32_t bitsLLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntLLen);
-
-                      uint32_t offs = (1u << symbolOffs) + bitsOffs;
-                const uint32_t mlen = SEQ_MATCH_LENGTH_BASELINES[symbolMLen] + bitsMLen;
-                const uint32_t llen = SEQ_LITERAL_LENGTH_BASELINES[symbolLLen] + bitsLLen;
-
+                uint32_t llen = 0, offs = 0, mlen = 0;
+                zstdgpu_ReadSeqBitsAndDecompress(bitBuffer, symbolLLen, symbolOffs, symbolMLen, llen, offs, mlen);
                 offs = zstdgpu_SequenceOffsets_Update2(offset1, offset2, offset3, offs, llen);
 
                 const uint32_t seqLdsCurrIndex = i & (SEQ_CACHE_LEN - 1u);
@@ -4175,21 +4104,8 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsOutCache(ZSTDGPU_PARAM_IN
                 const uint32_t symbolOffs = srt.inFseSymbols[stateOffs];
                 const uint32_t symbolMLen = srt.inFseSymbols[stateMLen];
 
-                ZSTDGPU_ASSERT(symbolLLen < 36);
-                ZSTDGPU_ASSERT(symbolMLen < 53);
-
-                const uint32_t bitcntLLen = SEQ_LITERAL_LENGTH_EXTRA_BITS[symbolLLen];
-                const uint32_t bitcntOffs = symbolOffs;
-                const uint32_t bitcntMLen = SEQ_MATCH_LENGTH_EXTRA_BITS[symbolMLen];
-
-                const uint32_t bitsOffs = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntOffs);
-                const uint32_t bitsMLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntMLen);
-                const uint32_t bitsLLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntLLen);
-
-                      uint32_t offs = (1u << symbolOffs) + bitsOffs;
-                const uint32_t mlen = SEQ_MATCH_LENGTH_BASELINES[symbolMLen] + bitsMLen;
-                const uint32_t llen = SEQ_LITERAL_LENGTH_BASELINES[symbolLLen] + bitsLLen;
-
+                uint32_t llen = 0, offs = 0, mlen = 0;
+                zstdgpu_ReadSeqBitsAndDecompress(bitBuffer, symbolLLen, symbolOffs, symbolMLen, llen, offs, mlen);
                 offs = zstdgpu_SequenceOffsets_Update2(offset1, offset2, offset3, offs, llen);
 
                 // TODO: output totalSize per iteration to automatically compute prefix
@@ -4253,21 +4169,8 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsOutCache(ZSTDGPU_PARAM_IN
                 ZSTDGPU_LOAD_FSE_SYMBOL(MLen)
                 #undef ZSTDGPU_LOAD_FSE_SYMBOL
 
-                ZSTDGPU_ASSERT(symbolLLen < 36);
-                ZSTDGPU_ASSERT(symbolMLen < 53);
-
-                const uint32_t bitcntLLen = SEQ_LITERAL_LENGTH_EXTRA_BITS[symbolLLen];
-                const uint32_t bitcntOffs = symbolOffs;
-                const uint32_t bitcntMLen = SEQ_MATCH_LENGTH_EXTRA_BITS[symbolMLen];
-
-                const uint32_t bitsOffs = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntOffs);
-                const uint32_t bitsMLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntMLen);
-                const uint32_t bitsLLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, bitcntLLen);
-
-                      uint32_t offs = (1u << symbolOffs) + bitsOffs;
-                const uint32_t mlen = SEQ_MATCH_LENGTH_BASELINES[symbolMLen] + bitsMLen;
-                const uint32_t llen = SEQ_LITERAL_LENGTH_BASELINES[symbolLLen] + bitsLLen;
-
+                uint32_t llen = 0, offs = 0, mlen = 0;
+                zstdgpu_ReadSeqBitsAndDecompress(bitBuffer, symbolLLen, symbolOffs, symbolMLen, llen, offs, mlen);
                 offs = zstdgpu_SequenceOffsets_Update2(offset1, offset2, offset3, offs, llen);
 
                 // TODO: output totalSize per iteration to automatically compute prefix

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -3243,7 +3243,7 @@ static void zstdgpu_DecompressHuffmanCompressedLiterals_StoreLdsCache(ZSTDGPU_RO
             {
                 // Inverse of the store swizzle: thread i stored logical dword d at cache position ((d + i) & mask)
                 const uint32_t dwordIdxInCache = (dwordIdxToStore & ~kStoreCacheBankMask) + ((dwordIdxToStore + i) & kStoreCacheBankMask);
-                const uint32_t dword = zstdgpu_LdsLoadU32(GS_LiteralStoreCache + i * cacheDwordsPerStream + dwordIdxInCache);
+                const uint32_t dword = zstdgpu_LdsLoadU32(GS_LiteralStoreCache + ZSTDGPU_INTENDED_MUL32(i * cacheDwordsPerStream) + dwordIdxInCache);
 
                 DecompressedLiteralsAsDwords[dstDwordIdx + dwordIdxToStore] = dword;
             }

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -2785,23 +2785,6 @@ static inline void zstdgpu_DecompressHuffmanCompressedLiterals(ZSTDGPU_RO_RAW_BU
                                                                uint32_t bitsMax,
                                                                uint32_t tgSize);
 
-static inline void zstdgpu_DecompressHuffmanCompressedLiterals_StoreLdsCache(ZSTDGPU_RO_RAW_BUFFER(uint32_t) CompressedData,
-                                                                                    ZSTDGPU_RO_BUFFER(uint32_t) LitStreamRemap,
-                                                                                    ZSTDGPU_RO_BUFFER(zstdgpu_LitStreamInfo) LitRefs,
-                                                                                    ZSTDGPU_RW_TYPED_BUFFER(uint32_t, uint8_t) DecompressedLiterals,
-                                                                                    ZSTDGPU_RW_BUFFER(uint32_t) DecompressedLiteralsAsDwords,
-                                                                                    ZSTDGPU_PARAM_LDS_IN(uint32_t) GS_HuffmanTable,
-                                                                                    ZSTDGPU_PARAM_LDS_INOUT(uint32_t) GS_LiteralStoreCache,
-                                                                                    uint32_t groupId,
-                                                                                    uint32_t threadId,
-                                                                                    uint32_t htGroupStart,
-                                                                                    uint32_t htLiteralStart,
-                                                                                    uint32_t htLiteralCount,
-                                                                                    uint32_t bitsMax,
-                                                                                    uint32_t tgSize,
-                                                                                    uint32_t streamsPerGroup,
-                                                                                    uint32_t cacheDwordsPerStream);
-
 
 static void zstdgpu_ConvertThreadgroupIdToDecompressLiteralsInputs(ZSTDGPU_RO_BUFFER(uint32_t) LitGroupEndPerHuffmanTable,
                                                                    ZSTDGPU_RO_BUFFER(uint32_t) LitStreamEndPerHuffmanTable,
@@ -3079,51 +3062,47 @@ void zstdgpu_DecompressHuffmanCompressedLiterals(ZSTDGPU_RO_RAW_BUFFER(uint32_t)
         const uint32_t literalStreamId = LitStreamRemap[htLiteralStart + thisGroupLiteralStart + literalIndex];
 
         zstdgpu_LitStreamInfo compressedLiteral = LitRefs[literalStreamId];
-
-        if (compressedLiteral.dst.size != 0) // derived from block Regenerated_Size
-        {
-            uint32_t decodedByteCnt = 0;
+        uint32_t decodedByteCnt = 0;
 #if 0
-            zstdgpu_Backward_BitBuffer_V0 bitBuffer;
-            zstdgpu_Backward_BitBuffer_V0_InitWithSegment(bitBuffer, CompressedData, compressedLiteral.src);
+        zstdgpu_Backward_BitBuffer_V0 bitBuffer;
+        zstdgpu_Backward_BitBuffer_V0_InitWithSegment(bitBuffer, CompressedData, compressedLiteral.src);
 
-            uint32_t state = zstdgpu_Backward_BitBuffer_V0_Get_Huffman(bitBuffer, bitsMax, bitsMax);
-            for (;;)
+        uint32_t state = zstdgpu_Backward_BitBuffer_V0_Get_Huffman(bitBuffer, bitsMax, bitsMax);
+        for (;;)
+        {
+            uint32_t symbol = 0;
+            uint32_t bitcnt = 0;
+            zstdgpu_SampleHuffmanSymbolAndBitcnt(symbol, bitcnt, state, GS_HuffmanTable);
+
+            // FIXME/TODO(pamartis): Experiment with storing data to LDS first (we have some allocated but unused)
+            // and then to memory. At least try small LDS cache of 32-dwords per literal
+            zstdgpu_TypedStoreU8(DecompressedLiterals, compressedLiteral.dst.offs + decodedByteCnt++, symbol);
+
+            if (decodedByteCnt == compressedLiteral.dst.size)
             {
-                uint32_t symbol = 0;
-                uint32_t bitcnt = 0;
-                zstdgpu_SampleHuffmanSymbolAndBitcnt(symbol, bitcnt, state, GS_HuffmanTable);
-
-                // FIXME/TODO(pamartis): Experiment with storing data to LDS first (we have some allocated but unused)
-                // and then to memory. At least try small LDS cache of 32-dwords per literal
-                zstdgpu_TypedStoreU8(DecompressedLiterals, compressedLiteral.dst.offs + decodedByteCnt++, symbol);
-
-                if (decodedByteCnt == compressedLiteral.dst.size)
-                {
-                    break;
-                }
-
-                const uint32_t rest = zstdgpu_Backward_BitBuffer_V0_Get_Huffman(bitBuffer, bitcnt, bitsMax);
-                state = ((state << bitcnt) + rest) & maxBitcntMask;
+                break;
             }
-#else
-            zstdgpu_HuffmanStream stream;
-            zstdgpu_HuffmanStream_InitWithSegment(stream, CompressedData, compressedLiteral.src, bitsMax);
-            do
-            {
-                const uint32_t state = zstdgpu_HuffmanStream_RefillAndPeek(stream);
-                uint32_t symbol = 0;
-                uint32_t bitcnt = 0;
-                zstdgpu_SampleHuffmanSymbolAndBitcnt(symbol, bitcnt, state, GS_HuffmanTable);
 
-                // FIXME/TODO(pamartis): Experiment with storing data to LDS first (we have some allocated but unused)
-                // and then to memory. At least try small LDS cache of 32-dwords per literal
-                zstdgpu_TypedStoreU8(DecompressedLiterals, compressedLiteral.dst.offs + decodedByteCnt++, symbol);
-                // It could make sense to mid-break on (decodedByteCnt == compressedLiteral.dst.size) instead.
-                zstdgpu_HuffmanStream_Consume(stream, bitcnt);
-            } while (decodedByteCnt < compressedLiteral.dst.size);
-#endif
+            const uint32_t rest = zstdgpu_Backward_BitBuffer_V0_Get_Huffman(bitBuffer, bitcnt, bitsMax);
+            state = ((state << bitcnt) + rest) & maxBitcntMask;
         }
+#else
+        zstdgpu_HuffmanStream stream;
+        zstdgpu_HuffmanStream_InitWithSegment(stream, CompressedData, compressedLiteral.src, bitsMax);
+        do
+        {
+            const uint32_t state = zstdgpu_HuffmanStream_RefillAndPeek(stream);
+            uint32_t symbol = 0;
+            uint32_t bitcnt = 0;
+            zstdgpu_SampleHuffmanSymbolAndBitcnt(symbol, bitcnt, state, GS_HuffmanTable);
+
+            // FIXME/TODO(pamartis): Experiment with storing data to LDS first (we have some allocated but unused)
+            // and then to memory. At least try small LDS cache of 32-dwords per literal
+            zstdgpu_TypedStoreU8(DecompressedLiterals, compressedLiteral.dst.offs + decodedByteCnt++, symbol);
+            // It could make sense to mid-break on (decodedByteCnt == compressedLiteral.dst.size) instead.
+            zstdgpu_HuffmanStream_Consume(stream, bitcnt);
+        } while (decodedByteCnt < compressedLiteral.dst.size);
+#endif
     }
 }
 
@@ -3299,28 +3278,6 @@ static void zstdgpu_DecompressHuffmanCompressedLiterals_StoreLdsCache(ZSTDGPU_RO
         }
     }
 }
-
-#ifdef __hlsl_dx_compiler
-
-static const uint32_t SEQ_LITERAL_LENGTH_BASELINES[36] = {
-    0,  1,  2,   3,   4,   5,    6,    7,    8,    9,     10,    11,
-    12, 13, 14,  15,  16,  18,   20,   22,   24,   28,    32,    40,
-    48, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536};
-static const uint32_t SEQ_LITERAL_LENGTH_EXTRA_BITS[36] = {
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  1,  1,
-    1, 1, 2, 2, 3, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
-
-static const uint32_t SEQ_MATCH_LENGTH_BASELINES[53] = {
-    3,  4,   5,   6,   7,    8,    9,    10,   11,    12,    13,   14, 15, 16,
-    17, 18,  19,  20,  21,   22,   23,   24,   25,    26,    27,   28, 29, 30,
-    31, 32,  33,  34,  35,   37,   39,   41,   43,    47,    51,   59, 67, 83,
-    99, 131, 259, 515, 1027, 2051, 4099, 8195, 16387, 32771, 65539 };
-
-static const uint32_t SEQ_MATCH_LENGTH_EXTRA_BITS[53] = {
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  1,  1,  1, 1,
-    2, 2, 3, 3, 4, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
-#endif
 
 static void zstdgpu_SequenceOffsets_Init(ZSTDGPU_PARAM_INOUT(uint32_t) offset1,
                                          ZSTDGPU_PARAM_INOUT(uint32_t) offset2,
@@ -3582,12 +3539,14 @@ static void zstdgpu_ShaderEntry_DecompressSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_
             stateOffs += startOffs;
             stateMLen += startMLen;
 
-            const uint32_t symbolLLen = srt.inFseSymbols[stateLLen];
-            const uint32_t symbolOffs = srt.inFseSymbols[stateOffs];
-            const uint32_t symbolMLen = srt.inFseSymbols[stateMLen];
-
             uint32_t llen = 0, offs = 0, mlen = 0;
-            zstdgpu_ReadSeqBitsAndDecompress(bitBuffer, symbolLLen, symbolOffs, symbolMLen, llen, offs, mlen);
+            zstdgpu_ReadSeqBitsAndDecompress(
+                bitBuffer,
+                srt.inFseSymbols[stateLLen],
+                srt.inFseSymbols[stateOffs],
+                srt.inFseSymbols[stateMLen],
+                llen, offs, mlen
+            );
             offs = zstdgpu_SequenceOffsets_Update2(offset1, offset2, offset3, offs, llen);
 
             // TODO: output totalSize per iteration to automatically compute prefix
@@ -3771,96 +3730,93 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsFseCache(ZSTDGPU_PARAM_IN
         return;
     }
 
-    if (dst.size != 0)
-    {
         #ifdef ZSTDGPU_BACKWARD_BITBUF
         #   error `ZSTDGPU_BACKWARD_BITBUF` must not be defined.
         #endif
 
-        zstdgpu_Backward_BitBuffer_V0 bitBuffer;
-        #define ZSTDGPU_BACKWARD_BITBUF(method) zstdgpu_Backward_BitBuffer_V0_##method
-        ZSTDGPU_BACKWARD_BITBUF(InitWithSegment)(bitBuffer, srt.inCompressedData, seqRef.src);
+    zstdgpu_Backward_BitBuffer_V0 bitBuffer;
+    #define ZSTDGPU_BACKWARD_BITBUF(method) zstdgpu_Backward_BitBuffer_V0_##method
+    ZSTDGPU_BACKWARD_BITBUF(InitWithSegment)(bitBuffer, srt.inCompressedData, seqRef.src);
 
-        #define ZSTDGPU_INIT_FSE_STATE(name)                                                                    \
-            uint32_t state##name = 0;                                                                           \
-            if (seqRef.fse##name < kzstdgpu_FseProbTableIndex_MinRLE)                                           \
-            {                                                                                                   \
-                const uint32_t initBitcnt = srt.inFseInfos[seqRef.fse##name].fseProbCountAndAccuracyLog2 >> 8;  \
-                state##name = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, initBitcnt);                              \
-            }
-
-        ZSTDGPU_INIT_FSE_STATE(LLen)
-        ZSTDGPU_INIT_FSE_STATE(Offs)
-        ZSTDGPU_INIT_FSE_STATE(MLen)
-        #undef ZSTDGPU_INIT_FSE_STATE
-
-        #define ZSTGPU_DECODE_SEQ(outIdx, outNState, outRestBitcnt)                             \
-        {                                                                                       \
-            const uint32_t packedFseElemLLen = WaveReadLaneFirst(zstdgpu_LdsLoadU32(GS_FsePackedLLen + stateLLen));\
-            const uint32_t packedFseElemOffs = WaveReadLaneFirst(zstdgpu_LdsLoadU32(GS_FsePackedOffs + stateOffs));\
-            const uint32_t packedFseElemMLen = WaveReadLaneFirst(zstdgpu_LdsLoadU32(GS_FsePackedMLen + stateMLen));\
-                                                                                                \
-            const uint32_t symbolLLen = packedFseElemLLen & 0xff;                               \
-            const uint32_t symbolOffs = packedFseElemOffs & 0xff;                               \
-            const uint32_t symbolMLen = packedFseElemMLen & 0xff;                               \
-                                                                                                \
-            outRestBitcnt##LLen = (packedFseElemLLen >> 8) & 0xff;                              \
-            outRestBitcnt##Offs = (packedFseElemOffs >> 8) & 0xff;                              \
-            outRestBitcnt##MLen = (packedFseElemMLen >> 8) & 0xff;                              \
-                                                                                                \
-            outNState##LLen = (packedFseElemLLen >> 16) & 0xffff;                               \
-            outNState##Offs = (packedFseElemOffs >> 16) & 0xffff;                               \
-            outNState##MLen = (packedFseElemMLen >> 16) & 0xffff;                               \
-                                                                                                \
-            uint32_t llen = 0, offs = 0, mlen = 0;                                              \
-            zstdgpu_ReadSeqBitsAndDecompress(bitBuffer, symbolLLen, symbolOffs, symbolMLen, llen, offs, mlen);   \
-            offs = zstdgpu_SequenceOffsets_Update2(offset1, offset2, offset3, offs, llen);      \
-                                                                                                \
-            /*totalSize += llen + mlen;*/                                                       \
-            totalMLen += mlen;                                                                  \
-                                                                                                \
-            srt.inoutDecompressedSequenceLLen[outIdx] = llen;                                   \
-            srt.inoutDecompressedSequenceMLen[outIdx] = mlen;                                   \
-            srt.inoutDecompressedSequenceOffs[outIdx] = offs;                                   \
+    #define ZSTDGPU_INIT_FSE_STATE(name)                                                                    \
+        uint32_t state##name = 0;                                                                           \
+        if (seqRef.fse##name < kzstdgpu_FseProbTableIndex_MinRLE)                                           \
+        {                                                                                                   \
+            const uint32_t initBitcnt = srt.inFseInfos[seqRef.fse##name].fseProbCountAndAccuracyLog2 >> 8;  \
+            state##name = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, initBitcnt);                              \
         }
 
-              uint32_t i         = dst.offs;
-        const uint32_t outputEnd = dst.offs + dst.size;
-        for (;;)
-        {
-            uint32_t restbitcntLLen, restbitcntOffs, restbitcntMLen;
-            uint32_t nstateLLen, nstateOffs, nstateMLen;
-            ZSTGPU_DECODE_SEQ(i, nstate, restbitcnt)
-            if (++i == outputEnd)
-            {
-                break;
-            }
+    ZSTDGPU_INIT_FSE_STATE(LLen)
+    ZSTDGPU_INIT_FSE_STATE(Offs)
+    ZSTDGPU_INIT_FSE_STATE(MLen)
+    #undef ZSTDGPU_INIT_FSE_STATE
 
-            #if 0
-            const uint32_t restLLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcntLLen);
-            const uint32_t restMLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcntMLen);
-            const uint32_t restOffs = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcntOffs);
-            #else
-            // NOTE(pamartis): bit counts stored in FSE tables are equal to accuracy_log in worst case
-            // so it's 9 for LLen/MLen and 8 for offset, so we are not extracting more than 26 bits at once
-            uint32_t packedBits = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcntLLen + restbitcntMLen + restbitcntOffs);
-
-            const uint32_t restOffs = packedBits & ((1u << restbitcntOffs) - 1u);
-            packedBits >>= restbitcntOffs;
-
-            const uint32_t restMLen = packedBits & ((1u << restbitcntMLen) - 1u);
-            packedBits >>= restbitcntMLen;
-
-            const uint32_t restLLen = packedBits;
-            #endif
-
-            stateLLen = nstateLLen + restLLen;
-            stateMLen = nstateMLen + restMLen;
-            stateOffs = nstateOffs + restOffs;
-        }
-        ZSTDGPU_ASSERT(bitBuffer.hadlastrefill && bitBuffer.bitcnt == 0);
-        #undef ZSTDGPU_BACKWARD_BITBUF
+    #define ZSTGPU_DECODE_SEQ(outIdx, outNState, outRestBitcnt)                             \
+    {                                                                                       \
+        const uint32_t packedFseElemLLen = WaveReadLaneFirst(zstdgpu_LdsLoadU32(GS_FsePackedLLen + stateLLen));\
+        const uint32_t packedFseElemOffs = WaveReadLaneFirst(zstdgpu_LdsLoadU32(GS_FsePackedOffs + stateOffs));\
+        const uint32_t packedFseElemMLen = WaveReadLaneFirst(zstdgpu_LdsLoadU32(GS_FsePackedMLen + stateMLen));\
+                                                                                            \
+        const uint32_t symbolLLen = packedFseElemLLen & 0xff;                               \
+        const uint32_t symbolOffs = packedFseElemOffs & 0xff;                               \
+        const uint32_t symbolMLen = packedFseElemMLen & 0xff;                               \
+                                                                                            \
+        outRestBitcnt##LLen = (packedFseElemLLen >> 8) & 0xff;                              \
+        outRestBitcnt##Offs = (packedFseElemOffs >> 8) & 0xff;                              \
+        outRestBitcnt##MLen = (packedFseElemMLen >> 8) & 0xff;                              \
+                                                                                            \
+        outNState##LLen = (packedFseElemLLen >> 16) & 0xffff;                               \
+        outNState##Offs = (packedFseElemOffs >> 16) & 0xffff;                               \
+        outNState##MLen = (packedFseElemMLen >> 16) & 0xffff;                               \
+                                                                                            \
+        uint32_t llen = 0, offs = 0, mlen = 0;                                              \
+        zstdgpu_ReadSeqBitsAndDecompress(bitBuffer, symbolLLen, symbolOffs, symbolMLen, llen, offs, mlen);   \
+        offs = zstdgpu_SequenceOffsets_Update2(offset1, offset2, offset3, offs, llen);      \
+                                                                                            \
+        /*totalSize += llen + mlen;*/                                                       \
+        totalMLen += mlen;                                                                  \
+                                                                                            \
+        srt.inoutDecompressedSequenceLLen[outIdx] = llen;                                   \
+        srt.inoutDecompressedSequenceMLen[outIdx] = mlen;                                   \
+        srt.inoutDecompressedSequenceOffs[outIdx] = offs;                                   \
     }
+
+        uint32_t i         = dst.offs;
+    const uint32_t outputEnd = dst.offs + dst.size;
+    for (;;)
+    {
+        uint32_t restbitcntLLen, restbitcntOffs, restbitcntMLen;
+        uint32_t nstateLLen, nstateOffs, nstateMLen;
+        ZSTGPU_DECODE_SEQ(i, nstate, restbitcnt)
+        if (++i == outputEnd)
+        {
+            break;
+        }
+
+        #if 0
+        const uint32_t restLLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcntLLen);
+        const uint32_t restMLen = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcntMLen);
+        const uint32_t restOffs = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcntOffs);
+        #else
+        // NOTE(pamartis): bit counts stored in FSE tables are equal to accuracy_log in worst case
+        // so it's 9 for LLen/MLen and 8 for offset, so we are not extracting more than 26 bits at once
+        uint32_t packedBits = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcntLLen + restbitcntMLen + restbitcntOffs);
+
+        const uint32_t restOffs = packedBits & ((1u << restbitcntOffs) - 1u);
+        packedBits >>= restbitcntOffs;
+
+        const uint32_t restMLen = packedBits & ((1u << restbitcntMLen) - 1u);
+        packedBits >>= restbitcntMLen;
+
+        const uint32_t restLLen = packedBits;
+        #endif
+
+        stateLLen = nstateLLen + restLLen;
+        stateMLen = nstateMLen + restMLen;
+        stateOffs = nstateOffs + restOffs;
+    }
+    ZSTDGPU_ASSERT(bitBuffer.hadlastrefill && bitBuffer.bitcnt == 0);
+    #undef ZSTDGPU_BACKWARD_BITBUF
 
     // NOTE(pamartis): update block size adding `totalMLen` bytes on top
     srt.inoutBlockSizePrefix[seqRef.blockId] = totalMLen + literalSize;
@@ -3967,12 +3923,14 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsOutCache(ZSTDGPU_PARAM_IN
                 stateOffs += startOffs;
                 stateMLen += startMLen;
 
-                const uint32_t symbolLLen = srt.inFseSymbols[stateLLen];
-                const uint32_t symbolOffs = srt.inFseSymbols[stateOffs];
-                const uint32_t symbolMLen = srt.inFseSymbols[stateMLen];
-
                 uint32_t llen = 0, offs = 0, mlen = 0;
-                zstdgpu_ReadSeqBitsAndDecompress(bitBuffer, symbolLLen, symbolOffs, symbolMLen, llen, offs, mlen);
+                zstdgpu_ReadSeqBitsAndDecompress(
+                    bitBuffer,
+                    srt.inFseSymbols[stateLLen],
+                    srt.inFseSymbols[stateOffs],
+                    srt.inFseSymbols[stateMLen],
+                    llen, offs, mlen
+                );
                 offs = zstdgpu_SequenceOffsets_Update2(offset1, offset2, offset3, offs, llen);
 
                 const uint32_t seqLdsCurrIndex = i & (SEQ_CACHE_LEN - 1u);
@@ -4100,12 +4058,14 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsOutCache(ZSTDGPU_PARAM_IN
                 stateOffs += startOffs;
                 stateMLen += startMLen;
 
-                const uint32_t symbolLLen = srt.inFseSymbols[stateLLen];
-                const uint32_t symbolOffs = srt.inFseSymbols[stateOffs];
-                const uint32_t symbolMLen = srt.inFseSymbols[stateMLen];
-
                 uint32_t llen = 0, offs = 0, mlen = 0;
-                zstdgpu_ReadSeqBitsAndDecompress(bitBuffer, symbolLLen, symbolOffs, symbolMLen, llen, offs, mlen);
+                zstdgpu_ReadSeqBitsAndDecompress(
+                    bitBuffer,
+                    srt.inFseSymbols[stateLLen],
+                    srt.inFseSymbols[stateOffs],
+                    srt.inFseSymbols[stateMLen],
+                    llen, offs, mlen
+                );
                 offs = zstdgpu_SequenceOffsets_Update2(offset1, offset2, offset3, offs, llen);
 
                 // TODO: output totalSize per iteration to automatically compute prefix

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -113,6 +113,22 @@
 #   endif
 #endif /* ZSTDGPU_ENUM */
 
+#ifndef ZSTDGPU_INTENDED_SHIFT
+#   ifdef _MSC_VER
+#       define ZSTDGPU_INTENDED_SHIFT(e) ZSTDGPU_WARN_DISABLE_MSVC(26450, (e))
+#   else
+#       define ZSTDGPU_INTENDED_SHIFT(e) (e)
+#   endif
+#endif /* ZSTDGPU_INTENDED_SHIFT */
+
+#ifndef ZSTDGPU_INTENDED_MUL32
+#   ifdef _MSC_VER
+#       define ZSTDGPU_INTENDED_MUL32(e) ZSTDGPU_WARN_DISABLE_MSVC(26451, (e))
+#   else
+#       define ZSTDGPU_INTENDED_MUL32(e) (e)
+#   endif
+#endif /* ZSTDGPU_INTENDED_MUL32 */
+
 #ifndef ZSTDGPU_RO_BUFFER
 #   ifdef __hlsl_dx_compiler
 #       define ZSTDGPU_RO_BUFFER(type) StructuredBuffer<type>
@@ -501,7 +517,8 @@ static inline uint64_t zstdgpu_LoBitFieldWideMaskU64(uint32_t width)
 static inline uint32_t zstdgpu_HiBitFieldMaskU32(uint32_t width)
 {
     ZSTDGPU_ASSERT(width <= 31u);
-    return (~0u << 1u) << (31u - width);
+    /**NOTE(pamartis): disable the warning because the overflow here is intended behaviour */
+    return ZSTDGPU_INTENDED_SHIFT(~0u << 1u) << (31u - width);
 }
 
 static inline uint64_t zstdgpu_HiBitFieldMaskU64(uint32_t width)

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -47,6 +47,38 @@
 #   endif
 #endif
 
+#ifndef ZSTDGPU_PRAGMA_GNUC
+#   if defined(__clang__) || defined(__GNUC__)  || defined(__hlsl_dx_compiler)
+#       define ZSTDGPU_PRAGMA_GNUC(x) _Pragma(#x)
+#   else
+#       define ZSTDGPU_PRAGMA_GNUC(x)
+#   endif
+#endif /* ZSTDGPU_PRAGMA_GNUC */
+
+#ifndef ZSTDGPU_WARN_PUSH_DXC
+#   ifdef __hlsl_dx_compiler
+#      define ZSTDGPU_WARN_PUSH_DXC()  ZSTDGPU_PRAGMA_GNUC(dxc diagnostic push)
+#      define ZSTDGPU_WARN_STOP_DXC(w) ZSTDGPU_PRAGMA_GNUC(dxc diagnostic ignored #w)
+#      define ZSTDGPU_WARN_POP_DXC()   ZSTDGPU_PRAGMA_GNUC(dxc diagnostic pop)
+#   else
+#      define ZSTDGPU_WARN_PUSH_DXC()
+#      define ZSTDGPU_WARN_STOP_DXC(w)
+#      define ZSTDGPU_WARN_POP_DXC()
+#   endif
+#endif /* ZSTDGPU_WARN_PUSH_DXC */
+
+#ifndef ZSTDGPU_WARN_DISABLE_DXC
+#   define ZSTDGPU_WARN_DISABLE_DXC(w, statement) ZSTDGPU_WARN_PUSH_DXC() ZSTDGPU_WARN_STOP_DXC(w) statement ZSTDGPU_WARN_POP_DXC()
+#endif /* ZSTDGPU_WARN_DISABLE_DXC */
+
+#ifndef ZSTDGPU_GLC
+#   ifdef __hlsl_dx_compiler
+#       define ZSTDGPU_GLC ZSTDGPU_WARN_DISABLE_DXC(-Wignored-attributes, globallycoherent)
+#   else
+#       define ZSTDGPU_GLC
+#   endif
+#endif /* ZSTDGPU_GLC */
+
 #ifndef ZSTDGPU_RO_BUFFER
 #   ifdef __hlsl_dx_compiler
 #       define ZSTDGPU_RO_BUFFER(type) StructuredBuffer<type>
@@ -65,7 +97,7 @@
 
 #ifndef ZSTDGPU_RW_BUFFER_GLC
 #   ifdef __hlsl_dx_compiler
-#       define ZSTDGPU_RW_BUFFER_GLC(type) globallycoherent RWStructuredBuffer<type>
+#       define ZSTDGPU_RW_BUFFER_GLC(type) ZSTDGPU_GLC RWStructuredBuffer<type>
 #   else
 #       define ZSTDGPU_RW_BUFFER_GLC(type) type *
 #   endif
@@ -89,7 +121,7 @@
 
 #ifndef ZSTDGPU_RW_TYPED_BUFFER_GLC
 #   ifdef __hlsl_dx_compiler
-#       define ZSTDGPU_RW_TYPED_BUFFER_GLC(ShaderType, StorageType) globallycoherent RWBuffer<ShaderType>
+#       define ZSTDGPU_RW_TYPED_BUFFER_GLC(ShaderType, StorageType) ZSTDGPU_GLC RWBuffer<ShaderType>
 #   else
 #       define ZSTDGPU_RW_TYPED_BUFFER_GLC(ShaderType, StorageType) StorageType *
 #   endif
@@ -336,13 +368,10 @@ static const uint32_t kzstdgpu_TgSizeX_ExecuteSequences = 32;
 #define ZSTDGPU_TG_MULTIPLE(elemCount, tgSize) (((elemCount) + (tgSize) - 1) & ~(tgSize - 1))
 
 #ifdef __hlsl_dx_compiler
-#   define ZSTDGPU_FOR_WORK_ITEMS(workItemId, workItemCount, groupThreadId, groupThreadCount)                  \
-        _Pragma("dxc diagnostic push")                                                                          \
-        _Pragma("dxc diagnostic ignored \"-Wfor-redefinition\"")                                                \
-        for (uint32_t workItemId = groupThreadId; workItemId < workItemCount; workItemId += groupThreadCount)   \
-        _Pragma("dxc diagnostic pop")
+#   define ZSTDGPU_FOR_WORK_ITEMS(workItemId, workItemCount, groupThreadId, groupThreadCount)   \
+        for (ZSTDGPU_WARN_DISABLE_DXC(-Wfor-redefinition, uint32_t workItemId = groupThreadId); workItemId < workItemCount; workItemId += groupThreadCount)
 #else
-#   define ZSTDGPU_FOR_WORK_ITEMS(workItemId, workItemCount, groupThreadId, groupThreadCount)                  \
+#   define ZSTDGPU_FOR_WORK_ITEMS(workItemId, workItemCount, groupThreadId, groupThreadCount)   \
         for (uint32_t workItemId = 0; workItemId < workItemCount; workItemId += 1u)
 #endif
 
@@ -1648,14 +1677,7 @@ typedef struct zstdgpu_InitResources_SRT
 
 typedef struct zstdgpu_ParseCompressedBlocks_SRT
 {
-#ifdef __hlsl_dx_compiler
-    #pragma dxc diagnostic push
-    #pragma dxc diagnostic ignored "-Wignored-attributes"
-#endif
     ZSTDGPU_PARSE_COMPRESSED_BLOCKS_SRT()
-#ifdef __hlsl_dx_compiler
-    #pragma dxc diagnostic pop
-#endif
     uint32_t    compressedBlockCount;
     uint32_t    compressedBufferSizeInBytes;
     uint32_t    frameCount;

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -103,7 +103,7 @@
 #   endif
 #endif /* ZSTDGPU_GLC */
 
-#ifndef ZSTDGPU_UNSCOPED_ENUM
+#ifndef ZSTDGPU_ENUM
 #   ifdef _MSC_VER
 #       define ZSTDGPU_ENUM(e)          ZSTDGPU_WARN_DISABLE_MSVC(26812, zstdgpu_##e)
 #       define ZSTDGPU_ENUM_CONST(ec)   ZSTDGPU_WARN_DISABLE_MSVC(26812, kzstdgpu_##ec)

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -55,6 +55,14 @@
 #   endif
 #endif /* ZSTDGPU_PRAGMA_GNUC */
 
+#ifndef ZSTDGPU_PRAGMA_MSVC
+#   if defined(_MSC_VER)
+#       define ZSTDGPU_PRAGMA_MSVC(x) __pragma(x)
+#   else
+#define ZSTDGPU_PRAGMA_MSVC(x)
+#   endif
+#endif /* ZSTDGPU_PRAGMA_MSVC */
+
 #ifndef ZSTDGPU_WARN_PUSH_DXC
 #   ifdef __hlsl_dx_compiler
 #      define ZSTDGPU_WARN_PUSH_DXC()  ZSTDGPU_PRAGMA_GNUC(dxc diagnostic push)
@@ -71,6 +79,22 @@
 #   define ZSTDGPU_WARN_DISABLE_DXC(w, statement) ZSTDGPU_WARN_PUSH_DXC() ZSTDGPU_WARN_STOP_DXC(w) statement ZSTDGPU_WARN_POP_DXC()
 #endif /* ZSTDGPU_WARN_DISABLE_DXC */
 
+#ifndef ZSTDGPU_WARN_PUSH_MSVC
+#   ifdef _MSC_VER
+#      define ZSTDGPU_WARN_PUSH_MSVC()  ZSTDGPU_PRAGMA_MSVC(warning(push))
+#      define ZSTDGPU_WARN_STOP_MSVC(w) ZSTDGPU_PRAGMA_MSVC(warning(disable : w))
+#      define ZSTDGPU_WARN_POP_MSVC()   ZSTDGPU_PRAGMA_MSVC(warning(pop))
+#   else
+#      define ZSTDGPU_WARN_PUSH_MSVC()
+#      define ZSTDGPU_WARN_STOP_MSVC(w)
+#      define ZSTDGPU_WARN_POP_MSVC()
+#   endif
+#endif /* ZSTDGPU_WARN_PUSH_MSVC */
+
+#ifndef ZSTDGPU_WARN_DISABLE_MSVC
+#   define ZSTDGPU_WARN_DISABLE_MSVC(w, statement) ZSTDGPU_WARN_PUSH_MSVC() ZSTDGPU_WARN_STOP_MSVC(w) statement ZSTDGPU_WARN_POP_MSVC()
+#endif /* ZSTDGPU_WARN_DISABLE_MSVC */
+
 #ifndef ZSTDGPU_GLC
 #   ifdef __hlsl_dx_compiler
 #       define ZSTDGPU_GLC ZSTDGPU_WARN_DISABLE_DXC(-Wignored-attributes, globallycoherent)
@@ -78,6 +102,16 @@
 #       define ZSTDGPU_GLC
 #   endif
 #endif /* ZSTDGPU_GLC */
+
+#ifndef ZSTDGPU_UNSCOPED_ENUM
+#   ifdef _MSC_VER
+#       define ZSTDGPU_ENUM(e)          ZSTDGPU_WARN_DISABLE_MSVC(26812, zstdgpu_##e)
+#       define ZSTDGPU_ENUM_CONST(ec)   ZSTDGPU_WARN_DISABLE_MSVC(26812, kzstdgpu_##ec)
+#   else
+#       define ZSTDGPU_ENUM(e)          zstdgpu_##e
+#       define ZSTDGPU_ENUM_CONST(ec)   kzstdgpu_##ec
+#   endif
+#endif /* ZSTDGPU_ENUM */
 
 #ifndef ZSTDGPU_RO_BUFFER
 #   ifdef __hlsl_dx_compiler

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -91,15 +91,22 @@ static void loadFileAligned(void **outData, uint32_t *outDataSize, uint32_t *out
         fseek(file, 0, SEEK_END);
         dataSize = ftell(file);
         fseek(file, 0, SEEK_SET);
-        bufferSize = (dataSize + alignmentMask) & ~alignmentMask;
-        data = malloc(bufferSize);
-        size_t readSize = fread(data, 1, dataSize, file);
-        ZSTDGPU_ASSERT(readSize == dataSize);
-        fclose(file);
-        if (bufferSize > dataSize)
+        if (-1 != dataSize)
         {
-            memset((char *)data + dataSize, 0, bufferSize - dataSize);
+            bufferSize = (dataSize + alignmentMask) & ~alignmentMask;
+            data = malloc(bufferSize);
+            ZSTDGPU_ASSERT(NULL != data);
+            if (NULL != data)
+            {
+                size_t readSize = fread(data, 1, dataSize, file);
+                ZSTDGPU_ASSERT(readSize == dataSize);
+                if(bufferSize > dataSize)
+                {
+                    memset((char*)data + dataSize, 0, bufferSize - dataSize);
+                }
+            }
         }
+        fclose(file);
     }
     *outData = data;
     *outDataSize = (uint32_t)dataSize;

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -225,7 +225,7 @@ static void zstdgpu_Init_FinaliseSequenceOffsets_SRT(zstdgpu_FinaliseSequenceOff
 #define STRINGIZE(x) STRINGIZE2(x)
 #define STRINGIZE2(x) #x
 #define VALIDATE(name) \
-    if (kzstdgpu_Validate_Success != zstdgpu_ReferenceStore_Validate_##name) \
+    if (ZSTDGPU_ENUM_CONST(Validate_Success) != zstdgpu_ReferenceStore_Validate_##name) \
         debugPrint(L"Validation of "#name" failed in function: " __FUNCTION__ ", file: " __FILE__ ", line: " STRINGIZE(__LINE__) "\n")
 
 static void zstdgpu_Test_DecompressHuffmanWeights(zstdgpu_ResourceDataCpu & cpuRes, zstdgpu_ResourceDataCpu & gpuReadbackRes, uint32_t zstdDataBufferSize, bool chkGpu, bool simGpu)
@@ -1044,16 +1044,16 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
     zstdgpu_PersistentContext persistentContext = NULL;
     {
         const uint32_t persistentMemorySize = zstdgpu_GetPersistentContextRequiredMemorySizeInBytes();
-        zstdgpu_Status status = zstdgpu_CreatePersistentContext(&persistentContext, device, malloc(persistentMemorySize), persistentMemorySize);
-        ZSTDGPU_ASSERT(kzstdgpu_StatusSuccess == status);
+        ZSTDGPU_ENUM(Status) status = zstdgpu_CreatePersistentContext(&persistentContext, device, malloc(persistentMemorySize), persistentMemorySize);
+        ZSTDGPU_ASSERT(ZSTDGPU_ENUM_CONST(StatusSuccess) == status);
     }
 
     debugPrint(L"Initializing 'zstdgpu' PerRequest Context.\n");
     zstdgpu_PerRequestContext perRequestContext = NULL;
     {
         const uint32_t perRequestMemorySize = zstdgpu_GetPerRequestContextRequiredMemorySizeInBytes();
-        zstdgpu_Status status = zstdgpu_CreatePerRequestContext(&perRequestContext, persistentContext, malloc(perRequestMemorySize), perRequestMemorySize);
-        ZSTDGPU_ASSERT(kzstdgpu_StatusSuccess == status);
+        ZSTDGPU_ENUM(Status) status = zstdgpu_CreatePerRequestContext(&perRequestContext, persistentContext, malloc(perRequestMemorySize), perRequestMemorySize);
+        ZSTDGPU_ASSERT(ZSTDGPU_ENUM_CONST(StatusSuccess) == status);
     }
 
     uint32_t stageCount = 0;
@@ -1387,15 +1387,15 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
     d3d12aid_CmdQueue_CpuWaitForGpuIdle(&cmdQueue);
     {
         void *memory = NULL;
-        zstdgpu_Status status = zstdgpu_DestroyPerRequestContext(&memory, NULL, perRequestContext);
-        ZSTDGPU_ASSERT(kzstdgpu_StatusSuccess == status);
+        ZSTDGPU_ENUM(Status) status = zstdgpu_DestroyPerRequestContext(&memory, NULL, perRequestContext);
+        ZSTDGPU_ASSERT(ZSTDGPU_ENUM_CONST(StatusSuccess) == status);
         free(memory);
     }
 
     {
         void *memory = NULL;
-        zstdgpu_Status status = zstdgpu_DestroyPersistentContext(&memory, NULL, persistentContext);
-        ZSTDGPU_ASSERT(kzstdgpu_StatusSuccess == status);
+        ZSTDGPU_ENUM(Status) status = zstdgpu_DestroyPersistentContext(&memory, NULL, persistentContext);
+        ZSTDGPU_ASSERT(ZSTDGPU_ENUM_CONST(StatusSuccess) == status);
         free(memory);
     }
 


### PR DESCRIPTION
This PR mainly brings maintenance changes to fix code analysis warnings where they should be fixes and suppresses warnings where they are redundant. Additionally, it pulls some some of shared code from sequence decoding into new functions, such as `zstdgpu_ReadSeqBitsAndDecompress` and `zstdgpu_ReadExtraBitsAndUpdateState`