### PR TITLE
Unifies RLE/non-RLE FSE tables by storing RLE FSE table in a compact form -- 1 entry per table at the beginning of FSE buffer. This helps to reduce code divergence.

### DIFF
--- a/zstd/zstdgpu/Shaders/ZstdGpuInitFseTable.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuInitFseTable.hlsl
@@ -45,6 +45,8 @@
 struct Consts
 {
     uint32_t tableStartIndex;
+    uint32_t tableDataStart;
+    uint32_t tableDataCount;
 };
 
 ConstantBuffer<Consts> Constants : register(b0);
@@ -62,7 +64,7 @@ groupshared uint32_t Lds[kzstdgpu_InitFseTable_Experimental_LdsSize];
 #define ZSTDGPU_LDS Lds
 #include "../zstdgpu_lds_hlsl.h"
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors = 2), UAV(u0, numDescriptors=3)), RootConstants(b0, num32BitConstants=1)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors = 2), UAV(u0, numDescriptors=3)), RootConstants(b0, num32BitConstants=3)")]
 [numthreads(kzstdgpu_TgSizeX_InitFseTable, 1, 1)]
 void main(uint32_t groupId : SV_GroupId, uint32_t i : SV_GroupThreadId)
 {
@@ -72,5 +74,7 @@ void main(uint32_t groupId : SV_GroupId, uint32_t i : SV_GroupThreadId)
     ZSTDGPU_INIT_FSE_TABLE_SRT()
     #include "../zstdgpu_srt_decl_undef.h"
     srt.tableStartIndex = Constants.tableStartIndex;
+    srt.tableDataStart  = Constants.tableDataStart;
+    srt.tableDataCount  = Constants.tableDataCount;
     zstdgpu_ShaderEntry_InitFseTable(srt, groupId, i);
 }

--- a/zstd/zstdgpu/Shaders/ZstdGpuInitResources.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuInitResources.hlsl
@@ -36,7 +36,7 @@ ConstantBuffer<Consts> Constants : register(b0);
 ZSTDGPU_INIT_RESOURCES_SRT()
 #include "../zstdgpu_srt_decl_undef.h"
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=1), UAV(u0, numDescriptors=19)), RootConstants(b0, num32BitConstants=4)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=1), UAV(u0, numDescriptors=22)), RootConstants(b0, num32BitConstants=4)")]
 [numthreads(kzstdgpu_TgSizeX_InitCounters, 1, 1)]
 void main(uint i : SV_DispatchThreadId)
 {

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -1601,22 +1601,34 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             ID3D12Resource* argBuf = req->resData.gpuOnly.Counters;
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Huffman Weights");
-            cmdList->SetComputeRoot32BitConstant(1, 0, 0);
+            uint32_t tableStartIndex = 0;
+            cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 0);
+            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartHufW(0, req->zstdCmpBlockCount), 1);
+            cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_HufW, 2);
             cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_FseHufW * sizeof(uint32_t), NULL, 0);
             PIXEndEvent(cmdList);
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Literal Lengths");
-            cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 0);
+            tableStartIndex += req->zstdCmpBlockCount;
+            cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 0);
+            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartLLen(0, req->zstdCmpBlockCount), 1);
+            cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_LLen, 2);
             cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_FseLLen * sizeof(uint32_t), NULL, 0);
             PIXEndEvent(cmdList);
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Offsets");
-            cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount * 2 + 1, 0);
+            tableStartIndex += req->zstdCmpBlockCount + 1;
+            cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 0);
+            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartOffs(0, req->zstdCmpBlockCount), 1);
+            cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_Offs, 2);
             cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_FseOffs * sizeof(uint32_t), NULL, 0);
             PIXEndEvent(cmdList);
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Match Lengths");
-            cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount * 3 + 2, 0);
+            tableStartIndex += req->zstdCmpBlockCount + 1;
+            cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 0);
+            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartMLen(0, req->zstdCmpBlockCount), 1);
+            cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_MLen, 2);
             cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_FseMLen * sizeof(uint32_t), NULL, 0);
             PIXEndEvent(cmdList);
             PIXEndEvent(cmdList);

--- a/zstd/zstdgpu/zstdgpu_reference_store.cpp
+++ b/zstd/zstdgpu/zstdgpu_reference_store.cpp
@@ -21,6 +21,9 @@
 #include "zstdgpu_resources.h"
 
 static const uint8_t *GBase = 0;
+
+typedef uint32_t (*zstdgpu_FseElemOffsetFn)(uint32_t fseTableIndex, uint32_t cmpBlockCount);
+
 static uint32_t GFrameCount = 0;
 
 static uint32_t GBlockCountRAW = 0;
@@ -92,6 +95,15 @@ void zstdgpu_ReferenceStore_AllocateMemory(void)
 
     zstdgpu_ResourceDataCpu_InitZero(&GZstd);
     zstdgpu_ResourceDataCpu_InitFromHeap(&GZstd, &GZstdInfo);
+
+    // Pre-populate 256 dense RLE entries at the beginning of FSE element buffers
+    for (uint32_t i = 0; i < kzstdgpu_FseRleTableCount; ++i)
+    {
+        GZstd.FseSymbols[i] = (uint8_t)i;
+        GZstd.FseBitcnts[i] = 0;
+        GZstd.FseNStates[i] = 0;
+        GZstd.FseInfos[i].fseProbCountAndAccuracyLog2 = 0;
+    }
 }
 
 void zstdgpu_ReferenceStore_FreeMemory(void)
@@ -328,26 +340,29 @@ void zstdgpu_ReferenceStore_Report_FseTable(const int16_t *probs, uint32_t symCo
     free(testBitcnt);
     #endif
 
-#define STORE(name, tableIdx)                                                                                       \
-    if (GFseProbTableTypePending == kzstdgpu_ReferenceStore_Fse##name)                                                    \
-    {                                                                                                               \
-        const uint32_t storeIdx = GBlockCountCMP * tableIdx + GFseProbTableIndex##name++;                           \
-        GZstd.CompressedBlocks[GBlockIndexCMP - 1].fseTableIndex##name = storeIdx;                                  \
-        GLastTableIndex_Fse##name = storeIdx;                                                                       \
-        GZstd.FseInfos[storeIdx] = zstdgpu_CreateFseInfo(symCount, accuracyLog2);                                    \
-        memcpy(&GZstd.FseProbs[storeIdx * kzstdgpu_MaxCount_FseProbs], probs, sizeof(probs[0]) * symCount);            \
-        memcpy(&GZstd.FseSymbols[storeIdx * kzstdgpu_FseElemMaxCount_LLen], symbol, sizeof(symbol[0]) * elemCount);   \
-        memcpy(&GZstd.FseBitcnts[storeIdx * kzstdgpu_FseElemMaxCount_LLen], bitcnt, sizeof(bitcnt[0]) * elemCount);   \
-        memcpy(&GZstd.FseNStates[storeIdx * kzstdgpu_FseElemMaxCount_LLen], nstate, sizeof(nstate[0]) * elemCount);   \
+#define STORE(name, storeExpr)                                                                              \
+    if (GFseProbTableTypePending == kzstdgpu_ReferenceStore_Fse##name)                                      \
+    {                                                                                                       \
+        const uint32_t localIdx = GFseProbTableIndex##name++;                                               \
+        const uint32_t fseIndex = zstdgpu_ComputeFseIndex##name(localIdx, GBlockCountCMP);                  \
+        const uint32_t fseElemStart = zstdgpu_ComputeFseDataStart##name(localIdx, GBlockCountCMP);          \
+        const uint32_t fseProbStart = (fseIndex - kzstdgpu_FseRleTableCount) * kzstdgpu_MaxCount_FseProbs;  \
+        GZstd.CompressedBlocks[GBlockIndexCMP - 1].fseTableIndex##name = storeExpr;                         \
+        GLastTableIndex_Fse##name = storeExpr;                                                              \
+        GZstd.FseInfos[fseIndex] = zstdgpu_CreateFseInfo(symCount, accuracyLog2);                           \
+        memcpy(&GZstd.FseProbs[fseProbStart], probs, sizeof(probs[0]) * symCount);                          \
+        memcpy(&GZstd.FseSymbols[fseElemStart], symbol, sizeof(symbol[0]) * elemCount);                     \
+        memcpy(&GZstd.FseBitcnts[fseElemStart], bitcnt, sizeof(bitcnt[0]) * elemCount);                     \
+        memcpy(&GZstd.FseNStates[fseElemStart], nstate, sizeof(nstate[0]) * elemCount);                     \
     }
 
-    STORE(HufW, 0)
+    STORE(HufW, localIdx)
     else
-    STORE(LLen, 1)
+    STORE(LLen, fseIndex)
     else
-    STORE(Offs, 2)
+    STORE(Offs, fseIndex)
     else
-    STORE(MLen, 3)
+    STORE(MLen, fseIndex)
     else
     {
         __debugbreak();
@@ -360,28 +375,30 @@ void zstdgpu_ReferenceStore_Report_FseDefaultTable(const int16_t *probs, uint32_
     ZSTDGPU_ASSERT(symCount < kzstdgpu_MaxCount_FseProbs);
     const uint32_t elemCount = 1u << accuracyLog2;
 
-#define STORE(name, tableIdx)                                                                                           \
-    if (GFseProbTableTypePending == kzstdgpu_ReferenceStore_Fse##name)                                                        \
-    {                                                                                                                   \
-        const uint32_t storeIdx = GBlockCountCMP * tableIdx + 0;                                                        \
-        GZstd.CompressedBlocks[GBlockIndexCMP - 1].fseTableIndex##name = storeIdx;                                      \
-        GLastTableIndex_Fse##name = storeIdx;                                                                           \
-        if (GFseProbDefaultTable##name##Stored == 0)                                                                    \
-        {                                                                                                               \
-            GZstd.FseInfos[storeIdx] = zstdgpu_CreateFseInfo(symCount, accuracyLog2);                                    \
-            memcpy(&GZstd.FseProbs[storeIdx * kzstdgpu_MaxCount_FseProbs], probs, sizeof(probs[0]) * symCount);            \
-            memcpy(&GZstd.FseSymbols[storeIdx * kzstdgpu_FseElemMaxCount_LLen], symbol, sizeof(symbol[0]) * elemCount);   \
-            memcpy(&GZstd.FseBitcnts[storeIdx * kzstdgpu_FseElemMaxCount_LLen], bitcnt, sizeof(bitcnt[0]) * elemCount);   \
-            memcpy(&GZstd.FseNStates[storeIdx * kzstdgpu_FseElemMaxCount_LLen], nstate, sizeof(nstate[0]) * elemCount);   \
-            GFseProbDefaultTable##name##Stored = 1;                                                                     \
-        }                                                                                                               \
+#define STORE(name)                                                                                         \
+    if (GFseProbTableTypePending == kzstdgpu_ReferenceStore_Fse##name)                                      \
+    {                                                                                                       \
+        const uint32_t fseIndex = zstdgpu_ComputeFseIndex##name(0, GBlockCountCMP);                         \
+        const uint32_t fseElemStart = zstdgpu_ComputeFseDataStart##name(0, GBlockCountCMP);                 \
+        const uint32_t fseProbStart = (fseIndex - kzstdgpu_FseRleTableCount) * kzstdgpu_MaxCount_FseProbs;  \
+        GZstd.CompressedBlocks[GBlockIndexCMP - 1].fseTableIndex##name = fseIndex;                          \
+        GLastTableIndex_Fse##name = fseIndex;                                                               \
+        if (GFseProbDefaultTable##name##Stored == 0)                                                        \
+        {                                                                                                   \
+            GZstd.FseInfos[fseIndex] = zstdgpu_CreateFseInfo(symCount, accuracyLog2);                       \
+            memcpy(&GZstd.FseProbs[fseProbStart], probs, sizeof(probs[0]) * symCount);                      \
+            memcpy(&GZstd.FseSymbols[fseElemStart], symbol, sizeof(symbol[0]) * elemCount);                 \
+            memcpy(&GZstd.FseBitcnts[fseElemStart], bitcnt, sizeof(bitcnt[0]) * elemCount);                 \
+            memcpy(&GZstd.FseNStates[fseElemStart], nstate, sizeof(nstate[0]) * elemCount);                 \
+            GFseProbDefaultTable##name##Stored = 1;                                                         \
+        }                                                                                                   \
     }
 
-    STORE(LLen, 1)
+    STORE(LLen)
     else
-    STORE(Offs, 2)
+    STORE(Offs)
     else
-    STORE(MLen, 3)
+    STORE(MLen)
     else
     {
         __debugbreak();
@@ -393,11 +410,11 @@ void zstdgpu_ReferenceStore_Report_FseProbSymbol(uint32_t symbol)
 {
     ZSTDGPU_ASSERT(symbol < kzstdgpu_MaxCount_FseProbs);
 
-#define STORE(name)                                                                                                 \
-    if (GFseProbTableTypePending == kzstdgpu_ReferenceStore_Fse##name)                                                    \
-    {                                                                                                               \
-        GZstd.CompressedBlocks[GBlockIndexCMP - 1].fseTableIndex##name = kzstdgpu_FseProbTableIndex_MinRLE + symbol; \
-        GLastTableIndex_Fse##name = GZstd.CompressedBlocks[GBlockIndexCMP - 1].fseTableIndex##name;                 \
+#define STORE(name)                                                                 \
+    if (GFseProbTableTypePending == kzstdgpu_ReferenceStore_Fse##name)              \
+    {                                                                               \
+        GZstd.CompressedBlocks[GBlockIndexCMP - 1].fseTableIndex##name = symbol;    \
+        GLastTableIndex_Fse##name = symbol;                                         \
     }
 
     STORE(LLen)
@@ -804,6 +821,9 @@ ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_Blocks(const zstdg
 
 static ZSTDGPU_ENUM(Validate_Result) izstdgpu_ReferenceStore_Validate_FseTable(uint32_t refFseTableIndex,
                                                                          uint32_t tstFseTableIndex,
+                                                                         uint32_t fseInfoOffset,
+                                                                         uint32_t cmpBlockCount,
+                                                                         zstdgpu_FseElemOffsetFn elemOffsetFn,
                                                                          const zstdgpu_FseInfo *refFseInfos,
                                                                          const zstdgpu_FseInfo *tstFseInfos,
                                                                          const int16_t *refFseProbs,
@@ -815,28 +835,38 @@ static ZSTDGPU_ENUM(Validate_Result) izstdgpu_ReferenceStore_Validate_FseTable(u
                                                                          const uint16_t *refFseNStates,
                                                                          const uint16_t *tstFseNStates)
 {
-    // if reference FSE/Huffman table index is an actual index -- the test index should be also an actual index (but it's allowed to be different)
-    if (refFseTableIndex < kzstdgpu_FseProbTableIndex_MinRLE)
+    // All table indices (including RLE 0-255) are valid real indices now
+    if (refFseTableIndex < kzstdgpu_FseProbTableIndex_Repeat)
     {
-        if (tstFseTableIndex >= kzstdgpu_FseProbTableIndex_MinRLE)
+        if (tstFseTableIndex >= kzstdgpu_FseProbTableIndex_Repeat)
             return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
-        if (refFseInfos[refFseTableIndex].fseProbCountAndAccuracyLog2 != tstFseInfos[tstFseTableIndex].fseProbCountAndAccuracyLog2)
+        // For HufW: fseInfoOffset=256 maps localIdx to FseInfos[256+localIdx]
+        // For LLen/Offs/MLen: fseInfoOffset=0, fseTableIndex already includes +256 (or is RLE 0-255)
+        const uint32_t refFseInfoIndex = fseInfoOffset + refFseTableIndex;
+        const uint32_t tstFseInfoIndex = fseInfoOffset + tstFseTableIndex;
+
+        if (refFseInfos[refFseInfoIndex].fseProbCountAndAccuracyLog2 != tstFseInfos[tstFseInfoIndex].fseProbCountAndAccuracyLog2)
             return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
-        const uint32_t probCount = refFseInfos[refFseTableIndex].fseProbCountAndAccuracyLog2 & 0xff;
-        const uint32_t symbolCount = 1u << (refFseInfos[refFseTableIndex].fseProbCountAndAccuracyLog2 >> 8u);
+        const uint32_t probCount = refFseInfos[refFseInfoIndex].fseProbCountAndAccuracyLog2 & 0xff;
+        const uint32_t symbolCount = 1u << (refFseInfos[refFseInfoIndex].fseProbCountAndAccuracyLog2 >> 8u);
 
-        const uint32_t refProbStart = refFseTableIndex * kzstdgpu_MaxCount_FseProbs;
-        const uint32_t tstProbStart = tstFseTableIndex * kzstdgpu_MaxCount_FseProbs;
+        // FseProbs are indexed at (fseInfoIndex - 256) * MaxCount_FseProbs
+        // For RLE (fseInfoIndex < 256), probCount is 0 so no comparison is needed
+        if (probCount > 0)
+        {
+            const uint32_t refProbStart = (refFseInfoIndex - kzstdgpu_FseRleTableCount) * kzstdgpu_MaxCount_FseProbs;
+            const uint32_t tstProbStart = (tstFseInfoIndex - kzstdgpu_FseRleTableCount) * kzstdgpu_MaxCount_FseProbs;
 
-        if (0 != memcmp(&refFseProbs[refProbStart], &tstFseProbs[tstProbStart], probCount * sizeof(refFseProbs[0])))
-            return ZSTDGPU_ENUM_CONST(Validate_Failed);
+            if (0 != memcmp(&refFseProbs[refProbStart], &tstFseProbs[tstProbStart], probCount * sizeof(refFseProbs[0])))
+                return ZSTDGPU_ENUM_CONST(Validate_Failed);
+        }
 
         if (NULL != tstFseSymbols)
         {
-            const uint32_t refElemStart = refFseTableIndex * kzstdgpu_FseElemMaxCount_LLen;
-            const uint32_t tstElemStart = tstFseTableIndex * kzstdgpu_FseElemMaxCount_LLen;
+            const uint32_t refElemStart = elemOffsetFn(refFseTableIndex, cmpBlockCount);
+            const uint32_t tstElemStart = elemOffsetFn(tstFseTableIndex, cmpBlockCount);
 
             if (0 != memcmp(&refFseSymbols[refElemStart], &tstFseSymbols[tstElemStart], symbolCount * sizeof(refFseSymbols[0])))
                 return ZSTDGPU_ENUM_CONST(Validate_Failed);
@@ -886,10 +916,11 @@ ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_FseTables(const zs
     for (uint32_t i = 0; i < GBlockCountCMP; ++i)
     {
          // Validate Referred FSE Tables
-        #define VALIDATE_FSE_TABLE_CONTENT(name)                \
+        #define VALIDATE_FSE_TABLE_CONTENT(name, infoOfs, elemFn) \
             izstdgpu_ReferenceStore_Validate_FseTable(          \
                 ref->CompressedBlocks[i].fseTableIndex##name,   \
                 tst->CompressedBlocks[i].fseTableIndex##name,   \
+                infoOfs, GBlockCountCMP, elemFn,                \
                 ref->FseInfos,                                  \
                 tst->FseInfos,                                  \
                 ref->FseProbs,                                  \
@@ -910,17 +941,17 @@ ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_FseTables(const zs
             if (!(tst->CompressedBlocks[i].fseTableIndexHufW < GFseProbTableIndexHufW))
                 return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
-            if (ZSTDGPU_ENUM_CONST(Validate_Success) != VALIDATE_FSE_TABLE_CONTENT(HufW))
+            if (ZSTDGPU_ENUM_CONST(Validate_Success) != VALIDATE_FSE_TABLE_CONTENT(HufW, kzstdgpu_FseRleTableCount, zstdgpu_ComputeFseDataStartHufW))
                 return ZSTDGPU_ENUM_CONST(Validate_Failed);
         }
 
-        if (ZSTDGPU_ENUM_CONST(Validate_Success) != VALIDATE_FSE_TABLE_CONTENT(LLen))
+        if (ZSTDGPU_ENUM_CONST(Validate_Success) != VALIDATE_FSE_TABLE_CONTENT(LLen, 0, zstdgpu_ComputeFseDataStartFromFseIndexLLen))
             return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
-        if (ZSTDGPU_ENUM_CONST(Validate_Success) != VALIDATE_FSE_TABLE_CONTENT(Offs))
+        if (ZSTDGPU_ENUM_CONST(Validate_Success) != VALIDATE_FSE_TABLE_CONTENT(Offs, 0, zstdgpu_ComputeFseDataStartFromFseIndexOffs))
             return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
-        if (ZSTDGPU_ENUM_CONST(Validate_Success) != VALIDATE_FSE_TABLE_CONTENT(MLen))
+        if (ZSTDGPU_ENUM_CONST(Validate_Success) != VALIDATE_FSE_TABLE_CONTENT(MLen, 0, zstdgpu_ComputeFseDataStartFromFseIndexMLen))
             return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
 

--- a/zstd/zstdgpu/zstdgpu_resources.h
+++ b/zstd/zstdgpu/zstdgpu_resources.h
@@ -294,9 +294,11 @@ static void zstdgpu_ResourceInfo_Stage_1_InitSize(zstdgpu_ResourceInfo *outInfo,
     const uint32_t PerSeqStreamFinalOffset3_Count = PerSeqStreamFinalOffset1_Count;
     const uint32_t PerSeqStreamSeqStart_Count = cmpBlockCount;
 
-    const uint32_t FseTable_Count = cmpBlockCount * 4 + 3; // 4 FSE tables per compressed block (Huff, LLen, Offs, MLen) + 3 default tables for (LLen, Offs, MLen)
-    const uint32_t FseProbs_Count = FseTable_Count * kzstdgpu_MaxCount_FseProbs;
-    const uint32_t FseTableElem_Count = FseTable_Count * kzstdgpu_FseElemMaxCount_LLen;
+    const uint32_t SeqFseElemMaxCount = kzstdgpu_FseElemMaxCount_LLen + kzstdgpu_FseElemMaxCount_Offs + kzstdgpu_FseElemMaxCount_MLen;
+    const uint32_t NonRLE_FseTableCount = cmpBlockCount * 4 + 3; // 4 FSE tables per compressed block (Huff, LLen, Offs, MLen) + 3 default tables for (LLen, Offs, MLen);
+    const uint32_t FseTable_Count = kzstdgpu_FseRleTableCount + NonRLE_FseTableCount;
+    const uint32_t FseProbs_Count = NonRLE_FseTableCount * kzstdgpu_MaxCount_FseProbs;
+    const uint32_t FseTableElem_Count = kzstdgpu_FseRleTableCount + cmpBlockCount * (kzstdgpu_FseElemMaxCount_HufW + SeqFseElemMaxCount) + SeqFseElemMaxCount;
 
     const uint32_t FseSymbols_Count = FseTableElem_Count;
     const uint32_t FseBitcnts_Count = FseTableElem_Count;

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -598,9 +598,23 @@ static void zstdgpu_ShaderEntry_InitResources(ZSTDGPU_PARAM_INOUT(zstdgpu_InitRe
 
     ZSTDGPU_FOR_WORK_ITEMS(i, 1, threadId, kzstdgpu_TgSizeX_InitCounters)
     {
-        srt.inoutFseInfos[srt.cmpBlockCount * 1 + 0] = zstdgpu_CreateFseInfo(kzstdgpu_FseDefaultProbCount_LLen, kzstdgpu_FseDefaultProbAccuracy_LLen);
-        srt.inoutFseInfos[srt.cmpBlockCount * 2 + 1] = zstdgpu_CreateFseInfo(kzstdgpu_FseDefaultProbCount_Offs, kzstdgpu_FseDefaultProbAccuracy_Offs);
-        srt.inoutFseInfos[srt.cmpBlockCount * 3 + 2] = zstdgpu_CreateFseInfo(kzstdgpu_FseDefaultProbCount_MLen, kzstdgpu_FseDefaultProbAccuracy_MLen);
+        srt.inoutFseInfos[kzstdgpu_FseRleTableCount + srt.cmpBlockCount * 1 + 0] = zstdgpu_CreateFseInfo(kzstdgpu_FseDefaultProbCount_LLen, kzstdgpu_FseDefaultProbAccuracy_LLen);
+        srt.inoutFseInfos[kzstdgpu_FseRleTableCount + srt.cmpBlockCount * 2 + 1] = zstdgpu_CreateFseInfo(kzstdgpu_FseDefaultProbCount_Offs, kzstdgpu_FseDefaultProbAccuracy_Offs);
+        srt.inoutFseInfos[kzstdgpu_FseRleTableCount + srt.cmpBlockCount * 3 + 2] = zstdgpu_CreateFseInfo(kzstdgpu_FseDefaultProbCount_MLen, kzstdgpu_FseDefaultProbAccuracy_MLen);
+    }
+
+    // Initialize 256 dense RLE entries at the beginning of FSE element buffers.
+    // RLE table with symbol S uses FseSymbols[S] = S, FseBitcnts[S] = 0, FseNStates[S] = 0.
+    // FseInfos[S] = {0, 0}: accuracyLog=0 so decode reads 0 bits for initial state → state=0 → reads element[0].
+    ZSTDGPU_FOR_WORK_ITEMS(i, kzstdgpu_FseRleTableCount, threadId, kzstdgpu_TgSizeX_InitCounters)
+    {
+        zstdgpu_TypedStoreU8(srt.inoutFseSymbols, i, i);
+        zstdgpu_TypedStoreU8(srt.inoutFseBitcnts, i, 0);
+        zstdgpu_TypedStoreU16(srt.inoutFseNStates, i, 0);
+
+        zstdgpu_FseInfo rleInfo;
+        rleInfo.fseProbCountAndAccuracyLog2 = 0;
+        srt.inoutFseInfos[i] = rleInfo;
     }
 
     // NOTE(pamartis): We initialize the buffer which is going to store (per frame) an index of the first compressed block
@@ -613,7 +627,7 @@ static void zstdgpu_ShaderEntry_InitResources(ZSTDGPU_PARAM_INOUT(zstdgpu_InitRe
         srt.inoutPerFrameSeqStreamMinIdx[i] = ~0u;
     }
 
-    // NOTE(pamartis): We start from `srt.cmpBlockCount * kzstdgpuFseProbMaxCount` because
+    // NOTE(pamartis): We start from `srt.cmpBlockCount * kzstdgpu_MaxCount_FseProbs` because
     // it's the maximal size of FSE probabilities used for Huffman Weights FSE tables, but those don't have "default" probabilities,
     // and therefore not initialised.
     uint32_t dstStart = srt.cmpBlockCount * kzstdgpu_MaxCount_FseProbs;
@@ -693,9 +707,13 @@ static void zstdgpu_ShaderEntry_InitResources(ZSTDGPU_PARAM_INOUT(zstdgpu_InitRe
     }
 }
 
-static void zstdgpu_ParseFseHeader(ZSTDGPU_PARAM_INOUT(zstdgpu_Forward_BitBuffer) buffer, ZSTDGPU_RW_BUFFER(zstdgpu_FseInfo) outFseInfo, ZSTDGPU_RW_TYPED_BUFFER(int32_t, int16_t) outFseProb, uint32_t outFseProbTableIndex, uint32_t accuracyLog2Max)
+static void zstdgpu_ParseFseHeader(ZSTDGPU_PARAM_INOUT(zstdgpu_Forward_BitBuffer) buffer,
+                                   ZSTDGPU_RW_BUFFER(zstdgpu_FseInfo) outFseInfo,
+                                   ZSTDGPU_RW_TYPED_BUFFER(int32_t, int16_t) outFseProb,
+                                   uint32_t outFseTableIndex,
+                                   uint32_t accuracyLog2Max)
 {
-    const uint32_t outFseProbTableOffset = outFseProbTableIndex * kzstdgpu_MaxCount_FseProbs;
+    const uint32_t outFseProbTableOffset = outFseTableIndex * kzstdgpu_MaxCount_FseProbs - kzstdgpu_FseRleTableCount * kzstdgpu_MaxCount_FseProbs;
     if (accuracyLog2Max > 15)
     {
         ZSTDGPU_BREAK();
@@ -790,7 +808,7 @@ static void zstdgpu_ParseFseHeader(ZSTDGPU_PARAM_INOUT(zstdgpu_Forward_BitBuffer
         // If the last symbol makes cumulated total go above 1 << Accuracy_Log, distribution is considered corrupted."
         ZSTDGPU_BREAK(); // Corruption
     }
-    outFseInfo[outFseProbTableIndex] = zstdgpu_CreateFseInfo(symbol, accuracyLog2);
+    outFseInfo[outFseTableIndex] = zstdgpu_CreateFseInfo(symbol, accuracyLog2);
 }
 
 static void zstdgpu_ShaderEntry_ParseCompressedBlocks(ZSTDGPU_PARAM_INOUT(zstdgpu_ParseCompressedBlocks_SRT) srt, uint32_t threadId)
@@ -981,17 +999,26 @@ static void zstdgpu_ShaderEntry_ParseCompressedBlocks(ZSTDGPU_PARAM_INOUT(zstdgp
             {
                 const uint32_t fseProbOffs = zstdgpu_Forward_BitBuffer_GetByteOffset(buffer);
 
-                #define ALLOCATE_FSE_TABLE_INDEX(name, start)                                                                           \
-                    const uint32_t fseWaveTableCount##name = WaveActiveCountBits(true);                                                 \
-                    uint32_t fseWaveTableIndexStart##name = 0;                                                                          \
-                    if (WaveIsFirstLane())                                                                                              \
-                    {                                                                                                                   \
-                        InterlockedAdd(srt.inoutCounters[kzstdgpu_CounterIndex_Fse##name], fseWaveTableCount##name, fseWaveTableIndexStart##name);         \
-                    }                                                                                                                   \
-                    outBlockData.fseTableIndex##name = (start) + WaveReadLaneFirst(fseWaveTableIndexStart##name) + WavePrefixCountBits(true);     \
+                #define ALLOCATE_FSE_TABLE_INDEX(name)                                      \
+                    const uint32_t fseWaveTableCount##name = WaveActiveCountBits(true);     \
+                    uint32_t fseWaveTableStart##name = 0;                                   \
+                    if (WaveIsFirstLane())                                                  \
+                    {                                                                       \
+                        InterlockedAdd(                                                     \
+                            srt.inoutCounters[kzstdgpu_CounterIndex_Fse##name],             \
+                            fseWaveTableCount##name,                                        \
+                            fseWaveTableStart##name                                         \
+                        );                                                                  \
+                    }                                                                       \
+                    outBlockData.fseTableIndex##name = zstdgpu_ComputeFseIndex##name(       \
+                        WaveReadLaneFirst(fseWaveTableStart##name) + WavePrefixCountBits(true),\
+                        srt.compressedBlockCount                                            \
+                    );                                                                      \
                     zstdgpu_ParseFseHeader(buffer, srt.inoutFseInfos, srt.inoutFseProbs, outBlockData.fseTableIndex##name, kzstdgpu_FseProbMaxAccuracy_##name)
 
-                ALLOCATE_FSE_TABLE_INDEX(HufW, 0);
+                ALLOCATE_FSE_TABLE_INDEX(HufW);
+
+                outBlockData.fseTableIndexHufW -= zstdgpu_ComputeFseIndexHufW(0, srt.compressedBlockCount);
 
                 zstdgpu_OffsetAndSize fseCompressedHuffmanWeights;
                 fseCompressedHuffmanWeights.offs = zstdgpu_Forward_BitBuffer_GetByteOffset(buffer);
@@ -1195,31 +1222,32 @@ static void zstdgpu_ShaderEntry_ParseCompressedBlocks(ZSTDGPU_PARAM_INOUT(zstdgp
             ZSTDGPU_BREAK();
         }
 
-        #define PARSE_FSE_TABLE(startBit, name, start)                                      \
+        #define PARSE_FSE_TABLE(startBit, name)                                             \
             const uint32_t mode##name = zstdgpu_BitFieldExtractU32(compressionModes, startBit, 2); \
             if (2 == mode##name)                                                            \
             {                                                                               \
-                ALLOCATE_FSE_TABLE_INDEX(name, start);                                      \
+                ALLOCATE_FSE_TABLE_INDEX(name);                                             \
             }                                                                               \
             else if (0 == mode##name)                                                       \
             {                                                                               \
-                outBlockData.fseTableIndex##name = (start);                                 \
+                /** default FSE table is always at index '0' in a chunk of appropriate type*/\
+                outBlockData.fseTableIndex##name = zstdgpu_ComputeFseIndex##name(0, srt.compressedBlockCount);\
             }                                                                               \
             else if (1 == mode##name)                                                       \
             {                                                                               \
-                outBlockData.fseTableIndex##name = kzstdgpu_FseProbTableIndex_MinRLE         \
-                                                 + zstdgpu_Forward_BitBuffer_Get(buffer, 8);         \
+                outBlockData.fseTableIndex##name = zstdgpu_Forward_BitBuffer_Get(buffer, 8); \
             }                                                                               \
             else/* if (3 == mode##name)*/                                                   \
             {                                                                               \
                 outBlockData.fseTableIndex##name = kzstdgpu_FseProbTableIndex_Repeat;        \
             }
 
-        PARSE_FSE_TABLE(6, LLen, srt.compressedBlockCount)
-        PARSE_FSE_TABLE(4, Offs, srt.compressedBlockCount * 2 + 1)
-        PARSE_FSE_TABLE(2, MLen, srt.compressedBlockCount * 3 + 2)
-#undef PARSE_FSE_TABLE
-#undef ALLOCATE_FSE_TABLE_INDEX
+        PARSE_FSE_TABLE(6, LLen)
+        PARSE_FSE_TABLE(4, Offs)
+        PARSE_FSE_TABLE(2, MLen)
+
+        #undef PARSE_FSE_TABLE
+        #undef ALLOCATE_FSE_TABLE_INDEX
 
         const uint32_t offs = zstdgpu_Forward_BitBuffer_GetByteOffset(buffer);
         srt.inoutSeqRefs[outBlockData.seqStreamIndex].src.offs = offs;
@@ -1683,11 +1711,11 @@ static void zstdgpu_ShaderEntry_InitFseTable(ZSTDGPU_PARAM_INOUT(zstdgpu_InitFse
     #endif
     #include "zstdgpu_lds_decl_undef.h"
 
-    const uint32_t tableStartIndex = srt.tableStartIndex + groupId;
-    const uint32_t frqDataOffset = tableStartIndex * kzstdgpu_MaxCount_FseProbs;
-    const uint32_t tblDataOffset = tableStartIndex * kzstdgpu_MaxCount_FseElems;
+    const uint32_t tableIndex    = srt.tableStartIndex + groupId;
+    const uint32_t frqDataOffset = tableIndex * kzstdgpu_MaxCount_FseProbs;
+    const uint32_t tblDataOffset = srt.tableDataStart + groupId * srt.tableDataCount;
 
-    const zstdgpu_FseInfo fseInfo = srt.inFseInfos[tableStartIndex];
+    const zstdgpu_FseInfo fseInfo = srt.inFseInfos[kzstdgpu_FseRleTableCount + tableIndex];
 
     const uint32_t accuracyLog2 = (fseInfo.fseProbCountAndAccuracyLog2 >> 8u);
 
@@ -2345,6 +2373,7 @@ static void zstdgpu_ShaderEntry_InitFseTable(ZSTDGPU_PARAM_INOUT(zstdgpu_InitFse
 
 static void zstdgpu_ShaderEntry_DecompressHuffmanWeights(ZSTDGPU_PARAM_INOUT(zstdgpu_DecompressHuffmanWeights_SRT) srt, uint32_t threadId)
 {
+    const uint32_t cmpBlockCnt = srt.inCounters[kzstdgpu_CounterIndex_Blocks_CMP];
     // NOTE(pamartis): We check the number of FSE tables for Huffman Weights, which gives us the number of FSE-compressed Huffman Weight streams
     if (threadId >= srt.inCounters[kzstdgpu_CounterIndex_FseHufW])
         return;
@@ -2352,12 +2381,12 @@ static void zstdgpu_ShaderEntry_DecompressHuffmanWeights(ZSTDGPU_PARAM_INOUT(zst
     zstdgpu_Backward_BitBuffer_V0 buffer;
     zstdgpu_Backward_BitBuffer_V0_InitWithSegment(buffer, srt.inCompressedData, srt.inHufRefs[threadId]);
 
-    const uint32_t initialBitcnt = srt.inFseInfos[threadId].fseProbCountAndAccuracyLog2 >> 8;
+    const uint32_t initialBitcnt = srt.inFseInfos[zstdgpu_ComputeFseIndexHufW(threadId, cmpBlockCnt)].fseProbCountAndAccuracyLog2 >> 8;
 
     uint32_t state0 = zstdgpu_Backward_BitBuffer_V0_Get(buffer, initialBitcnt);
     uint32_t state1 = zstdgpu_Backward_BitBuffer_V0_Get(buffer, initialBitcnt);
 
-    uint32_t fseTableOffset = threadId * kzstdgpu_FseElemMaxCount_LLen;
+    uint32_t fseTableOffset = zstdgpu_ComputeFseDataStartHufW(threadId, cmpBlockCnt);
     uint32_t hufTableOffset = threadId * kzstdgpu_MaxCount_HuffmanWeights;
 
     uint32_t hufWeightIndex = hufTableOffset;
@@ -3519,15 +3548,12 @@ static void zstdgpu_ShaderEntry_DecompressSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_
 {
     const uint32_t seqStreamIdx = threadId;
     const uint32_t seqStreamCnt = srt.inCounters[kzstdgpu_CounterIndex_Seq_Streams];
+    const uint32_t cmpBlockCnt = srt.inCounters[kzstdgpu_CounterIndex_Blocks_CMP];
 
     if (seqStreamIdx >= seqStreamCnt)
         return;
 
     const zstdgpu_SeqStreamInfo seqRef = srt.inSeqRefs[seqStreamIdx];
-
-    const bool isAllNonRLE = seqRef.fseLLen < kzstdgpu_FseProbTableIndex_MinRLE &&
-                             seqRef.fseOffs < kzstdgpu_FseProbTableIndex_MinRLE &&
-                             seqRef.fseMLen < kzstdgpu_FseProbTableIndex_MinRLE;
 
     #ifdef ZSTDGPU_BACKWARD_BITBUF
     #   error `ZSTDGPU_BACKWARD_BITBUF` must not be defined.
@@ -3547,15 +3573,14 @@ static void zstdgpu_ShaderEntry_DecompressSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_
     uint32_t offset1, offset2, offset3;
     zstdgpu_SequenceOffsets_Init(offset1, offset2, offset3);
 
-    const uint32_t startLLen = seqRef.fseLLen * kzstdgpu_FseElemMaxCount_LLen;
-    const uint32_t startOffs = seqRef.fseOffs * kzstdgpu_FseElemMaxCount_LLen;
-    const uint32_t startMLen = seqRef.fseMLen * kzstdgpu_FseElemMaxCount_LLen;
+    const uint32_t startLLen = zstdgpu_ComputeFseDataStartFromFseIndexLLen(seqRef.fseLLen, cmpBlockCnt);
+    const uint32_t startOffs = zstdgpu_ComputeFseDataStartFromFseIndexOffs(seqRef.fseOffs, cmpBlockCnt);
+    const uint32_t startMLen = zstdgpu_ComputeFseDataStartFromFseIndexMLen(seqRef.fseMLen, cmpBlockCnt);
 
     const zstdgpu_OffsetAndSize dst = zstdgpu_GetSequenceStartAndCount(srt, seqStreamIdx, seqStreamCnt);
     const uint32_t outputStart = dst.offs;
     const uint32_t outputEnd = outputStart + dst.size;
 
-    if (isAllNonRLE)
     {
         const uint32_t initBitcntLLen = srt.inFseInfos[seqRef.fseLLen].fseProbCountAndAccuracyLog2 >> 8;
         const uint32_t initBitcntOffs = srt.inFseInfos[seqRef.fseOffs].fseProbCountAndAccuracyLog2 >> 8;
@@ -3599,71 +3624,6 @@ static void zstdgpu_ShaderEntry_DecompressSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_
             zstdgpu_ReadExtraBitsAndUpdateState(srt, bitBuffer, stateLLen, stateOffs, stateMLen);
         }
     }
-    else
-    {
-        #define ZSTDGPU_INIT_FSE_STATE(name)                                                                   \
-            uint32_t state##name = 0;                                                                           \
-            if (seqRef.fse##name < kzstdgpu_FseProbTableIndex_MinRLE)                                            \
-            {                                                                                                   \
-                const uint32_t initBitcnt = srt.inFseInfos[seqRef.fse##name].fseProbCountAndAccuracyLog2 >> 8;  \
-                state##name = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, initBitcnt);                             \
-            }
-        ZSTDGPU_INIT_FSE_STATE(LLen)
-        ZSTDGPU_INIT_FSE_STATE(Offs)
-        ZSTDGPU_INIT_FSE_STATE(MLen)
-        #undef ZSTDGPU_INIT_FSE_STATE
-
-        for (uint32_t i = outputStart; i < outputEnd; ++i)
-        {
-            uint32_t symbolLLen = 0;
-            uint32_t symbolOffs = 0;
-            uint32_t symbolMLen = 0;
-
-            #define ZSTDGPU_LOAD_FSE_SYMBOL(name)                                      \
-                if (seqRef.fse##name < kzstdgpu_FseProbTableIndex_MinRLE)                \
-                {                                                                       \
-                    state##name += start##name;                                         \
-                    symbol##name = srt.inFseSymbols[state##name];                       \
-                }                                                                       \
-                else                                                                    \
-                {                                                                       \
-                    symbol##name = seqRef.fse##name - kzstdgpu_FseProbTableIndex_MinRLE; \
-                }
-            ZSTDGPU_LOAD_FSE_SYMBOL(LLen)
-            ZSTDGPU_LOAD_FSE_SYMBOL(Offs)
-            ZSTDGPU_LOAD_FSE_SYMBOL(MLen)
-            #undef ZSTDGPU_LOAD_FSE_SYMBOL
-
-            uint32_t llen = 0, offs = 0, mlen = 0;
-            zstdgpu_ReadSeqBitsAndDecompress(bitBuffer, symbolLLen, symbolOffs, symbolMLen, llen, offs, mlen);
-            offs = zstdgpu_SequenceOffsets_Update2(offset1, offset2, offset3, offs, llen);
-
-            // TODO: output totalSize per iteration to automatically compute prefix
-            totalSize += llen + mlen;
-            totalMLen += mlen;
-
-            srt.inoutDecompressedSequenceLLen[i] = llen;
-            srt.inoutDecompressedSequenceMLen[i] = mlen;
-            srt.inoutDecompressedSequenceOffs[i] = offs;
-
-            if (i == outputEnd - 1u)
-            {
-                break;
-            }
-
-            #define ZSTDGPU_UPDATE_FSE_STATE(name)                                                         \
-                if (seqRef.fse##name < kzstdgpu_FseProbTableIndex_MinRLE)                                    \
-                {                                                                                           \
-                    const uint32_t restbitcnt##name = srt.inFseBitcnts[state##name];                        \
-                    const uint32_t rest##name = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcnt##name); \
-                    state##name = srt.inFseNStates[state##name] + rest##name;                               \
-                }
-            ZSTDGPU_UPDATE_FSE_STATE(LLen)
-            ZSTDGPU_UPDATE_FSE_STATE(MLen)
-            ZSTDGPU_UPDATE_FSE_STATE(Offs)
-            #undef ZSTDGPU_UPDATE_FSE_STATE
-        }
-    }
 
     // NOTE(pamartis): update block size adding `totalMLen` bytes on top
     srt.inoutBlockSizePrefix[seqRef.blockId] = totalMLen + literalSize;
@@ -3695,6 +3655,7 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsFseCache(ZSTDGPU_PARAM_IN
 
     const uint32_t seqStreamIdx = groupId;
     const uint32_t seqStreamCnt = srt.inCounters[kzstdgpu_CounterIndex_Seq_Streams];
+    const uint32_t cmpBlockCnt = srt.inCounters[kzstdgpu_CounterIndex_Blocks_CMP];
 
     if (seqStreamIdx >= seqStreamCnt)
         return;
@@ -3709,9 +3670,9 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsFseCache(ZSTDGPU_PARAM_IN
     uint32_t offset1, offset2, offset3;
     zstdgpu_SequenceOffsets_Init(offset1, offset2, offset3);
 
-    const uint32_t startLLen = seqRef.fseLLen * kzstdgpu_FseElemMaxCount_LLen;
-    const uint32_t startOffs = seqRef.fseOffs * kzstdgpu_FseElemMaxCount_LLen;
-    const uint32_t startMLen = seqRef.fseMLen * kzstdgpu_FseElemMaxCount_LLen;
+    const uint32_t startLLen = zstdgpu_ComputeFseDataStartFromFseIndexLLen(seqRef.fseLLen, cmpBlockCnt);
+    const uint32_t startOffs = zstdgpu_ComputeFseDataStartFromFseIndexOffs(seqRef.fseOffs, cmpBlockCnt);
+    const uint32_t startMLen = zstdgpu_ComputeFseDataStartFromFseIndexMLen(seqRef.fseMLen, cmpBlockCnt);
 
     const zstdgpu_OffsetAndSize dst = zstdgpu_GetSequenceStartAndCount(srt, seqStreamIdx, seqStreamCnt);
 
@@ -3720,24 +3681,18 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsFseCache(ZSTDGPU_PARAM_IN
     #include "zstdgpu_lds_decl_undef.h"
 
     #define ZSTDGPU_PRELOAD_FSE_INTO_LDS(name)                                                                  \
-        if (seqRef.fse##name < kzstdgpu_FseProbTableIndex_MinRLE)                                               \
+    {                                                                                                           \
+        const uint32_t fseAccuracyLog2 = srt.inFseInfos[seqRef.fse##name].fseProbCountAndAccuracyLog2 >> 8;     \
+        const uint32_t fseElemCount = 1u << fseAccuracyLog2;                                                    \
+        ZSTDGPU_FOR_WORK_ITEMS(i, fseElemCount, threadId, tgSize)                                               \
         {                                                                                                       \
-            const uint32_t fseAccuracyLog2 = srt.inFseInfos[seqRef.fse##name].fseProbCountAndAccuracyLog2 >> 8; \
-            const uint32_t fseElemCount = 1u << fseAccuracyLog2;                                                \
-            ZSTDGPU_FOR_WORK_ITEMS(i, fseElemCount, threadId, tgSize)                                           \
-            {                                                                                                   \
-                const uint32_t symbol = srt.inFseSymbols[start##name + i];                                      \
-                const uint32_t bitcnt = srt.inFseBitcnts[start##name + i];                                      \
-                const uint32_t nstate = srt.inFseNStates[start##name + i];                                      \
-                const uint32_t packedFseElem = (nstate << 16) | (bitcnt << 8) | symbol;                         \
-                zstdgpu_LdsStoreU32(GS_FsePacked##name + i, packedFseElem);                                     \
-            }                                                                                                   \
+            const uint32_t symbol = srt.inFseSymbols[start##name + i];                                          \
+            const uint32_t bitcnt = srt.inFseBitcnts[start##name + i];                                          \
+            const uint32_t nstate = srt.inFseNStates[start##name + i];                                          \
+            const uint32_t packedFseElem = (nstate << 16) | (bitcnt << 8) | symbol;                             \
+            zstdgpu_LdsStoreU32(GS_FsePacked##name + i, packedFseElem);                                         \
         }                                                                                                       \
-        else                                                                                                    \
-        {                                                                                                       \
-            const uint32_t packedFseElem = seqRef.fse##name - kzstdgpu_FseProbTableIndex_MinRLE;                \
-            zstdgpu_LdsStoreU32(GS_FsePacked##name + 0, packedFseElem);                                         \
-        }
+    }
 
     ZSTDGPU_PRELOAD_FSE_INTO_LDS(LLen)
     ZSTDGPU_PRELOAD_FSE_INTO_LDS(Offs)
@@ -3764,7 +3719,6 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsFseCache(ZSTDGPU_PARAM_IN
 
     #define ZSTDGPU_INIT_FSE_STATE(name)                                                                    \
         uint32_t state##name = 0;                                                                           \
-        if (seqRef.fse##name < kzstdgpu_FseProbTableIndex_MinRLE)                                           \
         {                                                                                                   \
             const uint32_t initBitcnt = srt.inFseInfos[seqRef.fse##name].fseProbCountAndAccuracyLog2 >> 8;  \
             state##name = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, initBitcnt);                              \
@@ -3873,14 +3827,11 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsOutCache(ZSTDGPU_PARAM_IN
     const uint32_t seqIdPerThread = zstdgpu_MinU32(threadId, groupSeqCount - 1u);
     const uint32_t seqStreamIdx = groupId * kzstdgpu_TgSizeX_DecompressSequences + seqIdPerThread;
     const uint32_t seqStreamCnt = srt.inCounters[kzstdgpu_CounterIndex_Seq_Streams];
+    const uint32_t cmpBlockCnt = srt.inCounters[kzstdgpu_CounterIndex_Blocks_CMP];
 
     const zstdgpu_OffsetAndSize seqRefDst = zstdgpu_GetSequenceStartAndCount(srt, seqStreamIdx, seqStreamCnt);
 
     const zstdgpu_SeqStreamInfo seqRef = srt.inSeqRefs[seqStreamIdx];
-
-    const bool isAllNonRLE = seqRef.fseLLen < kzstdgpu_FseProbTableIndex_MinRLE &&
-                             seqRef.fseOffs < kzstdgpu_FseProbTableIndex_MinRLE &&
-                             seqRef.fseMLen < kzstdgpu_FseProbTableIndex_MinRLE;
 
     uint32_t offset1, offset2, offset3;
     zstdgpu_SequenceOffsets_Init(offset1, offset2, offset3);
@@ -3918,11 +3869,10 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsOutCache(ZSTDGPU_PARAM_IN
     uint32_t totalSize = 0;
     uint32_t totalMLen = 0;
 
-    const uint32_t startLLen = seqRef.fseLLen * kzstdgpu_FseElemMaxCount_LLen;
-    const uint32_t startOffs = seqRef.fseOffs * kzstdgpu_FseElemMaxCount_LLen;
-    const uint32_t startMLen = seqRef.fseMLen * kzstdgpu_FseElemMaxCount_LLen;
+    const uint32_t startLLen = zstdgpu_ComputeFseDataStartFromFseIndexLLen(seqRef.fseLLen, cmpBlockCnt);
+    const uint32_t startOffs = zstdgpu_ComputeFseDataStartFromFseIndexOffs(seqRef.fseOffs, cmpBlockCnt);
+    const uint32_t startMLen = zstdgpu_ComputeFseDataStartFromFseIndexMLen(seqRef.fseMLen, cmpBlockCnt);
 
-    if (WaveActiveAllTrue(isAllNonRLE))
     {
         const uint32_t initBitcntLLen = srt.inFseInfos[seqRef.fseLLen].fseProbCountAndAccuracyLog2 >> 8;
         const uint32_t initBitcntOffs = srt.inFseInfos[seqRef.fseOffs].fseProbCountAndAccuracyLog2 >> 8;
@@ -4050,119 +4000,6 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsOutCache(ZSTDGPU_PARAM_IN
         }
         #undef SEQ_CACHE_LEN
         #undef NUM_THREADS
-    }
-
-    else if (threadId < groupSeqCount)
-    {
-        if (isAllNonRLE)
-        {
-            const uint32_t initBitcntLLen = srt.inFseInfos[seqRef.fseLLen].fseProbCountAndAccuracyLog2 >> 8;
-            const uint32_t initBitcntOffs = srt.inFseInfos[seqRef.fseOffs].fseProbCountAndAccuracyLog2 >> 8;
-            const uint32_t initBitcntMLen = srt.inFseInfos[seqRef.fseMLen].fseProbCountAndAccuracyLog2 >> 8;
-
-            ZSTDGPU_BACKWARD_BITBUF(Refill)(bitBuffer, initBitcntLLen + initBitcntOffs + initBitcntMLen);
-
-            uint32_t stateLLen = ZSTDGPU_BACKWARD_BITBUF(GetNoRefill)(bitBuffer, initBitcntLLen);
-            uint32_t stateOffs = ZSTDGPU_BACKWARD_BITBUF(GetNoRefill)(bitBuffer, initBitcntOffs);
-            uint32_t stateMLen = ZSTDGPU_BACKWARD_BITBUF(GetNoRefill)(bitBuffer, initBitcntMLen);
-
-            for (uint32_t i = 0; i < seqRefDst.size; ++i)
-            {
-                stateLLen += startLLen;
-                stateOffs += startOffs;
-                stateMLen += startMLen;
-
-                uint32_t llen = 0, offs = 0, mlen = 0;
-                zstdgpu_ReadSeqBitsAndDecompress(
-                    bitBuffer,
-                    srt.inFseSymbols[stateLLen],
-                    srt.inFseSymbols[stateOffs],
-                    srt.inFseSymbols[stateMLen],
-                    llen, offs, mlen
-                );
-                offs = zstdgpu_SequenceOffsets_Update2(offset1, offset2, offset3, offs, llen);
-
-                // TODO: output totalSize per iteration to automatically compute prefix
-                totalSize += llen + mlen;
-                totalMLen += mlen;
-
-                srt.inoutDecompressedSequenceLLen[seqRefDst.offs + i] = llen;
-                srt.inoutDecompressedSequenceMLen[seqRefDst.offs + i] = mlen;
-                srt.inoutDecompressedSequenceOffs[seqRefDst.offs + i] = offs;
-
-                if (i + 1u == seqRefDst.size)
-                {
-                    break;
-                }
-
-                zstdgpu_ReadExtraBitsAndUpdateState(srt, bitBuffer, stateLLen, stateOffs, stateMLen);
-            }
-        }
-        else
-        {
-            #define ZSTDGPU_INIT_FSE_STATE(name)                                                                   \
-                uint32_t state##name = 0;                                                                           \
-                if (seqRef.fse##name < kzstdgpu_FseProbTableIndex_MinRLE)                                            \
-                {                                                                                                   \
-                    const uint32_t initBitcnt = srt.inFseInfos[seqRef.fse##name].fseProbCountAndAccuracyLog2 >> 8;  \
-                    state##name = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, initBitcnt);                             \
-                }
-            ZSTDGPU_INIT_FSE_STATE(LLen)
-            ZSTDGPU_INIT_FSE_STATE(Offs)
-            ZSTDGPU_INIT_FSE_STATE(MLen)
-            #undef ZSTDGPU_INIT_FSE_STATE
-
-            for (uint32_t i = 0; i < seqRefDst.size; ++i)
-            {
-                uint32_t symbolLLen = 0;
-                uint32_t symbolOffs = 0;
-                uint32_t symbolMLen = 0;
-
-                #define ZSTDGPU_LOAD_FSE_SYMBOL(name)                                      \
-                    if (seqRef.fse##name < kzstdgpu_FseProbTableIndex_MinRLE)                \
-                    {                                                                       \
-                        state##name += start##name;                                         \
-                        symbol##name = srt.inFseSymbols[state##name];                       \
-                    }                                                                       \
-                    else                                                                    \
-                    {                                                                       \
-                        symbol##name = seqRef.fse##name - kzstdgpu_FseProbTableIndex_MinRLE; \
-                    }
-                ZSTDGPU_LOAD_FSE_SYMBOL(LLen)
-                ZSTDGPU_LOAD_FSE_SYMBOL(Offs)
-                ZSTDGPU_LOAD_FSE_SYMBOL(MLen)
-                #undef ZSTDGPU_LOAD_FSE_SYMBOL
-
-                uint32_t llen = 0, offs = 0, mlen = 0;
-                zstdgpu_ReadSeqBitsAndDecompress(bitBuffer, symbolLLen, symbolOffs, symbolMLen, llen, offs, mlen);
-                offs = zstdgpu_SequenceOffsets_Update2(offset1, offset2, offset3, offs, llen);
-
-                // TODO: output totalSize per iteration to automatically compute prefix
-                totalSize += llen + mlen;
-                totalMLen += mlen;
-
-                srt.inoutDecompressedSequenceLLen[seqRefDst.offs + i] = llen;
-                srt.inoutDecompressedSequenceMLen[seqRefDst.offs + i] = mlen;
-                srt.inoutDecompressedSequenceOffs[seqRefDst.offs + i] = offs;
-
-                if (i + 1u == seqRefDst.size)
-                {
-                    break;
-                }
-
-                #define ZSTDGPU_UPDATE_FSE_STATE(name)                                                         \
-                    if (seqRef.fse##name < kzstdgpu_FseProbTableIndex_MinRLE)                                    \
-                    {                                                                                           \
-                        const uint32_t restbitcnt##name = srt.inFseBitcnts[state##name];                        \
-                        const uint32_t rest##name = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, restbitcnt##name); \
-                        state##name = srt.inFseNStates[state##name] + rest##name;                               \
-                    }
-                ZSTDGPU_UPDATE_FSE_STATE(LLen)
-                ZSTDGPU_UPDATE_FSE_STATE(MLen)
-                ZSTDGPU_UPDATE_FSE_STATE(Offs)
-                #undef ZSTDGPU_UPDATE_FSE_STATE
-            }
-        }
     }
 
     if (threadId < groupSeqCount)

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -273,14 +273,15 @@ static const uint32_t kzstdgpu_FseDefaultProbAccuracy_LLen = 6;
 static const uint32_t kzstdgpu_FseDefaultProbAccuracy_Offs = 5;
 static const uint32_t kzstdgpu_FseDefaultProbAccuracy_MLen = 6;
 
+// 256 dense RLE entries at the beginning of FSE element buffers (positions 0-255).
+// RLE table with symbol S uses fseTableIndex = S. Real tables start at index 256.
+static const uint32_t kzstdgpu_FseRleTableCount = 256;
+
 // We define some special indices to classify FSE table indices referred by compressed blocks:
 //  "Unused" - special index showing the compressed block doesn't use FSE table
 //  "Repeat" - special index showing the compressed block uses FSE table from previous block that uses some
-//  "MinRLE":"MaxRLE" - a range of special indices showing that that FSE table is defined by a single symbol = `index - kzstdgpu_FseProbTableIndex_MinRLE`
 static const uint32_t kzstdgpu_FseProbTableIndex_Unused = 0x3fffffff;
 static const uint32_t kzstdgpu_FseProbTableIndex_Repeat = kzstdgpu_FseProbTableIndex_Unused - 1;
-static const uint32_t kzstdgpu_FseProbTableIndex_MaxRLE = kzstdgpu_FseProbTableIndex_Repeat - 1;
-static const uint32_t kzstdgpu_FseProbTableIndex_MinRLE = kzstdgpu_FseProbTableIndex_MaxRLE - 256 + 1;
 
 static const uint32_t kzstdgpu_CounterIndex_FseHufW = 0;
 static const uint32_t kzstdgpu_CounterIndex_FseLLen = 3;
@@ -1348,6 +1349,64 @@ static zstdgpu_FseInfo zstdgpu_CreateFseInfo(uint32_t symbolCount, uint32_t accu
     return info;
 }
 
+static uint32_t zstdgpu_ComputeFseIndexHufW(uint32_t indexHufW, uint32_t cmpBlockCount)
+{
+    return kzstdgpu_FseRleTableCount + indexHufW;
+}
+
+static uint32_t zstdgpu_ComputeFseIndexLLen(uint32_t indexLLen, uint32_t cmpBlockCount)
+{
+    return kzstdgpu_FseRleTableCount + cmpBlockCount + indexLLen;
+}
+
+static uint32_t zstdgpu_ComputeFseIndexOffs(uint32_t indexOffs, uint32_t cmpBlockCount)
+{
+    return kzstdgpu_FseRleTableCount + (2 * cmpBlockCount + 1) + indexOffs;
+}
+
+static uint32_t zstdgpu_ComputeFseIndexMLen(uint32_t indexMLen, uint32_t cmpBlockCount)
+{
+    return kzstdgpu_FseRleTableCount + (3 * cmpBlockCount + 2) + indexMLen;
+}
+
+static uint32_t zstdgpu_ComputeFseDataStartHufW(uint32_t indexHufW, uint32_t cmpBlockCount)
+{
+    return kzstdgpu_FseRleTableCount + indexHufW * kzstdgpu_FseElemMaxCount_HufW;
+}
+
+static uint32_t zstdgpu_ComputeFseDataStartLLen(uint32_t indexLLen, uint32_t cmpBlockCount)
+{
+    return kzstdgpu_FseRleTableCount + cmpBlockCount * kzstdgpu_FseElemMaxCount_HufW + indexLLen * kzstdgpu_FseElemMaxCount_LLen;
+}
+
+static uint32_t zstdgpu_ComputeFseDataStartOffs(uint32_t indexOffs, uint32_t cmpBlockCount)
+{
+    return (kzstdgpu_FseRleTableCount + kzstdgpu_FseElemMaxCount_LLen) + cmpBlockCount * (kzstdgpu_FseElemMaxCount_HufW + kzstdgpu_FseElemMaxCount_LLen) + indexOffs * kzstdgpu_FseElemMaxCount_Offs;
+}
+
+static uint32_t zstdgpu_ComputeFseDataStartMLen(uint32_t indexMLen, uint32_t cmpBlockCount)
+{
+    return (kzstdgpu_FseRleTableCount + kzstdgpu_FseElemMaxCount_LLen + kzstdgpu_FseElemMaxCount_Offs) + cmpBlockCount * (kzstdgpu_FseElemMaxCount_HufW + kzstdgpu_FseElemMaxCount_LLen + kzstdgpu_FseElemMaxCount_Offs) + indexMLen * kzstdgpu_FseElemMaxCount_MLen;
+}
+
+static uint32_t zstdgpu_ComputeFseDataStartFromFseIndexLLen(uint32_t fseIndex, uint32_t cmpBlockCount)
+{
+    return (fseIndex < kzstdgpu_FseRleTableCount) ? fseIndex
+                                                  : zstdgpu_ComputeFseDataStartLLen(fseIndex - zstdgpu_ComputeFseIndexLLen(0, cmpBlockCount), cmpBlockCount);
+}
+
+static uint32_t zstdgpu_ComputeFseDataStartFromFseIndexOffs(uint32_t fseIndex, uint32_t cmpBlockCount)
+{
+    return (fseIndex < kzstdgpu_FseRleTableCount) ? fseIndex
+                                                  : zstdgpu_ComputeFseDataStartOffs(fseIndex - zstdgpu_ComputeFseIndexOffs(0, cmpBlockCount), cmpBlockCount);
+}
+
+static uint32_t zstdgpu_ComputeFseDataStartFromFseIndexMLen(uint32_t fseIndex, uint32_t cmpBlockCount)
+{
+    return (fseIndex < kzstdgpu_FseRleTableCount) ? fseIndex
+                                                  : zstdgpu_ComputeFseDataStartMLen(fseIndex - zstdgpu_ComputeFseIndexMLen(0, cmpBlockCount), cmpBlockCount);
+}
+
 typedef struct zstdgpu_CompressedBlockData
 {
     zstdgpu_OffsetAndSize literal;   //< The offset and the size of the uncompressed literal
@@ -1357,10 +1416,10 @@ typedef struct zstdgpu_CompressedBlockData
     uint32_t litStreamIndex;  //< CONSIDER REMOVING: The starting index of Huffman compressed literal streams in `compressedLiteralRefs`
     uint32_t seqStreamIndex;
 
-    uint32_t fseTableIndexHufW; //< Can be an actual index or kzstdgpu_FseProbTableIndex_Unused/Repeat
-    uint32_t fseTableIndexLLen; //< Can be an actual index or kzstdgpu_FseProbTableIndex_Unused/Repeat/MinRLE - MaxRLE
-    uint32_t fseTableIndexOffs; //< Can be an actual index or kzstdgpu_FseProbTableIndex_Unused/Repeat/MinRLE - MaxRLE
-    uint32_t fseTableIndexMLen; //< Can be an actual index or kzstdgpu_FseProbTableIndex_Unused/Repeat/MinRLE - MaxRLE
+    uint32_t fseTableIndexHufW; //< Can be an in range defined by 'zstdgpu_ComputeFseIndexHufW' or kzstdgpu_FseProbTableIndex_Unused/Repeat
+    uint32_t fseTableIndexLLen; //< Can be an in range [0; 255] - meaning RLE, or in range defined by 'zstdgpu_ComputeFseIndexLLen' or kzstdgpu_FseProbTableIndex_Unused/Repeat
+    uint32_t fseTableIndexOffs; //< Can be an in range [0; 255] - meaning RLE, or in range defined by 'zstdgpu_ComputeFseIndexOffs' or kzstdgpu_FseProbTableIndex_Unused/Repeat
+    uint32_t fseTableIndexMLen; //< Can be an in range [0; 255] - meaning RLE, or in range defined by 'zstdgpu_ComputeFseIndexMLen' or kzstdgpu_FseProbTableIndex_Unused/Repeat
 } zstdgpu_CompressedBlockData;
 
 static inline void zstdgpu_Init_CompressedBlockData(ZSTDGPU_PARAM_INOUT(zstdgpu_CompressedBlockData) outBlockData)
@@ -1452,6 +1511,10 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
         if (maxThreads < kzstdgpu_FseDefaultProbCount_MLen)
             maxThreads = kzstdgpu_FseDefaultProbCount_MLen;
 
+        // should be sufficient for RLE FSE table entries
+        if (maxThreads < kzstdgpu_FseRleTableCount)
+            maxThreads = kzstdgpu_FseRleTableCount;
+
         // should be sufficient to initialize PerFrameSeqStreamMinIdx
         if (maxThreads < frameCount)
             maxThreads = frameCount;
@@ -1511,7 +1574,11 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
     ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameBlockSizesRLE         , 15)    \
     ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameSeqStreamMinIdx       , 16)   \
     ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , SeqCountPrefixLookback        , 17)   \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , BlockSeqCountPrefixLookback   , 18)
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , BlockSeqCountPrefixLookback   , 18)   \
+    \
+    ZSTDGPU_RW_TYPED_BUFFER_DECL(uint32_t, uint8_t              , FseSymbols                    , 19)   \
+    ZSTDGPU_RW_TYPED_BUFFER_DECL(uint32_t, uint8_t              , FseBitcnts                    , 20)   \
+    ZSTDGPU_RW_TYPED_BUFFER_DECL(uint32_t, uint16_t             , FseNStates                    , 21)
 
 #define ZSTDGPU_PARSE_COMPRESSED_BLOCKS_SRT()                                                           \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , CompressedData                , 0)    \
@@ -1738,6 +1805,8 @@ typedef struct zstdgpu_InitFseTable_SRT
 {
     ZSTDGPU_INIT_FSE_TABLE_SRT()
     uint32_t    tableStartIndex;
+    uint32_t    tableDataStart;
+    uint32_t    tableDataCount;
 } zstdgpu_InitFseTable_SRT;
 
 typedef struct zstdgpu_DecompressHuffmanWeights_SRT

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -570,23 +570,31 @@ static void zstdgpu_Validate_GpuDecompressOnCpu(zstdgpu_ResourceDataCpu & zstdCp
         zstdgpu_Init_InitFseTable_SRT(srt, zstdCpu);
 
         srt.tableStartIndex = 0;
+        srt.tableDataStart  = zstdgpu_ComputeFseDataStartHufW(0, zstdCmpBlockCount);
+        srt.tableDataCount  = kzstdgpu_FseElemMaxCount_HufW;
         for (uint32_t i = 0; i < CNTRS(FseHufW); ++i)
         {
             zstdgpu_ShaderEntry_InitFseTable(srt, i, 0);
         }
 
         srt.tableStartIndex += zstdCmpBlockCount;
+        srt.tableDataStart  = zstdgpu_ComputeFseDataStartLLen(0, zstdCmpBlockCount);
+        srt.tableDataCount  = kzstdgpu_FseElemMaxCount_LLen;
         for (uint32_t i = 0; i < CNTRS(FseLLen); ++i)
         {
             zstdgpu_ShaderEntry_InitFseTable(srt, i, 0);
         }
 
         srt.tableStartIndex += zstdCmpBlockCount + 1;
+        srt.tableDataStart  = zstdgpu_ComputeFseDataStartOffs(0, zstdCmpBlockCount);
+        srt.tableDataCount  = kzstdgpu_FseElemMaxCount_Offs;
         for (uint32_t i = 0; i < CNTRS(FseOffs); ++i)
         {
             zstdgpu_ShaderEntry_InitFseTable(srt, i, 0);
         }
         srt.tableStartIndex += zstdCmpBlockCount + 1;
+        srt.tableDataStart  = zstdgpu_ComputeFseDataStartMLen(0, zstdCmpBlockCount);
+        srt.tableDataCount  = kzstdgpu_FseElemMaxCount_MLen;
         for (uint32_t i = 0; i < CNTRS(FseMLen); ++i)
         {
             zstdgpu_ShaderEntry_InitFseTable(srt, i, 0);


### PR DESCRIPTION
This PR adds 256 1-element entries for RLE FSE tables at the beginning of the buffer storing FSE tables, this helps to reduce code divergence and unblocks possibility of merging 3 buffers storing FSE table fields into a single buffer. Additionally, the PR reduces the size of maximal storage for FSE tables by limiting FSE tables for Offsets to 256 entries.