### PR TITLE
Address several correctness issues and simplifies sequence execution

### DIFF
--- a/zstd/zstdgpu/Shaders/ZstdGpuExecuteSequences.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuExecuteSequences.hlsl
@@ -24,7 +24,7 @@ ZSTDGPU_EXECUTE_SEQUENCES_SRT()
 #define MAX_COPY_SIZE 32
 #endif
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=13), UAV(u0, numDescriptors=1))")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=12), UAV(u0, numDescriptors=2))")]
 [numthreads(MAX_COPY_SIZE, 1, 1)]
 void main(uint groupId : SV_GroupId, uint i : SV_GroupThreadId)
 {
@@ -34,5 +34,5 @@ void main(uint groupId : SV_GroupId, uint i : SV_GroupThreadId)
     ZSTDGPU_EXECUTE_SEQUENCES_SRT()
     #include "../zstdgpu_srt_decl_undef.h"
 
-    zstdgpu_ShaderEntry_ExecuteSequences(srt, groupId, i, MAX_COPY_SIZE);
+    zstdgpu_ShaderEntry_ExecuteSequences(srt);
 }

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -1115,6 +1115,21 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithInteralMemory(zstdgpu_PerRequestContext r
     }                                                                                   \
     while(0)
 
+#define setResourceSrvCopyIndirectToUavSync(barriers, index, resource)                  \
+    do                                                                                  \
+    {                                                                                   \
+        const uint32_t slot = (index);                                                  \
+        barriers[slot].Type                    = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;\
+        barriers[slot].Flags                   = D3D12_RESOURCE_BARRIER_FLAG_NONE;      \
+        barriers[slot].Transition.pResource    = resource;                              \
+        barriers[slot].Transition.Subresource  = 0;                                     \
+        barriers[slot].Transition.StateBefore  = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE\
+                                               | D3D12_RESOURCE_STATE_COPY_SOURCE       \
+                                               | D3D12_RESOURCE_STATE_INDIRECT_ARGUMENT;\
+        barriers[slot].Transition.StateAfter   = D3D12_RESOURCE_STATE_UNORDERED_ACCESS; \
+    }                                                                                   \
+    while(0)
+
 #define setResourceUavToSrvCopyIndirectSync(barriers, index, resource)                  \
     do                                                                                  \
     {                                                                                   \
@@ -1945,6 +1960,24 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     }
     if (req->zstdCmpBlockCount > 0)
     {
+        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier with Resources for [Execute Sequences]");
+        D3D12_RESOURCE_BARRIER barriers[2];
+        uint32_t bc = 0;
+        if (req->zstdRawByteCount > 0 || req->zstdRleByteCount > 0)
+        {
+            // in case if the number of RAW+RLE blocks > 0, [Memcpy RAW blocks, Memset RLE blocks] has written to 'UnCompressedFramesData'
+            // next read by [Execute Sequences]
+            setResourceUavSync(barriers, bc + 0, req->resData.gpuOnly.UnCompressedFramesData);
+            bc += 1;
+        }
+        // next written by [Execute Sequences] when allocating
+        setResourceSrvCopyIndirectToUavSync(barriers, bc + 0, req->resData.gpuOnly.Counters);
+
+        cmdList->ResourceBarrier(_countof(barriers), barriers);
+        PIXEndEvent(cmdList);
+    }
+    if (req->zstdCmpBlockCount > 0)
+    {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Execute Sequences]");
         BIND_RS_PS_SRT(ExecuteSequences);
 
@@ -1969,7 +2002,7 @@ ZSTDGPU_API void zstdgpu_ReadbackGpuResults(zstdgpu_PerRequestContext req, ID3D1
     // NOTE(pamartis): these are required to make sure D3D12 validation doesn't complain about state mismatch when
     // Read-only resource from the last stage get a NON_PS_RESOURCE state as a result of promotion from COMMON state
     // and then used as COPY_SOURCE for debug readback
-    D3D12_RESOURCE_BARRIER barriers[13];
+    D3D12_RESOURCE_BARRIER barriers[14];
     uint32_t bc = 0;
     setResourceState(barriers, 0, req->resData.gpuOnly.PerFrameBlockCountCMP, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
     setResourceState(barriers, 1, req->resData.gpuOnly.PerFrameBlockCountAll, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
@@ -1981,7 +2014,8 @@ ZSTDGPU_API void zstdgpu_ReadbackGpuResults(zstdgpu_PerRequestContext req, ID3D1
     {
         setResourceState(barriers, bc + 0, req->resData.gpuOnly.GlobalBlockIndexPerCmpBlock, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
         setResourceState(barriers, bc + 1, req->resData.gpuOnly.PerSeqStreamSeqStart, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
-        bc += 2;
+        setResourceUavToSrvCopyIndirectSync(barriers, bc + 2, req->resData.gpuOnly.Counters);
+        bc += 3;
     }
     if (req->zstdRawBlockCount > 0)
     {

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -1972,8 +1972,9 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         }
         // next written by [Execute Sequences] when allocating
         setResourceSrvCopyIndirectToUavSync(barriers, bc + 0, req->resData.gpuOnly.Counters);
+        bc += 1;
 
-        cmdList->ResourceBarrier(_countof(barriers), barriers);
+        cmdList->ResourceBarrier(bc, barriers);
         PIXEndEvent(cmdList);
     }
     if (req->zstdCmpBlockCount > 0)

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -4053,70 +4053,169 @@ static void zstdgpu_ShaderEntry_FinaliseSequenceOffsets(ZSTDGPU_PARAM_INOUT(zstd
     srt.inoutDecompressedSequenceOffs[seqIdx] = offset;
 }
 
-static uint32_t zstdgpu_MatchLengthCopy(ZSTDGPU_RW_TYPED_BUFFER(uint32_t, uint8_t) outData, uint32_t outByteIdx, uint32_t outByteEnd, uint32_t seqOffs, uint32_t seqMLen, uint32_t i, uint32_t seqIdx, uint32_t maxCopySize, ZSTDGPU_PARAM_INOUT(uint32_t) readableOutputGlobalEnd)
+static void zstdgpu_MemSet(ZSTDGPU_RW_TYPED_BUFFER(uint32_t, uint8_t) dstData,
+                           ZSTDGPU_PARAM_INOUT(uint32_t) dstOfs,
+                           uint32_t srcSym,
+                           uint32_t srcCnt,
+                           uint32_t dstEnd //< NOTE(pamartis): this one is passed for safety clamp, could be ignored
+                           )
 {
-    ZSTDGPU_UNUSED(i);
-    ZSTDGPU_UNUSED(seqIdx);
-    ZSTDGPU_UNUSED(maxCopySize); //< NOTE(pamartis): Unused only on CPP side.
+    uint32_t dstI = dstOfs + WaveGetLaneIndex();
 
-    // NOTE(jweinste): Avoid waits on UAV stores when llen and mlen are small and match offset is large.
-    // This check may be inaccurate, but it should be conservative.
-    const uint32_t toReadNowGlobalEnd = (outByteIdx - seqOffs) + seqMLen;
-    if (readableOutputGlobalEnd < toReadNowGlobalEnd) // these values should be workgroup-uniform
+    dstOfs += srcCnt;
+    dstEnd = zstdgpu_MinU32(dstEnd, dstOfs);
+
+    ZSTDGPU_LOOP for (; dstI < dstEnd; dstI += WaveGetLaneCount())
     {
-        DeviceMemoryBarrierWithGroupSync();
-        readableOutputGlobalEnd = outByteIdx;
+        zstdgpu_TypedStoreU8(dstData, dstI, srcSym);
     }
+}
 
-    // NOTE(pamartis): when offset is large enough to fit the entire length, we do as wide copy as possible
-    if (seqOffs >= seqMLen)
+static void zstdgpu_MemCpy_DstSrc(ZSTDGPU_RW_TYPED_BUFFER(uint32_t, uint8_t) dstData,
+                                  ZSTDGPU_PARAM_INOUT(uint32_t) dstOfs,
+                                  ZSTDGPU_RO_TYPED_BUFFER(uint32_t, uint8_t) srcData,
+                                  ZSTDGPU_PARAM_INOUT(uint32_t) srcOfs,
+                                  uint32_t srcCnt,
+                                  uint32_t dstEnd //< NOTE(pamartis): this one is passed for safety clamp, could be ignored
+                                  )
+{
+    uint32_t dstI = dstOfs + WaveGetLaneIndex();
+    uint32_t srcI = srcOfs + WaveGetLaneIndex();
+
+    dstOfs += srcCnt;
+    srcOfs += srcCnt;
+    dstEnd = zstdgpu_MinU32(dstEnd, dstOfs);
+
+    ZSTDGPU_LOOP for (; dstI < dstEnd; dstI += WaveGetLaneCount(), srcI += WaveGetLaneCount())
     {
-        const uint32_t copyLen = zstdgpu_MinU32(outByteEnd - outByteIdx, seqMLen);
-        ZSTDGPU_FOR_WORK_ITEMS(byteIdx, copyLen, i, maxCopySize)
-        {
-            outData[outByteIdx + byteIdx] = outData[outByteIdx + byteIdx - seqOffs];
-        }
+        zstdgpu_TypedStoreU8(dstData, dstI, srcData[srcI]);
+    }
+}
 
-        outByteIdx += copyLen;
+static void zstdgpu_MemCpy_DstOfs(ZSTDGPU_RW_TYPED_BUFFER(uint32_t, uint8_t) dstData,
+                                  ZSTDGPU_PARAM_INOUT(uint32_t) dstOfs,
+                                  uint32_t srcOfs,
+                                  uint32_t srcCnt,
+                                  uint32_t dstEnd  //< NOTE(pamartis): this one is passed for safety clamp, could be ignored
+                                  )
+{
+    ZSTDGPU_BRANCH if (srcOfs >= WaveGetLaneCount())
+    {
+        uint32_t dstI = dstOfs + WaveGetLaneIndex();
+        dstOfs += srcCnt;
+        dstEnd = zstdgpu_MinU32(dstEnd, dstOfs); //< NOTE(pamartis): could skip min
+
+        ZSTDGPU_LOOP for (; dstI < dstEnd; dstI += WaveGetLaneCount())
+        {
+            zstdgpu_TypedStoreU8(dstData, dstI, dstData[dstI - srcOfs]);
+        }
     }
     else
     {
-        // NOTE(pamartis): when offset is short, so match length overlaps with the destination start
-        // we copy 'offs' bytes at a time, except the last copy which copes `mlen % offs` bytes.
-        //
-        // We don't compute `mlen % offs` to avoid expensive integer divsion and instead use `len` variable to track
-        // the start of the copy and use `min(mlen - len, offs)` to make sure last copy is exact.
-        uint32_t len = 0;
-        do
+        const uint32_t laneId = WaveGetLaneIndex();
+
+        // NOTE(pamartis): the case 'srcOfs' is short, so we can't start writing 'WaveGetLaneCount' chunks at a time...
+        // Therefore, we fetch 'srcOffs' bytes ...
+        uint32_t srcSym = 0;
+        ZSTDGPU_BRANCH if (laneId < srcOfs)
         {
-            const uint32_t copyLen = zstdgpu_MinU32(outByteEnd - outByteIdx, zstdgpu_MinU32(seqMLen - len, seqOffs));
-            ZSTDGPU_FOR_WORK_ITEMS(byteIdx, copyLen, i, maxCopySize)
-            {
-                outData[outByteIdx + byteIdx] = outData[outByteIdx + byteIdx - seqOffs];
-            }
-            DeviceMemoryBarrierWithGroupSync();
-
-            outByteIdx += copyLen;
-            len += copyLen;
+            srcSym = dstData[dstOfs + laneId - srcOfs];
         }
-        while (len < seqMLen);
-        readableOutputGlobalEnd = outByteIdx; // see barrier in do...while
-    }
 
-    return outByteIdx;
+        // .. and construct a chunk of memory of size 'WaveGetLaneCount() - WaveGetLaneCount % srcOfs' where
+        // 'srcOfs' bytes are repeated 'WaveGetLaneCount() / srcOfs' times.
+        // The purpose of that -- is to construct the widest chunk possible that we can repeat copying by the entire wave
+        ZSTDGPU_BRANCH if (srcOfs <= WaveGetLaneCount() / 2)
+        {
+            srcSym = WaveReadLaneAt(srcSym, laneId % srcOfs); //< NOTE(pamartis): We could replace 'mod' operation by Lemire'19 approach and precomputing up to 128 constants..
+        }
+
+        const uint32_t copySize = WaveGetLaneCount() - WaveGetLaneCount() % srcOfs;
+
+        uint32_t dstI = dstOfs + laneId;
+        dstOfs += srcCnt;
+        dstEnd = zstdgpu_MinU32(dstEnd, dstOfs); //< NOTE(pamartis): could skip min
+
+        ZSTDGPU_BRANCH if (laneId < copySize)
+        {
+            ZSTDGPU_LOOP for (; dstI < dstEnd; dstI += copySize)
+            {
+                zstdgpu_TypedStoreU8(dstData, dstI, srcSym);
+            }
+        }
+    }
 }
 
-static void zstdgpu_ShaderEntry_ExecuteSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_ExecuteSequences_SRT) srt, uint32_t groupId, uint32_t i, uint32_t maxCopySize)
+/**
+ *  NOTE(pamartis): This function exists solely to allow calling the same code and passing different 'litBuf'
+ *                  from different condition:
+ *
+ *      if (conditionA)
+ *      {
+ *          function( bufferA );
+ *      }
+ *      else if (conditionB)
+ *      {
+ *          function( bufferB );
+ *      }
+ *
+ *  because HLSL doesn't allow to create temporal reference to global resource and produces:
+ *      'error G96E47425: local resource not guaranteed to map to unique global resource'
+ *      as of (dxcompiler.dll: 1.9 - 1.8.2505.32 (b106a961d); dxil.dll: 1.9(1.8.2505.32))
+ *
+ *  when trying to write the code like this:
+ *
+ *      if (conditionA || conditionB)
+ *      {
+ *          function( WaveReadLaneFirst(conditionA) != 0 ? bufferA : bufferB );
+ *      }
+ */
+static void zstdgpu_ExecuteSequences_Lit(ZSTDGPU_PARAM_INOUT(zstdgpu_ExecuteSequences_SRT) srt,
+                                         ZSTDGPU_RO_TYPED_BUFFER(uint32_t, uint8_t) litBuf,
+                                         uint32_t litOfs,
+                                         uint32_t litEnd,
+                                         uint32_t dstOfs,
+                                         uint32_t dstEnd,
+                                         uint32_t seqIdx,
+                                         uint32_t seqEnd)
 {
-    const uint32_t seqStreamCnt = srt.inCounters[kzstdgpu_CounterIndex_Seq_Streams];
+    // NOTE(pamartis): LOOP is used to make sure validation layer doesn't complain about accessing `inDecompressedSequence*`
+    ZSTDGPU_LOOP for (; seqIdx < seqEnd; ++seqIdx)
+    {
+        // NOTE(pamartis): these are still uniform variables HLSL has no way of enforcing....
+        const uint32_t mlen = srt.inDecompressedSequenceMLen[seqIdx];
+        const uint32_t llen = srt.inDecompressedSequenceLLen[seqIdx];
+        const uint32_t offs = srt.inDecompressedSequenceOffs[seqIdx];
 
-    const uint32_t frameCnt = srt.inCounters[kzstdgpu_CounterIndex_Frames];
-    const uint32_t frameIdx = groupId;
+        zstdgpu_MemCpy_DstSrc(srt.inoutUnCompressedFramesData, dstOfs, litBuf, litOfs, llen, dstEnd);
+        zstdgpu_MemCpy_DstOfs(srt.inoutUnCompressedFramesData, dstOfs, offs, mlen, dstEnd);
+    }
+
+    // NOTE(pamartis): copy remaining literals. If there's no sequences, we copy the entire literal block.
+    ZSTDGPU_ASSERT(litEnd - litOfs == dstEnd - dstOfs);
+    zstdgpu_MemCpy_DstSrc(srt.inoutUnCompressedFramesData, dstOfs, litBuf, litOfs, litEnd - litOfs, dstEnd);
+}
+
+static void zstdgpu_ShaderEntry_ExecuteSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_ExecuteSequences_SRT) srt)
+{
+    const uint32_t seqStreamCnt = srt.inoutCounters[kzstdgpu_CounterIndex_Seq_Streams];
+
+    const uint32_t frameCnt = srt.inoutCounters[kzstdgpu_CounterIndex_Frames];
+
+    uint32_t frameIdx = 0;
+    if (WaveIsFirstLane())
+    {
+        InterlockedAdd(srt.inoutCounters[kzstdgpu_CounterIndex_Frames_ExecuteSequences], 1, frameIdx);
+    }
+    frameIdx = WaveReadLaneFirst(frameIdx);
+
+    if (frameIdx >= frameCnt)
+        return;
 
     const uint32_t cmpBlockBeg = srt.inPerFrameBlockCountCMP[frameIdx];
     const uint32_t cmpBlockEnd = (frameIdx + 1u < frameCnt)
                                ? srt.inPerFrameBlockCountCMP[frameIdx + 1u]
-                               : srt.inCounters[kzstdgpu_CounterIndex_Blocks_CMP];
+                               : srt.inoutCounters[kzstdgpu_CounterIndex_Blocks_CMP];
 
     const uint32_t firstFrameBlockIdx = srt.inPerFrameBlockCountAll[frameIdx];
 
@@ -4129,8 +4228,6 @@ static void zstdgpu_ShaderEntry_ExecuteSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_Exe
     }
 
     const zstdgpu_OffsetAndSize dstFrameOffsAndSize = srt.inUnCompressedFramesRefs[frameIdx];
-
-    uint32_t readableOutputGlobalEnd = 0;
 
     for (uint32_t cmpBlockIdx = cmpBlockBeg; cmpBlockIdx < cmpBlockEnd; ++cmpBlockIdx)
     {
@@ -4170,7 +4267,7 @@ static void zstdgpu_ShaderEntry_ExecuteSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_Exe
 
             ZSTDGPU_BRANCH if (seqStreamIdx + 1u == seqStreamCnt)
             {
-                seqEnd = srt.inCounters[kzstdgpu_CounterIndex_Seq_Streams_DecodedItems];
+                seqEnd = srt.inoutCounters[kzstdgpu_CounterIndex_Seq_Streams_DecodedItems];
             }
             else
             {
@@ -4178,75 +4275,17 @@ static void zstdgpu_ShaderEntry_ExecuteSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_Exe
             }
         }
 
-        const uint32_t litType = zstdgpu_DecodeLitOffsetType(literal.offs);
+        const uint32_t litType = WaveReadLaneFirst(zstdgpu_DecodeLitOffsetType(literal.offs));
         const uint32_t litOffs = zstdgpu_DecodeLitOffset(literal.offs);
         const uint32_t litSize = literal.size;
 
         if (zstdgpu_CheckLitOffsetTypeCmp(litType))
         {
-            uint32_t blockByteCur = blockByteBeg;
-            uint32_t litCur = litOffs;
-
-                // NOTE(pamartis): LOOP is used to make sure validation layer doesn't complain about accessing `inDecompressedSequence*`
-                ZSTDGPU_LOOP for (uint32_t seqIdx = seqOfs; seqIdx < seqEnd; ++seqIdx)
-                {
-                    // NOTE(pamartis): these are still uniform variables HLSL has no way of enforcing....
-                    const uint32_t mlen = srt.inDecompressedSequenceMLen[seqIdx];
-                    const uint32_t llen = srt.inDecompressedSequenceLLen[seqIdx];
-                    const uint32_t offs = srt.inDecompressedSequenceOffs[seqIdx];
-
-                    const uint32_t copyLen = zstdgpu_MinU32(blockByteEnd - blockByteCur, llen);
-                    ZSTDGPU_FOR_WORK_ITEMS(byteIdx, copyLen, i, maxCopySize)
-                    {
-                        srt.inoutUnCompressedFramesData[blockByteCur + byteIdx] = srt.inDecompressedLiterals[litCur + byteIdx];
-                    }
-                    blockByteCur += copyLen;
-                    litCur += copyLen;
-
-                    blockByteCur = zstdgpu_MatchLengthCopy(srt.inoutUnCompressedFramesData, blockByteCur, blockByteEnd, offs, mlen, i, seqIdx, maxCopySize, readableOutputGlobalEnd);
-                }
-
-            // NOTE(pamartis): copy remaining literals. If above condtion `seqStreamIdx == ~0u` is true,
-            // it means meaning there's no sequences, we copy the entire literal block.
-            ZSTDGPU_ASSERT(litOffs + litSize - litCur == blockByteEnd - blockByteCur);
-            ZSTDGPU_FOR_WORK_ITEMS(byteIdx, zstdgpu_MinU32(litOffs + litSize - litCur, blockByteEnd - blockByteCur), i, maxCopySize)
-            {
-                srt.inoutUnCompressedFramesData[blockByteCur + byteIdx] = srt.inDecompressedLiterals[litCur + byteIdx];
-            }
+            zstdgpu_ExecuteSequences_Lit(srt, srt.inDecompressedLiterals, litOffs, litOffs + litSize, blockByteBeg, blockByteEnd, seqOfs, seqEnd);
         }
         else if (zstdgpu_CheckLitOffsetTypeRaw(litType))
         {
-            uint32_t blockByteCur = blockByteBeg;
-            uint32_t litCur = litOffs;
-
-                // NOTE(pamartis): LOOP is used to make sure validation layer doesn't complain about accessing `inDecompressedSequence*`
-                ZSTDGPU_LOOP for (uint32_t seqIdx = seqOfs; seqIdx < seqEnd; ++seqIdx)
-                {
-                    // NOTE(pamartis): these are still uniform variables HLSL has no way of enforcing....
-                    const uint32_t mlen = srt.inDecompressedSequenceMLen[seqIdx];
-                    const uint32_t llen = srt.inDecompressedSequenceLLen[seqIdx];
-                    const uint32_t offs = srt.inDecompressedSequenceOffs[seqIdx];
-                    const uint32_t copyLen = zstdgpu_MinU32(blockByteEnd - blockByteCur, llen);
-
-                    ZSTDGPU_FOR_WORK_ITEMS(byteIdx, copyLen, i, maxCopySize)
-                    {
-                        const uint32_t byteOfs = litCur + byteIdx;
-                        srt.inoutUnCompressedFramesData[blockByteCur + byteIdx] = (srt.inCompressedData[byteOfs >> 2] >> ((byteOfs & 3u) << 3u)) & 0xffu;
-                    }
-                    blockByteCur += copyLen;
-                    litCur += copyLen;
-
-                    blockByteCur = zstdgpu_MatchLengthCopy(srt.inoutUnCompressedFramesData, blockByteCur, blockByteEnd, offs, mlen, i, seqIdx, maxCopySize, readableOutputGlobalEnd);
-                }
-
-            // NOTE(pamartis): copy remaining literals. If above condtion `seqStreamIdx == ~0u` is true,
-            // it means meaning there's no sequences, we copy the entire literal block.
-            ZSTDGPU_ASSERT(litOffs + litSize - litCur == blockByteEnd - blockByteCur);
-            ZSTDGPU_FOR_WORK_ITEMS(byteIdx, zstdgpu_MinU32(litOffs + litSize - litCur, blockByteEnd - blockByteCur), i, maxCopySize)
-            {
-                const uint32_t byteOfs = litCur + byteIdx;
-                srt.inoutUnCompressedFramesData[blockByteCur + byteIdx] = (srt.inCompressedData[byteOfs >> 2] >> ((byteOfs & 3u) << 3u)) & 0xffu;
-            }
+            zstdgpu_ExecuteSequences_Lit(srt, srt.inCompressedData, litOffs, litOffs + litSize, blockByteBeg, blockByteEnd, seqOfs, seqEnd);
         }
         else if (zstdgpu_CheckLitOffsetTypeRle(litType))
         {
@@ -4255,32 +4294,24 @@ static void zstdgpu_ShaderEntry_ExecuteSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_Exe
             uint32_t blockByteCur = blockByteBeg;
             uint32_t litCur = 0;
 
-                // NOTE(pamartis): LOOP is used to make sure validation layer doesn't complain about accessing `inDecompressedSequence*`
-                ZSTDGPU_LOOP for (uint32_t seqIdx = seqOfs; seqIdx < seqEnd; ++seqIdx)
-                {
-                    // NOTE(pamartis): these are still uniform variables HLSL has no way of enforcing....
-                    const uint32_t mlen = srt.inDecompressedSequenceMLen[seqIdx];
-                    const uint32_t llen = srt.inDecompressedSequenceLLen[seqIdx];
-                    const uint32_t offs = srt.inDecompressedSequenceOffs[seqIdx];
-                    const uint32_t copyLen = zstdgpu_MinU32(blockByteEnd - blockByteCur, llen);
+            // NOTE(pamartis): LOOP is used to make sure validation layer doesn't complain about accessing `inDecompressedSequence*`
+            ZSTDGPU_LOOP for (uint32_t seqIdx = seqOfs; seqIdx < seqEnd; ++seqIdx)
+            {
+                // NOTE(pamartis): these are still uniform variables HLSL has no way of enforcing....
+                const uint32_t mlen = srt.inDecompressedSequenceMLen[seqIdx];
+                const uint32_t llen = srt.inDecompressedSequenceLLen[seqIdx];
+                const uint32_t offs = srt.inDecompressedSequenceOffs[seqIdx];
 
-                    ZSTDGPU_FOR_WORK_ITEMS(byteIdx, copyLen, i, maxCopySize)
-                    {
-                        zstdgpu_TypedStoreU8(srt.inoutUnCompressedFramesData, blockByteCur + byteIdx, symbol);
-                    }
-                    blockByteCur += copyLen;
-                    litCur += copyLen;
-
-                    blockByteCur = zstdgpu_MatchLengthCopy(srt.inoutUnCompressedFramesData, blockByteCur, blockByteEnd, offs, mlen, i, seqIdx, maxCopySize, readableOutputGlobalEnd);
-                }
+                zstdgpu_MemSet(srt.inoutUnCompressedFramesData, blockByteCur, symbol, llen, blockByteEnd);
+                litCur += llen;
+                zstdgpu_MemCpy_DstOfs(srt.inoutUnCompressedFramesData, blockByteCur, offs, mlen, blockByteEnd);
+            }
 
             // NOTE(pamartis): copy remaining literals. If above condtion `seqStreamIdx == ~0u` is true,
             // it means meaning there's no sequences, we copy the entire literal block.
-            ZSTDGPU_ASSERT(litOffs + litSize - litCur == blockByteEnd - blockByteCur);
-            ZSTDGPU_FOR_WORK_ITEMS(byteIdx, zstdgpu_MinU32(litOffs + litSize - litCur, blockByteEnd - blockByteCur), i, maxCopySize)
-            {
-                zstdgpu_TypedStoreU8(srt.inoutUnCompressedFramesData, blockByteCur + byteIdx, symbol);
-            }
+            ZSTDGPU_ASSERT(litSize - litCur == blockByteEnd - blockByteCur);
+
+            zstdgpu_MemSet(srt.inoutUnCompressedFramesData, blockByteCur, symbol, litSize - litCur, blockByteEnd);
         }
 #endif
 

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -3731,30 +3731,28 @@ static void zstdgpu_ShaderEntry_DecompressSequences_LdsFseCache(ZSTDGPU_PARAM_IN
     #define ZSTDGPU_BACKWARD_BITBUF(method) zstdgpu_Backward_BitBuffer_V0_##method
     ZSTDGPU_BACKWARD_BITBUF(InitWithSegment)(bitBuffer, srt.inCompressedData, seqRef.src);
 
-    #define ZSTDGPU_INIT_FSE_STATE(name)                                                                    \
-        uint32_t state##name = 0;                                                                           \
-        {                                                                                                   \
-            const uint32_t initBitcnt = srt.inFseInfos[seqRef.fse##name].fseProbCountAndAccuracyLog2 >> 8;  \
-            state##name = ZSTDGPU_BACKWARD_BITBUF(Get)(bitBuffer, initBitcnt);                              \
-        }
+    const uint32_t initBitcntLLen = srt.inFseInfos[seqRef.fseLLen].fseProbCountAndAccuracyLog2 >> 8;
+    const uint32_t initBitcntOffs = srt.inFseInfos[seqRef.fseOffs].fseProbCountAndAccuracyLog2 >> 8;
+    const uint32_t initBitcntMLen = srt.inFseInfos[seqRef.fseMLen].fseProbCountAndAccuracyLog2 >> 8;
 
-    ZSTDGPU_INIT_FSE_STATE(LLen)
-    ZSTDGPU_INIT_FSE_STATE(Offs)
-    ZSTDGPU_INIT_FSE_STATE(MLen)
-    #undef ZSTDGPU_INIT_FSE_STATE
+    ZSTDGPU_BACKWARD_BITBUF(Refill)(bitBuffer, initBitcntLLen + initBitcntOffs + initBitcntMLen);
+
+    uint32_t stateLLen = ZSTDGPU_BACKWARD_BITBUF(GetNoRefill)(bitBuffer, initBitcntLLen);
+    uint32_t stateOffs = ZSTDGPU_BACKWARD_BITBUF(GetNoRefill)(bitBuffer, initBitcntOffs);
+    uint32_t stateMLen = ZSTDGPU_BACKWARD_BITBUF(GetNoRefill)(bitBuffer, initBitcntMLen);
 
         uint32_t i         = dst.offs;
     const uint32_t outputEnd = dst.offs + dst.size;
     for (;;)
     {
         #if !ZSTDGPU_DECOMPRESS_SEQUENCES_NO_LDS_FSE_CACHE
-        const uint32_t packedFseElemLLen = WaveReadLaneFirst(zstdgpu_LdsLoadU32(GS_FsePackedLLen + stateLLen));
-        const uint32_t packedFseElemOffs = WaveReadLaneFirst(zstdgpu_LdsLoadU32(GS_FsePackedOffs + stateOffs));
-        const uint32_t packedFseElemMLen = WaveReadLaneFirst(zstdgpu_LdsLoadU32(GS_FsePackedMLen + stateMLen));
+            const uint32_t packedFseElemLLen = zstdgpu_LdsLoadU32(GS_FsePackedLLen + stateLLen);
+            const uint32_t packedFseElemOffs = zstdgpu_LdsLoadU32(GS_FsePackedOffs + stateOffs);
+            const uint32_t packedFseElemMLen = zstdgpu_LdsLoadU32(GS_FsePackedMLen + stateMLen);
         #else
-        const uint32_t packedFseElemLLen = WaveReadLaneFirst(srt.inFseElems[startLLen + stateLLen]);
-        const uint32_t packedFseElemOffs = WaveReadLaneFirst(srt.inFseElems[startOffs + stateOffs]);
-        const uint32_t packedFseElemMLen = WaveReadLaneFirst(srt.inFseElems[startMLen + stateMLen]);
+            const uint32_t packedFseElemLLen = srt.inFseElems[startLLen + stateLLen];
+            const uint32_t packedFseElemOffs = srt.inFseElems[startOffs + stateOffs];
+            const uint32_t packedFseElemMLen = srt.inFseElems[startMLen + stateMLen];
         #endif
 
         uint32_t llen = 0, offs = 0, mlen = 0;

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -244,7 +244,9 @@
 #   endif
 #endif
 
-static const uint32_t kzstdgpu_MaxCount_LiteralBytes = 128u << 10u;
+static const uint32_t kzstdgpu_MaxCount_BlockSizeBits   = 17u;
+
+static const uint32_t kzstdgpu_MaxCount_LiteralBytes    = 1u << kzstdgpu_MaxCount_BlockSizeBits;
 
 static const uint32_t kzstdgpu_MaxCount_HuffmanWeights              = 256;
 #if 1 // ASSUME_11BIT_HUFFMAN_CODES
@@ -329,7 +331,8 @@ static const uint32_t kzstdgpu_CounterIndex_BlocksBytes_RLE = 40;
 
 static const uint32_t kzstdgpu_CounterIndex_Frames = 41;
 static const uint32_t kzstdgpu_CounterIndex_Frames_UncompressedByteSize = 42;
-static const uint32_t kzstdgpu_CounterIndex_Count = 43;
+static const uint32_t kzstdgpu_CounterIndex_Frames_ExecuteSequences = 43;
+static const uint32_t kzstdgpu_CounterIndex_Count = 44;
 
 // NOTE(pamartis):
 //      We use macro here to make sure we can use them to compile-out
@@ -455,6 +458,7 @@ static inline bool WaveIsFirstLane(void) { return true; }
 static inline uint32_t WaveActiveCountBits(bool bit) { return bit ? 1 : 0; }
 static inline uint32_t WavePrefixCountBits(bool bit) { (void)bit; return 0; }
 static inline uint32_t WaveGetLaneCount(void) { return 1; }
+static inline uint32_t WaveGetLaneIndex(void) { return 0; }
 static inline uint32_t4 WaveActiveBallot(bool b) { uint32_t4 mask = {}; mask.x = b ? 1 : 0; return mask; }
 static inline bool WaveActiveAnyTrue(bool bit) { return bit; }
 static inline bool WaveActiveAllTrue(bool bit) { return bit; }
@@ -1714,24 +1718,25 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
     ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , DecompressedSequenceOffs      , 0)
 
 #define ZSTDGPU_EXECUTE_SEQUENCES_SRT()                                                                 \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , Counters                      , 0)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , CompressedData                , 1)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , PerFrameBlockCountCMP         , 2)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , PerFrameBlockCountAll         , 3)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , BlockSizePrefix               , 4)    \
-    ZSTDGPU_RO_BUFFER_DECL(zstdgpu_OffsetAndSize                , UnCompressedFramesRefs        , 5)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , DecompressedSequenceLLen      , 6)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , DecompressedSequenceMLen      , 7)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , DecompressedSequenceOffs      , 8)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , GlobalBlockIndexPerCmpBlock   , 9)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , PerSeqStreamSeqStart          ,10)    \
-    ZSTDGPU_RO_BUFFER_DECL(zstdgpu_CompressedBlockData          , CompressedBlocks              ,11)    \
+    ZSTDGPU_RO_TYPED_BUFFER_DECL(uint32_t, uint8_t              , CompressedData                , 0)    \
     \
-    ZSTDGPU_RO_TYPED_BUFFER_DECL(uint32_t, uint8_t              , DecompressedLiterals          ,12)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , PerFrameBlockCountCMP         , 1)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , PerFrameBlockCountAll         , 2)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , BlockSizePrefix               , 3)    \
+    ZSTDGPU_RO_BUFFER_DECL(zstdgpu_OffsetAndSize                , UnCompressedFramesRefs        , 4)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , DecompressedSequenceLLen      , 5)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , DecompressedSequenceMLen      , 6)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , DecompressedSequenceOffs      , 7)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , GlobalBlockIndexPerCmpBlock   , 8)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , PerSeqStreamSeqStart          , 9)    \
+    ZSTDGPU_RO_BUFFER_DECL(zstdgpu_CompressedBlockData          , CompressedBlocks              ,10)    \
     \
-    ZSTDGPU_RW_TYPED_BUFFER_DECL(uint32_t, uint8_t              , UnCompressedFramesData        , 0)
+    ZSTDGPU_RO_TYPED_BUFFER_DECL(uint32_t, uint8_t              , DecompressedLiterals          ,11)    \
+    \
+    ZSTDGPU_RW_TYPED_BUFFER_DECL(uint32_t, uint8_t              , UnCompressedFramesData        , 0)    \
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , Counters                      , 1)
 
-#define ZSTDGPU_COMPUTE_DEST_SEQUENCE_OFFSETS_SRT()                                                                 \
+#define ZSTDGPU_COMPUTE_DEST_SEQUENCE_OFFSETS_SRT()                                                     \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , Counters                      , 0)    \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , PerFrameBlockCountAll         , 1)    \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , BlockSizePrefix               , 2)    \


### PR DESCRIPTION
This PR fixes several bugs:
- adds missing barrier between copying RAW/RLE blocks and sequence execution pass
- removes `WaveReadLaneFirst` applied to FSE element loads in `DecompressSequences_LdsFseCache` confusing some drivers.

also, this PR 

- simplifies match length copy path during sequence execution 
- switches to strict one wave per frame sequence execution by dynamically assigning waves to frames. Because D3D12 doesn't allow us to query actual number of waves per threadgroup and HLSL doesn't allow us to setup in the shader threadgroup size as a number of waves, we resort to dispatching the number of threadgroups equal to the number of frames on hardware with multiple supported wave sizes and the threadgroup size set to the largest supported wave size, so the number of waves launched could be higher than the number of frames, but due to dynamic assigning mechanism waves that have nothing to process -- terminate early, so the overhead is launching extra waves and having threadgroups containing multiple waves in the worst case.