### PR TITLE
ztsd: Do maximal width stores for overlapping match-copies. Refactors.

### DIFF
--- a/zstd/zstdgpu/Shaders/ZstdGpuExecuteSequences.hlsli
+++ b/zstd/zstdgpu/Shaders/ZstdGpuExecuteSequences.hlsli
@@ -20,10 +20,6 @@
 ZSTDGPU_EXECUTE_SEQUENCES_SRT()
 #include "../zstdgpu_srt_decl_undef.h"
 
-#ifndef MAX_COPY_SIZE
-#define MAX_COPY_SIZE 32
-#endif
-
 [RootSignature("DescriptorTable(SRV(t0, numDescriptors=12), UAV(u0, numDescriptors=2))")]
 [numthreads(MAX_COPY_SIZE, 1, 1)]
 void main(uint groupId : SV_GroupId, uint i : SV_GroupThreadId)

--- a/zstd/zstdgpu/Shaders/ZstdGpuExecuteSequences128.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuExecuteSequences128.hlsl
@@ -15,4 +15,4 @@
  */
 
 #define MAX_COPY_SIZE 128
-#include "ZstdGpuExecuteSequences.hlsl"
+#include "ZstdGpuExecuteSequences.hlsli"

--- a/zstd/zstdgpu/Shaders/ZstdGpuExecuteSequences32.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuExecuteSequences32.hlsl
@@ -15,4 +15,4 @@
  */
 
 #define MAX_COPY_SIZE 32
-#include "ZstdGpuExecuteSequences.hlsl"
+#include "ZstdGpuExecuteSequences.hlsli"

--- a/zstd/zstdgpu/Shaders/ZstdGpuExecuteSequences64.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuExecuteSequences64.hlsl
@@ -15,4 +15,4 @@
  */
 
 #define MAX_COPY_SIZE 64
-#include "ZstdGpuExecuteSequences.hlsl"
+#include "ZstdGpuExecuteSequences.hlsli"

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -4051,6 +4051,22 @@ static void zstdgpu_ShaderEntry_FinaliseSequenceOffsets(ZSTDGPU_PARAM_INOUT(zstd
     srt.inoutDecompressedSequenceOffs[seqIdx] = offset;
 }
 
+struct zstdgpu_Sequence
+{
+    uint32_t mlen;
+    uint32_t llen;
+    uint32_t offs;
+};
+
+static zstdgpu_Sequence zstdgpu_LoadSequence(ZSTDGPU_PARAM_INOUT(zstdgpu_ExecuteSequences_SRT) srt, uint32_t seqIdx)
+{
+    zstdgpu_Sequence seq;
+    seq.mlen = srt.inDecompressedSequenceMLen[seqIdx];
+    seq.llen = srt.inDecompressedSequenceLLen[seqIdx];
+    seq.offs = srt.inDecompressedSequenceOffs[seqIdx];
+    return seq;
+}
+
 static void zstdgpu_MemSet(ZSTDGPU_RW_TYPED_BUFFER(uint32_t, uint8_t) dstData,
                            ZSTDGPU_PARAM_INOUT(uint32_t) dstOfs,
                            uint32_t srcSym,
@@ -4090,48 +4106,47 @@ static void zstdgpu_MemCpy_DstSrc(ZSTDGPU_RW_TYPED_BUFFER(uint32_t, uint8_t) dst
     }
 }
 
-static void zstdgpu_MemCpy_DstOfs(ZSTDGPU_RW_TYPED_BUFFER(uint32_t, uint8_t) dstData,
-                                  ZSTDGPU_PARAM_INOUT(uint32_t) dstOfs,
-                                  uint32_t srcOfs,
-                                  uint32_t srcCnt,
-                                  uint32_t dstEnd  //< NOTE(pamartis): this one is passed for safety clamp, could be ignored
-                                  )
+static void zstdgpu_MatchCopy(ZSTDGPU_RW_TYPED_BUFFER(uint32_t, uint8_t) dstData,
+                              ZSTDGPU_PARAM_INOUT(uint32_t) dstOfs,
+                              zstdgpu_Sequence seq,
+                              uint32_t dstEnd  //< NOTE(pamartis): this one is passed for safety clamp, could be ignored
+                              )
 {
-    ZSTDGPU_BRANCH if (srcOfs >= WaveGetLaneCount())
+    ZSTDGPU_BRANCH if (seq.offs >= WaveGetLaneCount())
     {
         uint32_t dstI = dstOfs + WaveGetLaneIndex();
-        dstOfs += srcCnt;
+        dstOfs += seq.mlen;
         dstEnd = zstdgpu_MinU32(dstEnd, dstOfs); //< NOTE(pamartis): could skip min
 
         ZSTDGPU_LOOP for (; dstI < dstEnd; dstI += WaveGetLaneCount())
         {
-            zstdgpu_TypedStoreU8(dstData, dstI, dstData[dstI - srcOfs]);
+            zstdgpu_TypedStoreU8(dstData, dstI, dstData[dstI - seq.offs]);
         }
     }
     else
     {
         const uint32_t laneId = WaveGetLaneIndex();
 
-        // NOTE(pamartis): the case 'srcOfs' is short, so we can't start writing 'WaveGetLaneCount' chunks at a time...
-        // Therefore, we fetch 'srcOffs' bytes ...
+        // NOTE(pamartis): the case 'seq.offs' is short, so we can't start writing 'WaveGetLaneCount' chunks at a time...
+        // Therefore, we fetch 'seq.offs' bytes ...
         uint32_t srcSym = 0;
-        ZSTDGPU_BRANCH if (laneId < srcOfs)
+        ZSTDGPU_BRANCH if (laneId < seq.offs)
         {
-            srcSym = dstData[dstOfs + laneId - srcOfs];
+            srcSym = dstData[dstOfs + laneId - seq.offs];
         }
 
-        // .. and construct a chunk of memory of size 'WaveGetLaneCount() - WaveGetLaneCount % srcOfs' where
-        // 'srcOfs' bytes are repeated 'WaveGetLaneCount() / srcOfs' times.
+        // .. and construct a chunk of memory of size 'WaveGetLaneCount() - WaveGetLaneCount % seq.offs' where
+        // 'seq.offs' bytes are repeated 'WaveGetLaneCount() / seq.offs' times.
         // The purpose of that -- is to construct the widest chunk possible that we can repeat copying by the entire wave
-        ZSTDGPU_BRANCH if (srcOfs <= WaveGetLaneCount() / 2)
+        ZSTDGPU_BRANCH if (seq.offs <= WaveGetLaneCount() / 2)
         {
-            srcSym = WaveReadLaneAt(srcSym, laneId % srcOfs); //< NOTE(pamartis): We could replace 'mod' operation by Lemire'19 approach and precomputing up to 128 constants..
+            srcSym = WaveReadLaneAt(srcSym, laneId % seq.offs); //< NOTE(pamartis): We could replace 'mod' operation by Lemire'19 approach and precomputing up to 128 constants..
         }
 
-        const uint32_t copySize = WaveGetLaneCount() - WaveGetLaneCount() % srcOfs;
+        const uint32_t copySize = WaveGetLaneCount() - WaveGetLaneCount() % seq.offs;
 
         uint32_t dstI = dstOfs + laneId;
-        dstOfs += srcCnt;
+        dstOfs += seq.mlen;
         dstEnd = zstdgpu_MinU32(dstEnd, dstOfs); //< NOTE(pamartis): could skip min
 
         ZSTDGPU_BRANCH if (laneId < copySize)
@@ -4181,12 +4196,10 @@ static void zstdgpu_ExecuteSequences_Lit(ZSTDGPU_PARAM_INOUT(zstdgpu_ExecuteSequ
     ZSTDGPU_LOOP for (; seqIdx < seqEnd; ++seqIdx)
     {
         // NOTE(pamartis): these are still uniform variables HLSL has no way of enforcing....
-        const uint32_t mlen = srt.inDecompressedSequenceMLen[seqIdx];
-        const uint32_t llen = srt.inDecompressedSequenceLLen[seqIdx];
-        const uint32_t offs = srt.inDecompressedSequenceOffs[seqIdx];
+        zstdgpu_Sequence seq = zstdgpu_LoadSequence(srt, seqIdx);
 
-        zstdgpu_MemCpy_DstSrc(srt.inoutUnCompressedFramesData, dstOfs, litBuf, litOfs, llen, dstEnd);
-        zstdgpu_MemCpy_DstOfs(srt.inoutUnCompressedFramesData, dstOfs, offs, mlen, dstEnd);
+        zstdgpu_MemCpy_DstSrc(srt.inoutUnCompressedFramesData, dstOfs, litBuf, litOfs, seq.llen, dstEnd);
+        zstdgpu_MatchCopy(srt.inoutUnCompressedFramesData, dstOfs, seq, dstEnd);
     }
 
     // NOTE(pamartis): copy remaining literals. If there's no sequences, we copy the entire literal block.
@@ -4296,13 +4309,11 @@ static void zstdgpu_ShaderEntry_ExecuteSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_Exe
             ZSTDGPU_LOOP for (uint32_t seqIdx = seqOfs; seqIdx < seqEnd; ++seqIdx)
             {
                 // NOTE(pamartis): these are still uniform variables HLSL has no way of enforcing....
-                const uint32_t mlen = srt.inDecompressedSequenceMLen[seqIdx];
-                const uint32_t llen = srt.inDecompressedSequenceLLen[seqIdx];
-                const uint32_t offs = srt.inDecompressedSequenceOffs[seqIdx];
+                zstdgpu_Sequence seq = zstdgpu_LoadSequence(srt, seqIdx);
 
-                zstdgpu_MemSet(srt.inoutUnCompressedFramesData, blockByteCur, symbol, llen, blockByteEnd);
-                litCur += llen;
-                zstdgpu_MemCpy_DstOfs(srt.inoutUnCompressedFramesData, blockByteCur, offs, mlen, blockByteEnd);
+                zstdgpu_MemSet(srt.inoutUnCompressedFramesData, blockByteCur, symbol, seq.llen, blockByteEnd);
+                litCur += seq.llen;
+                zstdgpu_MatchCopy(srt.inoutUnCompressedFramesData, blockByteCur, seq, blockByteEnd);
             }
 
             // NOTE(pamartis): copy remaining literals. If above condtion `seqStreamIdx == ~0u` is true,

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -4112,50 +4112,55 @@ static void zstdgpu_MatchCopy(ZSTDGPU_RW_TYPED_BUFFER(uint32_t, uint8_t) dstData
                               uint32_t dstEnd  //< NOTE(pamartis): this one is passed for safety clamp, could be ignored
                               )
 {
-    ZSTDGPU_BRANCH if (seq.offs >= WaveGetLaneCount())
+    const uint32_t laneCount = WaveGetLaneCount();
+    const uint32_t laneId = WaveGetLaneIndex();
+
+    // When either path could handle the match copy, prefer this one since there is no modulo.
+    ZSTDGPU_BRANCH if (seq.offs >= zstdgpu_MinU32(laneCount, seq.mlen))
     {
-        uint32_t dstI = dstOfs + WaveGetLaneIndex();
+        uint32_t dstI = dstOfs + laneId;
         dstOfs += seq.mlen;
         dstEnd = zstdgpu_MinU32(dstEnd, dstOfs); //< NOTE(pamartis): could skip min
 
-        ZSTDGPU_LOOP for (; dstI < dstEnd; dstI += WaveGetLaneCount())
+        ZSTDGPU_LOOP for (; dstI < dstEnd; dstI += laneCount)
         {
             zstdgpu_TypedStoreU8(dstData, dstI, dstData[dstI - seq.offs]);
         }
     }
-    else
+    else // 'seq.offs < seq.mlen && seq.offs < laneCount':
     {
-        const uint32_t laneId = WaveGetLaneIndex();
-
-        // NOTE(pamartis): the case 'seq.offs' is short, so we can't start writing 'WaveGetLaneCount' chunks at a time...
-        // Therefore, we fetch 'seq.offs' bytes ...
         uint32_t srcSym = 0;
         ZSTDGPU_BRANCH if (laneId < seq.offs)
         {
             srcSym = dstData[dstOfs + laneId - seq.offs];
         }
 
-        // .. and construct a chunk of memory of size 'WaveGetLaneCount() - WaveGetLaneCount % seq.offs' where
-        // 'seq.offs' bytes are repeated 'WaveGetLaneCount() / seq.offs' times.
-        // The purpose of that -- is to construct the widest chunk possible that we can repeat copying by the entire wave
-        ZSTDGPU_BRANCH if (seq.offs <= WaveGetLaneCount() / 2)
+        const uint32_t copyLen = zstdgpu_MinU32(dstEnd - dstOfs, seq.mlen); //< NOTE(pamartis): could skip min
+
+        // NOTE(jweinste): It is undefined what is returned upon reading from an inactive lane via WaveReadLaneAt()
+        // (most current drivers seem to yield 0 for this case).
+        // Hence, we must place the loop exit/break carefully.
+        //
+        // Consider this example:
+        //      "ABC", offs=3, mlen=9 // initial data
+        //      "ABCABCABCABC"        // expected output
+        //
+        //      Say WaveSize = 4:
+        //          Store 0: stores ABCA = swizzle(ABC, {0,1,2,0}).
+        //          Store 1: stores BCAB = swizzle(ABC, {1,2,0,1}).
+        //          Store 2: only lane 0 can be active for the store, but the element it wants (C) is in lane 2.
+        for (uint32_t copyId = laneId; /* mid-break in the loop */; copyId += laneCount)
         {
-            srcSym = WaveReadLaneAt(srcSym, laneId % seq.offs); //< NOTE(pamartis): We could replace 'mod' operation by Lemire'19 approach and precomputing up to 128 constants..
-        }
-
-        const uint32_t copySize = WaveGetLaneCount() - WaveGetLaneCount() % seq.offs;
-
-        uint32_t dstI = dstOfs + laneId;
-        dstOfs += seq.mlen;
-        dstEnd = zstdgpu_MinU32(dstEnd, dstOfs); //< NOTE(pamartis): could skip min
-
-        ZSTDGPU_BRANCH if (laneId < copySize)
-        {
-            ZSTDGPU_LOOP for (; dstI < dstEnd; dstI += copySize)
+            //< NOTE(pamartis): We could replace 'mod' operation by Lemire'19 approach and precomputing up to 128 constants..
+            const uint32_t swizzled = WaveReadLaneAt(srcSym, copyId % seq.offs);
+            // Deactivate lanes only after doing WaveReadLaneAt.
+            if (copyId >= copyLen)
             {
-                zstdgpu_TypedStoreU8(dstData, dstI, srcSym);
+                break;
             }
+            zstdgpu_TypedStoreU8(dstData, dstOfs + copyId, swizzled);
         }
+        dstOfs += copyLen;
     }
 }
 

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -562,23 +562,28 @@ static inline uint32_t zstdgpu_FindFirstBitHiU32(uint32_t v)
 #endif
 }
 
+// The input to this function must not be 0.
 static inline uint32_t zstdgpu_FindFirstBitHiU32_Nonzero(uint32_t v)
 {
 #ifdef __hlsl_dx_compiler
-    // On AMD RDNA3, {v,s}_clz_i32_u32 return -1 for an input of 0, instead of returning 32.
-    // So firstbithigh can't directly be implemented as 31 - {v,s}_clz_i32_u32;
-    // there are additional fixup instructions, currently even when or-ing the input with 1.
-    // The current AMD driver compiler does not do a great job with uniform firstbithigh:
-    //          v_clz_i32_u32   v0, s10             // input s10 is scalar, but didn't use SALU s_clz_i32_u32
+    // HLSL's firstbithigh is like _BitScanReverse and returns -1 for an input of 0.
+    // However, the FirstbitHi DXIL instruction is like a count-leading-zeros, but it returns -1
+    // (instead of 32) for an input of 0. DXC expands firstbithigh into four DXIL instructions
+    // (FirstbitHi, sub, icmp, select). So the following formulation actually saves a DXIL instruction,
+    // and should be good on at least AMD RDNA3 ({v,s}_{ctz,clz}_i32_b32 match DXIL FirstBit{Lo,Hi} semantics),
+    // especially since its current shader compiler doesn't seem to emit the SALU version of clz_i32_u32.
+    // This method does not yield the same answer for an input of 0.
+    //
+    // ISA for HLSL firstbithigh:
+    //          v_clz_i32_u32   v0, s10
     //          v_sub_nc_u32    v1, 31, v0
     //          v_cmp_ne_i32    vcc_lo, -1, v0
     //          v_cndmask_b32   v0, -1, v1, vcc_lo  // final result in v0
-    // The following formulation gets us:
+    //
+    // ISA for the following:
     //          s_brev_b32    s13, s10
     //          s_ctz_i32_b32 s13, s13
     //          s_sub_u32     s13, 31, s13          // final result in s13
-    // Which isn't identical when v==0, so only use this when v!=0.
-    // If input is non-uniform (VALU), we still save an instruction.
     return 31 - firstbitlow(reversebits(v));
 #else
     unsigned long index = 0;


### PR DESCRIPTION
Minor refactoring:
- Edit `zstdgpu_FindFirstBitHiU32_Nonzero` comment.
- Don't compile 2 versions of threadgroup size 32 `ExecuteSequences`. Rename a file extension from `hlsl` to `hlsli`, modeled after `ZstdGpuDecompressLiterals_LdsStoreCache.hlsli` usage.
- Add `zstdgpu_LoadSequence`. On second look its not much nicer, but it'll help for switching to a raw buffer for some partial loop unrolling experiments to use `Load4` mostly and `Load` for the tail.

Two match copy optimizations:
- Send `offs >= mlen` cases down the simpler (no modulo) first path, instead of just `offs >= WaveGetLaneCount()` cases.
- For the other cases, use a different implementation that does (except for potentially the last store) fully active lane stores. This does a modulo per loop iteration (which could just be once), but it iterates less and the former version always did two modulo operations.

On 7900 XTX for the ~146 MB insects archive, saves roughly 100-250 us for the `ExecuteSequences` dispatch.