### PR TITLE
Brings recent QoL improvements from development repository

### DIFF
--- a/zstd/ThirdParty/d3d12aid.h
+++ b/zstd/ThirdParty/d3d12aid.h
@@ -33,6 +33,14 @@
 #   endif
 #endif
 
+#ifndef D3D12AID_MEMCPY
+#   define D3D12AID_MEMCPY memcpy
+#endif
+
+#ifndef D3D12AID_MEMSET
+#   define D3D12AID_MEMSET memset
+#endif
+
 #ifndef D3D12AID_CHECK
 #   define D3D12AID_CHECK(call)                             \
         do                                                  \
@@ -805,9 +813,9 @@ D3D12AID_API void d3d12aid_MappedBuffer_Append(d3d12aid_MappedBuffer *inoutBuffe
     {
         D3D12AID_ASSERT(frameIndex < inoutBuffer->frameCount);
         D3D12AID_ASSERT(frameIndex < inoutBuffer->frameCount);
-        D3D12AID_ASSERT(inoutBuffer->sizeInBytes - inoutBuffer->offsInBytes >= sizeInBytes);
+        D3D12AID_ASSERT(inoutBuffer->sizeInBytes >= inoutBuffer->offsInBytes + sizeInBytes);
 
-        memcpy((char *)inoutBuffer->bufMem[frameIndex] + inoutBuffer->offsInBytes, data, sizeInBytes);
+        D3D12AID_MEMCPY((char *)inoutBuffer->bufMem[frameIndex] + inoutBuffer->offsInBytes, data, sizeInBytes);
         inoutBuffer->offsInBytes += sizeInBytes;
     }
 }
@@ -818,9 +826,9 @@ D3D12AID_API void d3d12aid_MappedBuffer_Skip(d3d12aid_MappedBuffer* inoutBuffer,
     {
         D3D12AID_ASSERT(frameIndex < inoutBuffer->frameCount);
         D3D12AID_ASSERT(frameIndex < inoutBuffer->frameCount);
-        D3D12AID_ASSERT(inoutBuffer->sizeInBytes - inoutBuffer->offsInBytes <= sizeInBytes);
+        D3D12AID_ASSERT(inoutBuffer->sizeInBytes >= inoutBuffer->offsInBytes + sizeInBytes);
 
-        memset((char*)inoutBuffer->bufMem[frameIndex] + inoutBuffer->offsInBytes, 0, sizeInBytes);
+        D3D12AID_MEMSET((char*)inoutBuffer->bufMem[frameIndex] + inoutBuffer->offsInBytes, 0, sizeInBytes);
         inoutBuffer->offsInBytes += sizeInBytes;
     }
 }
@@ -880,6 +888,7 @@ struct d3d12aid_CmdQueue
     HANDLE                      fenceEvent;
     ID3D12Fence                *fence;
     ID3D12CommandQueue         *queue;
+    ID3D12Device               *device;
 
     ID3D12CommandAllocator     *cmdAllocs[D3D12AID_CMD_QUEUE_ALLOC_MAX_COUNT];
     uint64_t                    cmdAllocReuseFenceValues[D3D12AID_CMD_QUEUE_ALLOC_MAX_COUNT];
@@ -898,6 +907,7 @@ D3D12AID_API void d3d12aid_CmdQueue_Create(d3d12aid_CmdQueue *outQueue, ID3D12De
 {
     D3D12AID_ASSERT(frameCount <= D3D12AID_CMD_QUEUE_LATENCY_FRAME_MAX_COUNT);
     D3D12AID_ASSERT(listCountPerFrame <= D3D12AID_CMD_QUEUE_LIST_MAX_COUNT_PER_FRAME);
+
     D3D12_COMMAND_QUEUE_DESC queueDesc;
 
     queueDesc.Type      = cmdQueueType;
@@ -905,6 +915,8 @@ D3D12AID_API void d3d12aid_CmdQueue_Create(d3d12aid_CmdQueue *outQueue, ID3D12De
     queueDesc.Flags     = D3D12_COMMAND_QUEUE_FLAG_NONE;
     queueDesc.NodeMask  = 0x1;
 
+    outQueue->device = device;
+    outQueue->device->AddRef();
     D3D12AID_CHECK(device->CreateCommandQueue(&queueDesc, D3D12AID_IID_PPV_ARGS(&outQueue->queue)));
 
     outQueue->cmdAllocCount = frameCount * listCountPerFrame;
@@ -970,14 +982,28 @@ D3D12AID_API void d3d12aid_CmdQueue_GpuWaitForFence(d3d12aid_CmdQueue *queue, ui
     D3D12AID_CHECK(queue->queue->Wait(queue->fence, fenceId));
 }
 
+D3D12AID_API bool d3d12aid_CmdQueue_IsFenceCompleted(d3d12aid_CmdQueue *queue, uint64_t fenceId)
+{
+    const uint64_t completedFenceId = queue->fence->GetCompletedValue();
+    if (UINT64_MAX == completedFenceId)
+    {
+        HRESULT hr = queue->device->GetDeviceRemovedReason();
+        D3D12AID_ASSERT(DXGI_ERROR_DEVICE_HUNG != hr);
+        D3D12AID_ASSERT(DXGI_ERROR_DEVICE_REMOVED != hr);
+        D3D12AID_ASSERT(DXGI_ERROR_DEVICE_RESET != hr);
+        D3D12AID_ASSERT(S_OK == hr);
+        return false;
+    }
+    return fenceId <= completedFenceId;
+}
 D3D12AID_API void d3d12aid_CmdQueue_CpuWaitForFence(d3d12aid_CmdQueue *queue, uint64_t fenceId)
 {
     D3D12AID_ASSERT(fenceId < queue->fenceValue);
-    uint64_t fenceIdCompleted = queue->fence->GetCompletedValue();
-    if (fenceId > fenceIdCompleted)
+    if (!d3d12aid_CmdQueue_IsFenceCompleted(queue, fenceId))
     {
         D3D12AID_CHECK(queue->fence->SetEventOnCompletion(fenceId, queue->fenceEvent));
         WaitForSingleObjectEx(queue->fenceEvent, INFINITE, FALSE);
+        d3d12aid_CmdQueue_IsFenceCompleted(queue, fenceId);
     }
 }
 
@@ -1000,6 +1026,7 @@ D3D12AID_API void d3d12aid_CmdQueue_Release(d3d12aid_CmdQueue *queue)
 
     D3D12AID_SAFE_RELEASE(queue->fence);
     D3D12AID_SAFE_RELEASE(queue->queue);
+    D3D12AID_SAFE_RELEASE(queue->device);
 }
 
 D3D12AID_API uint64_t d3d12aid_CmdQueue_SubmitMultiCmdLists(d3d12aid_CmdQueue *queue, uint32_t cmdListIdStart, uint32_t cmdListIdCount)
@@ -1074,12 +1101,6 @@ D3D12AID_API uint64_t d3d12aid_CmdQueue_SubmitCmdList(d3d12aid_CmdQueue *queue, 
 D3D12AID_API ID3D12GraphicsCommandList *d3d12aid_CmdQueue_StartCmdList(d3d12aid_CmdQueue *queue, uint32_t cmdListId)
 {
     return d3d12aid_CmdQueue_StartMultiCmdLists(queue, cmdListId, 1)[0];
-}
-
-D3D12AID_API bool d3d12aid_CmdQueue_IsFenceCompleted(d3d12aid_CmdQueue *queue, uint64_t fenceId)
-{
-    return fenceId <= queue->fence->GetCompletedValue();
-
 }
 
 #endif /** D3D12AID_H */

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -272,9 +272,8 @@ static void zstdgpu_ReCreate_SRTs(zstdgpu_SRTs & srts, ID3D12Device *device, con
     D3D12_SHADER_RESOURCE_VIEW_DESC SRV;
     D3D12_UNORDERED_ACCESS_VIEW_DESC UAV;
     const DXGI_FORMAT DXGI_FORMAT_uint8_t = DXGI_FORMAT_R8_UINT;
-    const DXGI_FORMAT DXGI_FORMAT_uint16_t = DXGI_FORMAT_R16_UINT;
+    //const DXGI_FORMAT DXGI_FORMAT_uint16_t = DXGI_FORMAT_R16_UINT;
     const DXGI_FORMAT DXGI_FORMAT_int16_t = DXGI_FORMAT_R16_SINT;
-    ZSTDGPU_UNUSED(DXGI_FORMAT_uint16_t);
 
     #define ZSTDGPU_PUSH_STRUCT_BUFFER(type, name, viewType) \
         d3d12aid_##viewType##_Create(cpuDest, device,                                                       \

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -358,6 +358,55 @@ static void zstdgpu_ReCreate_SRTs(zstdgpu_SRTs & srts, ID3D12Device *device, con
     ZSTDGPU_KERNEL(PrefixSum                                ,   L"Prefix Sum")                                                          \
     ZSTDGPU_KERNEL(UpdateDispatchArgs                       ,   L"Update Dispatch Args")
 
+typedef enum zstdgpu_CompiledShaderId
+{
+#define ZSTDGPU_KERNEL(name, desc) kzstdgpu_CompiledShaderId_##name,
+    ZSTDGPU_KERNEL_LIST()
+#undef ZSTDGPU_KERNEL
+    kzstdgpu_CompiledShaderId_Count,
+    kzstdgpu_CompiledShaderId_MaxInt = 0x7fffffff
+} zstdgpu_CompiledShaderId;
+
+typedef struct zstdgpu_CompiledShader
+{
+    const void    *code;
+    const uint32_t size;
+    const wchar_t *desc;
+} zstdgpu_CompiledShader;
+
+static const zstdgpu_CompiledShader kzstdgpu_CompiledShaders [] =
+{
+#define ZSTDGPU_KERNEL(name, desc) { g_ZstdGpu##name, sizeof(g_ZstdGpu##name), desc },
+    ZSTDGPU_KERNEL_LIST()
+#undef ZSTDGPU_KERNEL
+};
+
+#define ZSTDGPU_RUNTIME_KERNEL_LIST_SHARED()        \
+    ZSTDGPU_KERNEL(ComputeDestSequenceOffsets)      \
+    ZSTDGPU_KERNEL(ComputePrefixSum)                \
+    ZSTDGPU_KERNEL(DecodeHuffmanWeights)            \
+    ZSTDGPU_KERNEL(DecompressHuffmanWeights)        \
+    ZSTDGPU_KERNEL(FinaliseSequenceOffsets)         \
+    ZSTDGPU_KERNEL(GroupCompressedLiterals)         \
+    ZSTDGPU_KERNEL(InitFseTable)                    \
+    ZSTDGPU_KERNEL(InitHuffmanTable)                \
+    ZSTDGPU_KERNEL(InitResources)                   \
+    ZSTDGPU_KERNEL(MemsetMemcpy)                    \
+    ZSTDGPU_KERNEL(ParseCompressedBlocks)           \
+    ZSTDGPU_KERNEL(ParseFrames)                     \
+    ZSTDGPU_KERNEL(PrefixSequenceOffsets)           \
+    ZSTDGPU_KERNEL(PrefixSum)                       \
+    ZSTDGPU_KERNEL(UpdateDispatchArgs)
+
+#define ZSTDGPU_RUNTIME_KERNEL_LIST_SPECIALISED()   \
+    ZSTDGPU_KERNEL(DecompressLiterals)              \
+    ZSTDGPU_KERNEL(DecompressSequences)             \
+    ZSTDGPU_KERNEL(ExecuteSequences)
+
+#define ZSTDGPU_RUNTIME_KERNEL_LIST()           \
+    ZSTDGPU_RUNTIME_KERNEL_LIST_SHARED()        \
+    ZSTDGPU_RUNTIME_KERNEL_LIST_SPECIALISED()
+
 #define ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_0() \
     ZSTDGPU_KERNEL_SCOPE_X(InitResources_CountBlocks            , L"Init Resources"             )   \
     ZSTDGPU_KERNEL_SCOPE_X(ParseFrames_CountBlocks              , L"Parse Frames"               )   \
@@ -378,8 +427,7 @@ static void zstdgpu_ReCreate_SRTs(zstdgpu_SRTs & srts, ID3D12Device *device, con
     ZSTDGPU_KERNEL_SCOPE_X(DecompressHuffmanWeights             , L"Decompress Huffman Weights" )   \
     ZSTDGPU_KERNEL_SCOPE_X(DecodeHuffmanWeights                 , L"Decode Huffman Weights"     )   \
     ZSTDGPU_KERNEL_SCOPE_X(InitHuffmanTable                     , L"Init Huffman Table"         )   \
-    ZSTDGPU_KERNEL_SCOPE_X(DecompressLiterals                   , L"Decompress Literals"         )  \
-    ZSTDGPU_KERNEL_SCOPE_X(InitHuffmanTableAndDecompressLiterals, L"Init Huffman Table and Decompress Literals" )   \
+    ZSTDGPU_KERNEL_SCOPE_X(DecompressLiterals                   , L"Decompress Literals"        )   \
     ZSTDGPU_KERNEL_SCOPE_X(DecompressSequences                  , L"Decompress Sequences"       )   \
     ZSTDGPU_KERNEL_SCOPE_X(PrefixSequenceOffsets                , L"Propagate Sequence Offsets" )   \
     ZSTDGPU_KERNEL_SCOPE_X(FinaliseSequenceOffsets              , L"Finalise Sequence Offsets"  )   \
@@ -404,12 +452,11 @@ struct zstdgpu_PersistentContextImpl
     void                    *thisMemoryBlock;
     ID3D12Device            *device;
     ID3D12CommandSignature  *dispatchCmdSig;
-    uint32_t                 minLaneCount;
-    uint32_t                 maxLaneCount;
 
-    #define ZSTDGPU_KERNEL(name, desc) d3d12aid_ComputeRsPs name;
-        ZSTDGPU_KERNEL_LIST()
+    #define ZSTDGPU_KERNEL(name) d3d12aid_ComputeRsPs name;
+        ZSTDGPU_RUNTIME_KERNEL_LIST()
     #undef ZSTDGPU_KERNEL
+    uint32_t                DecompressLiterals_LdsStoreCache_StreamsPerGroup;
 };
 
 enum zstdgpu_SetupInputsType
@@ -426,12 +473,9 @@ struct zstdgpu_PerRequestContextImpl
     ID3D12Device            *device;
     ID3D12CommandSignature  *dispatchCmdSig;
 
-    #define ZSTDGPU_KERNEL(name, desc) d3d12aid_ComputeRsPs name;
-        ZSTDGPU_KERNEL_LIST()
+    #define ZSTDGPU_KERNEL(name) d3d12aid_ComputeRsPs name;
+        ZSTDGPU_RUNTIME_KERNEL_LIST()
     #undef ZSTDGPU_KERNEL
-    d3d12aid_ComputeRsPs    ExecuteSequences;
-    d3d12aid_ComputeRsPs    DecompressSequences_LdsFseCache;
-    d3d12aid_ComputeRsPs    DecompressLiterals_LdsStoreCache;
     uint32_t                DecompressLiterals_LdsStoreCache_StreamsPerGroup;
 
     zstdgpu_SRTs            srts;
@@ -515,18 +559,69 @@ ZSTDGPU_ENUM(Status) zstdgpu_CreatePersistentContext(zstdgpu_PersistentContext *
         dispatchCmdSigDesc.NodeMask             = 0x1;
         D3D12AID_CHECK(device->CreateCommandSignature(&dispatchCmdSigDesc, NULL, D3D12AID_IID_PPV_ARGS(&context->dispatchCmdSig)));
 
+        #define ZSTDGPU_KERNEL_GET(name) &kzstdgpu_CompiledShaders[kzstdgpu_CompiledShaderId_##name];
+        #define ZSTDGPU_KERNEL_MAP(runtime, compiled) shader##runtime = ZSTDGPU_KERNEL_GET(compiled)
+
+        #define ZSTDGPU_KERNEL(name) const zstdgpu_CompiledShader *shader##name = ZSTDGPU_KERNEL_GET(name);
+            ZSTDGPU_RUNTIME_KERNEL_LIST_SHARED()
+        #undef ZSTDGPU_KERNEL
+
+        #define ZSTDGPU_KERNEL(name) const zstdgpu_CompiledShader *shader##name = NULL;
+            ZSTDGPU_RUNTIME_KERNEL_LIST_SPECIALISED()
+        #undef ZSTDGPU_KERNEL
+
+#if defined(_GAMING_XBOX_SCARLETT)
+        ZSTDGPU_KERNEL_MAP(DecompressLiterals, DecompressLiterals_LdsStoreCache32_16);
+        context->DecompressLiterals_LdsStoreCache_StreamsPerGroup = 16;
+        ZSTDGPU_KERNEL_MAP(DecompressSequences, DecompressSequences_LdsFseCache32);
+        ZSTDGPU_KERNEL_MAP(ExecuteSequences, ExecuteSequences64);
+#else
         D3D12_FEATURE_DATA_D3D12_OPTIONS1 featureOptions1;
         D3D12AID_CHECK(device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS1, ZSTDGPU_WARN_DISABLE_MSVC(6001, &featureOptions1), sizeof(featureOptions1)));
-        context->minLaneCount = featureOptions1.WaveLaneCountMin;
-        context->maxLaneCount = featureOptions1.WaveLaneCountMax;
+
+        const LUID luid = device->GetAdapterLuid();
+
+        IDXGIAdapter* adapter = NULL;
+        IDXGIFactory4 *factory = NULL;
+        CreateDXGIFactory2(0, D3D12AID_IID_PPV_ARGS(&factory));
+        D3D12AID_CHECK(factory->EnumAdapterByLuid(luid, D3D12AID_IID_PPV_ARGS(&adapter)));
+        D3D12AID_SAFE_RELEASE(factory);
+
+        DXGI_ADAPTER_DESC desc;
+        D3D12AID_CHECK(adapter->GetDesc(&desc));
+        D3D12AID_SAFE_RELEASE(adapter);
+
+        if (desc.VendorId == 0x1002)
+        {
+            ZSTDGPU_KERNEL_MAP(DecompressLiterals, DecompressLiterals_LdsStoreCache64_16);
+            context->DecompressLiterals_LdsStoreCache_StreamsPerGroup = 16;
+            ZSTDGPU_KERNEL_MAP(DecompressSequences, DecompressSequences_Scalar32);
+            ZSTDGPU_KERNEL_MAP(ExecuteSequences, ExecuteSequences64);
+        }
+        else if (featureOptions1.WaveLaneCountMax == 128)
+        {
+            ZSTDGPU_KERNEL_MAP(DecompressLiterals, DecompressLiterals_LdsStoreCache128_8);
+            context->DecompressLiterals_LdsStoreCache_StreamsPerGroup = 8;
+            ZSTDGPU_KERNEL_MAP(DecompressSequences, DecompressSequences_LdsFseCache128);
+            ZSTDGPU_KERNEL_MAP(ExecuteSequences, ExecuteSequences128);
+        }
+        else //if (desc.VendorId == 0x10de || desc.VendorId == 0x8086 || featureOptions1.WaveLaneCountMax == 32)
+        {
+            ZSTDGPU_KERNEL_MAP(DecompressLiterals, DecompressLiterals_LdsStoreCache32_16);
+            context->DecompressLiterals_LdsStoreCache_StreamsPerGroup = 16;
+            ZSTDGPU_KERNEL_MAP(DecompressSequences, DecompressSequences_LdsFseCache32);
+            ZSTDGPU_KERNEL_MAP(ExecuteSequences, ExecuteSequences32);
+        }
+#endif
+        #undef ZSTDGPU_KERNEL_GET
+        #undef ZSTDGPU_KERNEL_MAP
 
         /** NOTE(pamartis): generate PipelineState / RootSignature initialisation through macro list */
-        #define ZSTDGPU_KERNEL(name, desc) \
-            d3d12aid_ComputeRsPs_Create(&context->name, device, g_ZstdGpu##name, sizeof(g_ZstdGpu##name));\
-            context->name.rs->SetName(desc);\
-            context->name.ps->SetName(desc);
-
-            ZSTDGPU_KERNEL_LIST()
+        #define ZSTDGPU_KERNEL(name) \
+            d3d12aid_ComputeRsPs_Create(&context->name, device, shader##name->code, shader##name->size);\
+            context->name.rs->SetName(shader##name->desc);\
+            context->name.ps->SetName(shader##name->desc);
+            ZSTDGPU_RUNTIME_KERNEL_LIST()
         #undef ZSTDGPU_KERNEL
 
         *outPersistentContext = context;
@@ -543,8 +638,8 @@ ZSTDGPU_ENUM(Status) zstdgpu_DestroyPersistentContext(void **outMemoryBlock, uin
 
     if (proceed > 0)
     {
-        #define ZSTDGPU_KERNEL(name, desc) d3d12aid_ComputeRsPs_Release(&inPersistentContext->name);
-            ZSTDGPU_KERNEL_LIST()
+        #define ZSTDGPU_KERNEL(name) d3d12aid_ComputeRsPs_Release(&inPersistentContext->name);
+            ZSTDGPU_RUNTIME_KERNEL_LIST()
         #undef ZSTDGPU_KERNEL
 
         D3D12AID_SAFE_RELEASE(inPersistentContext->dispatchCmdSig);
@@ -585,48 +680,13 @@ ZSTDGPU_ENUM(Status) zstdgpu_CreatePerRequestContext(zstdgpu_PerRequestContext *
         context->dispatchCmdSig->AddRef();
 
         /** NOTE(pamartis): generate PipelineState / RootSignature initialisation through macro list */
-        #define ZSTDGPU_KERNEL(name, desc)          \
+        #define ZSTDGPU_KERNEL(name)                \
             context->name = persistentContext->name;\
             context->name.rs->AddRef();             \
             context->name.ps->AddRef();
-            ZSTDGPU_KERNEL_LIST()
+            ZSTDGPU_RUNTIME_KERNEL_LIST()
         #undef ZSTDGPU_KERNEL
-#ifdef _GAMING_XBOX_SCARLETT
-        context->ExecuteSequences = context->ExecuteSequences64;
-        context->DecompressSequences_LdsFseCache = context->DecompressSequences_LdsFseCache32;
-        context->DecompressLiterals_LdsStoreCache = context->DecompressLiterals_LdsStoreCache32_16;
-        context->DecompressLiterals_LdsStoreCache_StreamsPerGroup = 16;
-#else
-        if (persistentContext->maxLaneCount == 128)
-        {
-            context->ExecuteSequences = context->ExecuteSequences128;
-            context->DecompressSequences_LdsFseCache = context->DecompressSequences_LdsFseCache128;
-            context->DecompressLiterals_LdsStoreCache = context->DecompressLiterals_LdsStoreCache128_8;
-            context->DecompressLiterals_LdsStoreCache_StreamsPerGroup = 8;
-        }
-        else if (persistentContext->maxLaneCount == 64)
-        {
-            context->ExecuteSequences = context->ExecuteSequences64;
-            context->DecompressSequences_LdsFseCache = context->DecompressSequences_LdsFseCache64;
-            context->DecompressLiterals_LdsStoreCache = context->DecompressLiterals_LdsStoreCache64_16;
-            context->DecompressLiterals_LdsStoreCache_StreamsPerGroup = 16;
-        }
-        else
-        {
-            context->ExecuteSequences = context->ExecuteSequences32;
-            context->DecompressSequences_LdsFseCache = context->DecompressSequences_LdsFseCache32;
-            context->DecompressLiterals_LdsStoreCache = context->DecompressLiterals_LdsStoreCache32_16;
-            context->DecompressLiterals_LdsStoreCache_StreamsPerGroup = 16;
-        }
-#endif
-        context->ExecuteSequences.rs->AddRef();
-        context->ExecuteSequences.ps->AddRef();
-
-        context->DecompressSequences_LdsFseCache.rs->AddRef();
-        context->DecompressSequences_LdsFseCache.ps->AddRef();
-
-        context->DecompressLiterals_LdsStoreCache.rs->AddRef();
-        context->DecompressLiterals_LdsStoreCache.ps->AddRef();
+        context->DecompressLiterals_LdsStoreCache_StreamsPerGroup = persistentContext->DecompressLiterals_LdsStoreCache_StreamsPerGroup;
 
         context->srts.heap = NULL;
         context->srts.heapOffset = 0;
@@ -690,11 +750,8 @@ ZSTDGPU_ENUM(Status) zstdgpu_DestroyPerRequestContext(void **outMemoryBlock, uin
 
         D3D12AID_SAFE_RELEASE(inPerRequestContext->srts.heap);
 
-        d3d12aid_ComputeRsPs_Release(&inPerRequestContext->ExecuteSequences);
-        d3d12aid_ComputeRsPs_Release(&inPerRequestContext->DecompressSequences_LdsFseCache);
-        d3d12aid_ComputeRsPs_Release(&inPerRequestContext->DecompressLiterals_LdsStoreCache);
-        #define ZSTDGPU_KERNEL(name, desc) d3d12aid_ComputeRsPs_Release(&inPerRequestContext->name);
-            ZSTDGPU_KERNEL_LIST()
+        #define ZSTDGPU_KERNEL(name) d3d12aid_ComputeRsPs_Release(&inPerRequestContext->name);
+            ZSTDGPU_RUNTIME_KERNEL_LIST()
         #undef ZSTDGPU_KERNEL
 
         D3D12AID_SAFE_RELEASE(inPerRequestContext->dispatchCmdSig);
@@ -1758,7 +1815,6 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
     if (req->zstdCmpBlockCount > 0)
     {
-#if 0
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Decompress Literals]");
         BIND_RS_PS_SRT(DecompressLiterals);
         cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 0);
@@ -1768,39 +1824,13 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_DecompressLiteralsGroups * sizeof(uint32_t), NULL, 0);
         );
         PIXEndEvent(cmdList);
-#else
-        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Decompress Literals (LDS Store Cache)]");
-        d3d12aid_ComputeRsPs_Set(&req->DecompressLiterals_LdsStoreCache, cmdList);
-        cmdList->SetDescriptorHeaps(1, &req->srts.heap);
-        cmdList->SetComputeRootDescriptorTable(0, req->srts.DecompressLiteralsGpuHandle);
-        cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 0);
-
-        ID3D12Resource* argBuf = req->resData.gpuOnly.Counters;
-        ZSTDGPU_KERNEL_SCOPE(DecompressLiterals, cmdList,
-            cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_DecompressLiteralsGroups * sizeof(uint32_t), NULL, 0);
-        );
-        PIXEndEvent(cmdList);
-#endif
-    }
-
-    if (req->zstdCmpBlockCount > 0)
-    {
-        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Init Huffman Table and Decompress Literals]");
-        BIND_RS_PS_SRT(InitHuffmanTableAndDecompressLiterals);
-        cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 0);
-
-        //ID3D12Resource* argBuf = req->resData.gpuOnly.Counters;
-        ZSTDGPU_KERNEL_SCOPE(InitHuffmanTableAndDecompressLiterals, cmdList,
-            //cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_DecompressLiteralsGroups * sizeof(uint32_t), NULL, 0);
-        );
-        PIXEndEvent(cmdList);
     }
 
     // NOTE(pamartis): (can run in parallel with FSE-compressed Huffman Weight Decompression, right after FSE table initialisation)
     if (req->zstdCmpBlockCount > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Decompress Sequences]");
-        d3d12aid_ComputeRsPs_Set(&req->DecompressSequences_LdsFseCache, cmdList);
+        d3d12aid_ComputeRsPs_Set(&req->DecompressSequences, cmdList);
         cmdList->SetDescriptorHeaps(1, &req->srts.heap);
         cmdList->SetComputeRootDescriptorTable(0, req->srts.DecompressSequencesGpuHandle);
 

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -363,9 +363,11 @@ static void zstdgpu_ReCreate_SRTs(zstdgpu_SRTs & srts, ID3D12Device *device, con
     ZSTDGPU_KERNEL_SCOPE_X(ParseFrames_CountBlocks              , L"Parse Frames"               )   \
     ZSTDGPU_KERNEL_SCOPE_X(PrefixSum                            , L"Prefix Sums"                )
 
-#define ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1() \
+#define ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1_ALL_BLOCKS() \
     ZSTDGPU_KERNEL_SCOPE_X(InitResources                        , L"Init Resources"             )   \
-    ZSTDGPU_KERNEL_SCOPE_X(ParseFrames                          , L"Parse Frames"               )   \
+    ZSTDGPU_KERNEL_SCOPE_X(ParseFrames                          , L"Parse Frames"               )
+
+#define ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1_CMP_BLOCKS() \
     ZSTDGPU_KERNEL_SCOPE_X(ParseCompressedBlocks                , L"Parse Compressed Blocks"    )
 
 #define ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_CMP_BLOCKS() \
@@ -391,7 +393,8 @@ static void zstdgpu_ReCreate_SRTs(zstdgpu_SRTs & srts, ID3D12Device *device, con
 
 #define ZSTDGPU_KERNEL_SCOPE_LIST()                     \
     ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_0()                 \
-    ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1()                 \
+    ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1_ALL_BLOCKS()      \
+    ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1_CMP_BLOCKS()      \
     ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_CMP_BLOCKS()      \
     ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_RAW_RLE_BLOCKS()  \
     ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_ALL_BLOCKS()
@@ -2070,7 +2073,11 @@ ZSTDGPU_API void zstdgpu_RetrieveTimestamps(const wchar_t **outTimestampScopeNam
     }
     else if (stageIndex == 1)
     {
-        timestampScopeCountPerStage += 0 ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1();
+        timestampScopeCountPerStage += 0 ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1_ALL_BLOCKS();
+        if (req->zstdCmpBlockCount > 0)
+        {
+            timestampScopeCountPerStage += 0 ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1_CMP_BLOCKS();
+        }
     }
     else if (stageIndex == 2)
     {
@@ -2099,7 +2106,11 @@ ZSTDGPU_API void zstdgpu_RetrieveTimestamps(const wchar_t **outTimestampScopeNam
         }
         else if (stageIndex == 1)
         {
-            ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1()
+            ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1_ALL_BLOCKS()
+            if (req->zstdCmpBlockCount > 0)
+            {
+                ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1_CMP_BLOCKS();
+            }
         }
         else if (stageIndex == 2)
         {

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -1500,6 +1500,11 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         else
         {
             // last written by [Parse Frames :: Collect Blocks]
+            // next read by [Readback Counters :: After Block Parse] and updated by [Update Dispatch Args]
+            setResourceUavToSrvSync(barriers, bc + 0, req->resData.gpuOnly.Counters);
+            bc += 1;
+
+            // last written by [Parse Frames :: Collect Blocks]
             // next updated by [Prefix Block Sizes]
             setResourceUavSync(barriers, bc + 0, req->resData.gpuOnly.BlockSizePrefix);
             bc += 1;
@@ -1567,7 +1572,7 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXEndEvent(cmdList);
     }
     {
-        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Readback Counters :: After Block Parse");
+        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Readback Counters :: After Block Parse]");
         zstdgpu_PushReadback(Counters);
         PIXEndEvent(cmdList);
     }
@@ -2019,6 +2024,14 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         );
         PIXEndEvent(cmdList);
     }
+    if (req->zstdCmpBlockCount > 0)
+    {
+        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier with Resources for [Readback Counters :: After Block Decompression]");
+        D3D12_RESOURCE_BARRIER barriers[1];
+        setResourceUavToSrvSync(barriers, 0, req->resData.gpuOnly.Counters);
+        cmdList->ResourceBarrier(_countof(barriers), barriers);
+        PIXEndEvent(cmdList);
+    }
     if (0) /** IMPORTANT: requires DecompressedSequencesMLen to contain inclusive prefix of total sequence sizes */
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Compute Dest Sequence Offsets]");
@@ -2028,6 +2041,12 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
         PIXEndEvent(cmdList);
     }
+    if (req->zstdCmpBlockCount > 0) /* Readback for Counters is only needed if the number of compressed blocks > 0 because Counters are updated during Seqeunce Execution */
+    {
+        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Readback Counters :: After Block Decompression]");
+        zstdgpu_PushReadback(Counters);
+        PIXEndEvent(cmdList);
+    }
 }
 
 ZSTDGPU_API void zstdgpu_ReadbackGpuResults(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandList *cmdList)
@@ -2035,7 +2054,7 @@ ZSTDGPU_API void zstdgpu_ReadbackGpuResults(zstdgpu_PerRequestContext req, ID3D1
     // NOTE(pamartis): these are required to make sure D3D12 validation doesn't complain about state mismatch when
     // Read-only resource from the last stage get a NON_PS_RESOURCE state as a result of promotion from COMMON state
     // and then used as COPY_SOURCE for debug readback
-    D3D12_RESOURCE_BARRIER barriers[14];
+    D3D12_RESOURCE_BARRIER barriers[13];
     uint32_t bc = 0;
     setResourceState(barriers, 0, req->resData.gpuOnly.PerFrameBlockCountCMP, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
     setResourceState(barriers, 1, req->resData.gpuOnly.PerFrameBlockCountAll, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
@@ -2047,8 +2066,7 @@ ZSTDGPU_API void zstdgpu_ReadbackGpuResults(zstdgpu_PerRequestContext req, ID3D1
     {
         setResourceState(barriers, bc + 0, req->resData.gpuOnly.GlobalBlockIndexPerCmpBlock, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
         setResourceState(barriers, bc + 1, req->resData.gpuOnly.PerSeqStreamSeqStart, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
-        setResourceUavToSrvCopyIndirectSync(barriers, bc + 2, req->resData.gpuOnly.Counters);
-        bc += 3;
+        bc += 2;
     }
     if (req->zstdRawBlockCount > 0)
     {

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -2401,7 +2401,7 @@ static void zstdgpu_ShaderEntry_DecompressHuffmanWeights(ZSTDGPU_PARAM_INOUT(zst
 
         const uint32_t fseElem0 = srt.inFseElems[offsetState0];
         // peek
-        srt.inoutDecompressedHuffmanWeights[hufWeightIndex++] = ZSTDGPU_STATIC_CAST(uint8_t)zstdgpu_FseElem_Symbol(fseElem0);
+        zstdgpu_TypedStoreU8(srt.inoutDecompressedHuffmanWeights, hufWeightIndex++, zstdgpu_FseElem_Symbol(fseElem0));
 
         // update
         uint32_t bits0 = zstdgpu_FseElem_Bitcnt(fseElem0);
@@ -2412,7 +2412,7 @@ static void zstdgpu_ShaderEntry_DecompressHuffmanWeights(ZSTDGPU_PARAM_INOUT(zst
         }
         else
         {
-            srt.inoutDecompressedHuffmanWeights[hufWeightIndex++] = ZSTDGPU_STATIC_CAST(uint8_t)zstdgpu_FseElem_Symbol(srt.inFseElems[offsetState1]);
+            zstdgpu_TypedStoreU8(srt.inoutDecompressedHuffmanWeights, hufWeightIndex++, zstdgpu_FseElem_Symbol(srt.inFseElems[offsetState1]));
             break;
         }
 
@@ -2420,7 +2420,7 @@ static void zstdgpu_ShaderEntry_DecompressHuffmanWeights(ZSTDGPU_PARAM_INOUT(zst
 
         const uint32_t fseElem1 = srt.inFseElems[offsetState1];
         // peek
-        srt.inoutDecompressedHuffmanWeights[hufWeightIndex++] = ZSTDGPU_STATIC_CAST(uint8_t) zstdgpu_FseElem_Symbol(fseElem1);
+        zstdgpu_TypedStoreU8(srt.inoutDecompressedHuffmanWeights, hufWeightIndex++, zstdgpu_FseElem_Symbol(fseElem1));
 
         // update
         uint32_t bits1 = zstdgpu_FseElem_Bitcnt(fseElem1);
@@ -2431,7 +2431,7 @@ static void zstdgpu_ShaderEntry_DecompressHuffmanWeights(ZSTDGPU_PARAM_INOUT(zst
         }
         else
         {
-            srt.inoutDecompressedHuffmanWeights[hufWeightIndex++] = ZSTDGPU_STATIC_CAST(uint8_t)zstdgpu_FseElem_Symbol(srt.inFseElems[offsetState0]);
+            zstdgpu_TypedStoreU8(srt.inoutDecompressedHuffmanWeights, hufWeightIndex++, zstdgpu_FseElem_Symbol(srt.inFseElems[offsetState0]));
             break;
         }
 #if 0
@@ -2439,7 +2439,7 @@ static void zstdgpu_ShaderEntry_DecompressHuffmanWeights(ZSTDGPU_PARAM_INOUT(zst
 
         const uint32_t fseElem0 = srt.inFseElems[offsetState0];
         // peek
-        srt.inoutDecompressedHuffmanWeights[hufWeightIndex++] = zstdgpu_FseElem_Symbol(fseElem0);
+        zstdgpu_TypedStoreU8(srt.inoutDecompressedHuffmanWeights, hufWeightIndex++, zstdgpu_FseElem_Symbol(fseElem0));
 
         // update
         bits0 = zstdgpu_FseElem_Bitcnt(fseElem0);
@@ -2450,7 +2450,7 @@ static void zstdgpu_ShaderEntry_DecompressHuffmanWeights(ZSTDGPU_PARAM_INOUT(zst
         }
         else
         {
-            srt.inoutDecompressedHuffmanWeights[hufWeightIndex++] = zstdgpu_FseElem_Symbol(srt.inFseElems[offsetState1]);
+            zstdgpu_TypedStoreU8(srt.inoutDecompressedHuffmanWeights, hufWeightIndex++, zstdgpu_FseElem_Symbol(srt.inFseElems[offsetState1]));
             break;
         }
 
@@ -2458,7 +2458,7 @@ static void zstdgpu_ShaderEntry_DecompressHuffmanWeights(ZSTDGPU_PARAM_INOUT(zst
 
         const uint32_t fseElem1 = srt.inFseElems[offsetState1];
         // peek
-        srt.inoutDecompressedHuffmanWeights[hufWeightIndex++] = zstdgpu_FseElem_Symbol(fseElem1);
+        zstdgpu_TypedStoreU8(srt.inoutDecompressedHuffmanWeights, hufWeightIndex++, zstdgpu_FseElem_Symbol(fseElem1));
 
         // update
         bits1 = zstdgpu_FseElem_Bitcnt(fseElem1);
@@ -2469,7 +2469,7 @@ static void zstdgpu_ShaderEntry_DecompressHuffmanWeights(ZSTDGPU_PARAM_INOUT(zst
         }
         else
         {
-            srt.inoutDecompressedHuffmanWeights[hufWeightIndex++] = zstdgpu_FseElem_Symbol(srt.inFseElems[offsetState0]);
+            zstdgpu_TypedStoreU8(srt.inoutDecompressedHuffmanWeights, hufWeightIndex++, zstdgpu_FseElem_Symbol(srt.inFseElems[offsetState0]));
             break;
         }
 #endif
@@ -3078,8 +3078,6 @@ void zstdgpu_DecompressHuffmanCompressedLiterals(ZSTDGPU_RO_RAW_BUFFER(uint32_t)
                                                  uint32_t tgSize)
 {
     ZSTDGPU_UNUSED(threadId);
-    const uint32_t maxBitcntMask = (1u << bitsMax) - 1u;
-    ZSTDGPU_UNUSED(maxBitcntMask);
     //
     // The start of decompression of Huffman-compressed literals
     //
@@ -3092,6 +3090,7 @@ void zstdgpu_DecompressHuffmanCompressedLiterals(ZSTDGPU_RO_RAW_BUFFER(uint32_t)
         zstdgpu_LitStreamInfo compressedLiteral = LitRefs[literalStreamId];
         uint32_t decodedByteCnt = 0;
 #if 0
+        const uint32_t maxBitcntMask = (1u << bitsMax) - 1u;
         zstdgpu_Backward_BitBuffer_V0 bitBuffer;
         zstdgpu_Backward_BitBuffer_V0_InitWithSegment(bitBuffer, CompressedData, compressedLiteral.src);
 
@@ -3152,8 +3151,6 @@ static void zstdgpu_DecompressHuffmanCompressedLiterals_StoreLdsCache(ZSTDGPU_RO
                                                                       uint32_t cacheDwordsPerStream)
 {
     ZSTDGPU_UNUSED(threadId);
-    const uint32_t maxBitcntMask = (1u << bitsMax) - 1u;
-    ZSTDGPU_UNUSED(maxBitcntMask);
     //
     // The start of decompression of Huffman-compressed literals
     //

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -201,14 +201,6 @@
 #   endif
 #endif
 
-#ifndef ZSTDGPU_STATIC_CAST
-#   ifdef __hlsl_dx_compiler
-#       define ZSTDGPU_STATIC_CAST(type)
-#   else
-#       define ZSTDGPU_STATIC_CAST(type) (type)
-#   endif
-#endif
-
 // Opaque LDS address types: offset on HLSL, pointer on C++.
 // Using these instead of raw uint32_t / uint32_t* prevents accidental type
 // mismatches when storing intermediate LDS addresses in local variables.

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -233,7 +233,11 @@ static void zstdgpu_Init_FinaliseSequenceOffsets_SRT(zstdgpu_FinaliseSequenceOff
 #define STRINGIZE2(x) #x
 #define VALIDATE(name) \
     if (ZSTDGPU_ENUM_CONST(Validate_Success) != zstdgpu_ReferenceStore_Validate_##name) \
-        debugPrint(L"Validation of "#name" failed in function: " __FUNCTION__ ", file: " __FILE__ ", line: " STRINGIZE(__LINE__) "\n")
+        debugPrint(L"[FAIL] Validation of '"#name"' failed in function: " __FUNCTION__ ", file: " __FILE__ ", line: " STRINGIZE(__LINE__) "\n")
+
+#define VALIDATE_CND(cnd) \
+    if (!(cnd)) \
+        debugPrint(L"[FAIL] Validation of '"#cnd"' failed in function: " __FUNCTION__ ", file: " __FILE__ ", line: " STRINGIZE(__LINE__) "\n")
 
 static void zstdgpu_Test_DecompressHuffmanWeights(zstdgpu_ResourceDataCpu & cpuRes, zstdgpu_ResourceDataCpu & gpuReadbackRes, uint32_t zstdDataBufferSize, bool chkGpu, bool simGpu)
 {
@@ -430,6 +434,62 @@ static void zstdgpu_Test_DecompressSequences(zstdgpu_ResourceDataCpu & cpuRes, z
         }
 
     }
+}
+
+static void zstdgpu_Test_BlockPrefix(zstdgpu_ResourceDataCpu & cpuRes, zstdgpu_ResourceDataCpu & gpuReadbackRes)
+{
+    /** these buffers could be zero if some block types don't exist */
+    if (NULL != cpuRes.GlobalBlockIndexPerCmpBlock)
+        VALIDATE_CND(0 == memcmp(cpuRes.GlobalBlockIndexPerCmpBlock, gpuReadbackRes.GlobalBlockIndexPerCmpBlock, sizeof(cpuRes.GlobalBlockIndexPerCmpBlock[0])));
+
+    if (NULL != cpuRes.GlobalBlockIndexPerRawBlock)
+        VALIDATE_CND(0 == memcmp(cpuRes.GlobalBlockIndexPerRawBlock, gpuReadbackRes.GlobalBlockIndexPerRawBlock, sizeof(cpuRes.GlobalBlockIndexPerRawBlock[0])));
+
+    if (NULL != cpuRes.GlobalBlockIndexPerRleBlock)
+        VALIDATE_CND(0 == memcmp(cpuRes.GlobalBlockIndexPerRleBlock, gpuReadbackRes.GlobalBlockIndexPerRleBlock, sizeof(cpuRes.GlobalBlockIndexPerRleBlock[0])));
+
+    VALIDATE_CND(0 == memcmp(cpuRes.BlockSizePrefix, gpuReadbackRes.BlockSizePrefix, sizeof(cpuRes.BlockSizePrefix[0])));
+}
+
+static uint32_t zstdgpu_Test_DecompressedDataPerBlockType(const uint32_t *gpuGlobalBlockIndex,
+                                                          const uint32_t blockCount,
+                                                          const uint32_t *gpuPerFrameBlockCountPrefix,
+                                                          const zstdgpu_OffsetAndSize *cpuPerFrameOffsAndSize,
+                                                          const uint32_t frameCount,
+                                                          const uint32_t *gpuBlockSizePrefix,
+                                                          const void *refData,
+                                                          const void *tstData)
+{
+    uint32_t failedBlockCount = 0;
+    for (uint32_t i = 0; i < blockCount; ++i)
+    {
+        const uint32_t globalBlockIdx = gpuGlobalBlockIndex[i];
+
+        // We start by finding the right frame index for currently processed block
+        const uint32_t frameIndex = zstdgpu_BinarySearch(gpuPerFrameBlockCountPrefix, 0, frameCount, globalBlockIdx);
+
+        // and get the index of the first block in this frame
+        const uint32_t firstInFrameGlobalBlockIndex = gpuPerFrameBlockCountPrefix[frameIndex];
+
+        // knowing the index of the first block in the frame, we read its offset (tight one, non-aligned or anything)
+        uint32_t firstInFrameBlockDataBeg = 0;
+        if (firstInFrameGlobalBlockIndex > 0)
+            firstInFrameBlockDataBeg = gpuBlockSizePrefix[firstInFrameGlobalBlockIndex - 1];
+
+        // we read the data start and end for a given block
+        const uint32_t refDataBlockDataEnd = gpuBlockSizePrefix[globalBlockIdx];
+        const uint32_t refDataBlockDataBeg = globalBlockIdx == 0 ? 0 : gpuBlockSizePrefix[globalBlockIdx - 1];
+
+        // rebase those offset into new offset (provided by CPU-side meta buffer), so data offset become relative not relative to start of the the first block)
+        const uint32_t tstDataBlockDataBeg = cpuPerFrameOffsAndSize[frameIndex].offs + (refDataBlockDataBeg - firstInFrameBlockDataBeg);
+        const uint32_t tstDataBlockDataEnd = cpuPerFrameOffsAndSize[frameIndex].offs + (refDataBlockDataEnd - firstInFrameBlockDataBeg);
+
+        const uint32_t size = refDataBlockDataEnd - refDataBlockDataBeg;
+        ZSTDGPU_ASSERT(tstDataBlockDataEnd <= cpuPerFrameOffsAndSize[frameIndex].offs + cpuPerFrameOffsAndSize[frameIndex].size);
+
+        failedBlockCount += (0 != memcmp((char*)refData + refDataBlockDataBeg, (char*)tstData + tstDataBlockDataBeg, size));
+    }
+    return failedBlockCount;
 }
 
 /**
@@ -903,7 +963,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
             }
             if (NULL == zstFilePathStorage)
             {
-                debugPrint(L"WARN: No '--zst <path to .zst file>' option was specified, running with pre-defined file path: '%s'.\n", zstFilePath);
+                debugPrint(L"[WARN] No '--zst <path to .zst file>' option was specified, running with pre-defined file path: '%s'.\n", zstFilePath);
             }
         }
     }
@@ -916,12 +976,12 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
     loadFileAligned(&zstdData, &zstdDataSize, &zstdCompressedFramesMemorySizeInBytes, 2u, zstFilePath);
     if (NULL == zstdData)
     {
-        debugPrint(L"FAIL: Couldn't load '%s'. Early Out.\n", zstFilePath);
+        debugPrint(L"[FAIL] Couldn't load '%s'. Early Out.\n", zstFilePath);
         return ERROR_FILE_NOT_FOUND;
     }
     else
     {
-        debugPrint(L"Loaded '%s' -- %u bytes.\n", zstFilePath, zstdDataSize);
+        debugPrint(L"[INFO] Loaded '%s' -- %u bytes.\n", zstFilePath, zstdDataSize);
     }
 
     zstdgpu_CountFramesAndBlocksInfo fbInfo;
@@ -953,7 +1013,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
 
         if (fbInfo.frameCount != vcnt)
         {
-            debugPrint(L"FAIL: Some frames don't carry uncompressed size. Early Out.\n");
+            debugPrint(L"[FAIL] Some frames don't carry uncompressed size. Early Out.\n");
 
             free(zstdOutFrameRefs);
             free(zstdInFrameRefs);
@@ -974,6 +1034,11 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
 #endif
 
     ID3D12Device *device = zstdgpu_Demo_PlatformInit(gpuVenId, gpuDevId, d3dDbg);
+    if (NULL == device)
+    {
+        debugPrint(L"[FAIL] Couldn't load create D3D12 device with venId=%u, devId=%u. Early Out.\n", gpuVenId, gpuDevId);
+        return ERROR_SYSTEM_DEVICE_NOT_FOUND;
+    }
 
     d3d12aid_CmdQueue cmdQueue;
 #ifdef _GAMING_XBOX
@@ -1004,12 +1069,12 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
     if (simGpu)
     {
         chkCpu = true;
-        debugPrint(L"[VALIDATION] Option '--sim-gpu' was set. Enabling '--chk-cpu' automatically (required by '--sim-gpu').\n");
+        debugPrint(L"[INFO] Option '--sim-gpu' was set. Enabling '--chk-cpu' automatically (required by '--sim-gpu').\n");
     }
 
     if (chkCpu || chkGpu)
     {
-        debugPrint(L"[VALIDATION] Running Reference Decompression and building Reference Uncompressed data ('--chk-cpu' or '--chk-gpu' was set).\n");
+        debugPrint(L"[INFO] Running Reference Decompression and building Reference Uncompressed data ('--chk-cpu' or '--chk-gpu' was set).\n");
 
         zstdReferenceUncompressedDataSize = (uint32_t)ZSTD_get_decompressed_size(zstdData, zstdDataSize);
         zstdReferenceUncompressedData = malloc(zstdReferenceUncompressedDataSize);
@@ -1290,28 +1355,71 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
                     zstdgpu_Test_DecompressHuffmanWeights(zstdCpu, gpuData, zstdCompressedFramesMemorySizeInBytes, chkGpu, simGpu);
                     zstdgpu_Test_DecompressLiterals(zstdCpu, gpuData, zstdCompressedFramesMemorySizeInBytes, chkGpu, simGpu);
                     zstdgpu_Test_DecompressSequences(zstdCpu, gpuData, zstdCompressedFramesMemorySizeInBytes, chkGpu, simGpu);
-                }
-                if (chkGpu)
-                {
-                    uint32_t refOffs = 0;
-                    for (uint32_t i = 0; i < fbInfo.frameCount; ++i)
-                    {
-                        const char *ref = (char*)zstdReferenceUncompressedData + refOffs;
-                        const char *tst = (char*)zstdUnCompressedFramesMemory.bufMem[0] + zstdOutFrameRefs[i].offs;
-                        int result = memcmp(tst, ref, zstdOutFrameRefs[i].size);
-                        refOffs += zstdOutFrameRefs[i].size;
 
-                        if (0 != result)
+                    if (chkCpu && chkGpu)
+                        zstdgpu_Test_BlockPrefix(zstdCpu, gpuData);
+
+                    if (chkGpu)
+                    {
+                        uint32_t failedFrameCount = 0;
+
                         {
-                            debugPrint(L"[VALIDATION] Failed to verify decompressed 'frame %u' against decompressed frame from reference decompressor\n", i);
-                            for (uint32_t j = 0; j < zstdOutFrameRefs[i].size; ++j)
+                            const char *ref = (char*)zstdReferenceUncompressedData;
+                            const char *tst = (char*)zstdUnCompressedFramesMemory.bufMem[0];
+                            for (uint32_t i = 0; i < fbInfo.frameCount; ++i)
                             {
-                                if (tst[j] != ref[j])
-                                {
-                                    debugPrint(L"[VALIDATION] The first byte failing validation is '%u'\n", j);
-                                    break;
-                                }
+                                failedFrameCount += (0 != memcmp(ref, tst + zstdOutFrameRefs[i].offs, zstdOutFrameRefs[i].size));
+
+                                ref += zstdOutFrameRefs[i].size;
                             }
+                        }
+
+                        if (failedFrameCount > 0)
+                        {
+                            const char *ref = (char*)zstdReferenceUncompressedData;
+                            const char *tst = (char*)zstdUnCompressedFramesMemory.bufMem[0];
+
+                            debugPrint(L"[FAIL] %u/%u frames failed validation.\n", failedFrameCount, fbInfo.frameCount);
+
+                            const uint32_t failedRawBlockCount = zstdgpu_Test_DecompressedDataPerBlockType(
+                                gpuData.GlobalBlockIndexPerRawBlock,
+                                fbInfo.rawBlockCount,
+                                gpuData.PerFrameBlockCountAll,
+                                zstdOutFrameRefs,
+                                fbInfo.frameCount,
+                                gpuData.BlockSizePrefix,
+                                ref,
+                                tst
+                            );
+
+                            const uint32_t failedRleBlockCount = zstdgpu_Test_DecompressedDataPerBlockType(
+                                gpuData.GlobalBlockIndexPerRleBlock,
+                                fbInfo.rleBlockCount,
+                                gpuData.PerFrameBlockCountAll,
+                                zstdOutFrameRefs,
+                                fbInfo.frameCount,
+                                gpuData.BlockSizePrefix,
+                                ref,
+                                tst
+                            );
+
+                            const uint32_t failedCmpBlockCount = zstdgpu_Test_DecompressedDataPerBlockType(
+                                gpuData.GlobalBlockIndexPerCmpBlock,
+                                fbInfo.cmpBlockCount,
+                                gpuData.PerFrameBlockCountAll,
+                                zstdOutFrameRefs,
+                                fbInfo.frameCount,
+                                gpuData.BlockSizePrefix,
+                                ref,
+                                tst
+                            );
+
+                            if (failedRawBlockCount > 0 || failedRleBlockCount > 0)
+                                debugPrint(L"[FAIL] %u/%u RAW blocks and %u/%u RLE blocks failed validation. Likely MemCpy/MemSet pass is broken, unless ExecuteSequence stomps the memory written by MemCpu/MemSet.\n", failedRawBlockCount, fbInfo.rawBlockCount, failedRleBlockCount, fbInfo.rleBlockCount);
+
+                            if (failedCmpBlockCount > 0)
+                                debugPrint(L"[FAIL] %u/%u CMP blocks failed validation. ExecuteSequences is likely broken unless an issue happens earlier in the pipeline or unless TDR is hit.\n", failedCmpBlockCount, fbInfo.cmpBlockCount);
+
                         }
                     }
                 }

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -852,6 +852,8 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
     uint32_t gpuDevId = ~0u;    // means -- find any device id
     uint32_t repCount = 10;
     uint32_t prfLevel = 0;
+    uint32_t minFrame = 0;
+    uint32_t maxFrame = ~0u;
 
 #ifndef _GAMING_XBOX
     {
@@ -862,6 +864,8 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
             bool nextGpuDevId = false;
             bool nextRepCount = false;
             bool nextPrfLevel = false;
+            bool nextMinFrame = false;
+            bool nextMaxFrame = false;
             for (argi = 1; argi < argc; ++argi)
             {
                 if (nextZst)
@@ -885,7 +889,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
                     nextGpuVenId = false;
                     nextGpuDevId = false;
                 }
-                else if (nextRepCount || nextPrfLevel)
+                else if (nextRepCount || nextPrfLevel || nextMinFrame || nextMaxFrame)
                 {
                     errno = 0;
                     wchar_t *end = NULL;
@@ -896,10 +900,16 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
                             repCount = value;
                         else if (nextPrfLevel)
                             prfLevel = value;
+                        else if (nextMinFrame)
+                            minFrame = value;
+                        else if (nextMaxFrame)
+                            maxFrame = value;
                     }
 
                     nextRepCount = false;
                     nextPrfLevel = false;
+                    nextMinFrame = false;
+                    nextMaxFrame = false;
                 }
                 else if (0 == wcscmp(argv[argi], L"--chk-gpu"))
                 {
@@ -945,6 +955,14 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
                 {
                     nextPrfLevel = true;
                 }
+                else if (0 == wcscmp(argv[argi], L"--idx-min"))
+                {
+                    nextMinFrame = true;
+                }
+                else if (0 == wcscmp(argv[argi], L"--idx-max"))
+                {
+                    nextMaxFrame = true;
+                }
             }
             if (1 == argc)
             {
@@ -960,6 +978,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
                 debugPrint(L"\t--run-cnt <count>         [Optional] The number of times to repeat the experiment.\n");
                 debugPrint(L"\t--ext-mem                 [Optional] Enables external heaps so the library doesn't create them.\n");
                 debugPrint(L"\t--prf-lvl <0, 1, 2>       [Optional] Chooses the level of profiling: 0 - overall bandwidth in GB/s, 1 - stage cost, 2 - internal pass cost.\n");
+                debugPrint(L"\t--idx-{min,max} <number>  [Optional] Chooses the {minimal, maximal} index of the frame to decompress in multi-frame .zst file. Both values are clamped to the number of available frames.\n");
             }
             if (NULL == zstFilePathStorage)
             {
@@ -992,6 +1011,27 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
     zstdgpu_OffsetAndSize *zstdOutFrameRefs = (zstdgpu_OffsetAndSize *)malloc(sizeof(zstdgpu_OffsetAndSize) * fbInfo.frameCount);
     zstdgpu_CollectFrames(zstdInFrameRefs, zstdFrameInfo, fbInfo.frameCount, zstdData, zstdCompressedFramesMemorySizeInBytes, zstdDataSize);
 
+    void *zstdDataFree = zstdData;
+    const uint32_t endFrame = fbInfo.frameCount - 1;
+
+
+    // NOTE(pamartis): Support the option to choose a range of frame in the input package/data
+    if (minFrame > 0 || maxFrame < endFrame)
+    {
+        maxFrame = maxFrame < endFrame
+                 ? maxFrame : endFrame;
+        minFrame = minFrame < maxFrame
+                 ? minFrame : maxFrame;
+
+        zstdData = (char*)zstdData + zstdInFrameRefs[minFrame].offs;
+        zstdDataSize = zstdInFrameRefs[maxFrame].offs - zstdInFrameRefs[minFrame].offs + zstdInFrameRefs[maxFrame].size;
+        zstdCompressedFramesMemorySizeInBytes = (zstdDataSize + 3) & ~3u;
+
+        // NOTE(pamartis): update all structures because 'zstdData' and 'zstdDataSize' has changed
+        zstdgpu_CountFramesAndBlocks(&fbInfo, zstdData, zstdCompressedFramesMemorySizeInBytes, zstdDataSize);
+        zstdgpu_CollectFrames(zstdInFrameRefs, zstdFrameInfo, fbInfo.frameCount, zstdData, zstdCompressedFramesMemorySizeInBytes, zstdDataSize);
+    }
+
     // NOTE(pamartis): compute offsets of frame in the output data using the decompressed frame sizes.
     // We also align offset to make sure we support writing several non-consecutive frames from zstdgpu
     // Beceause zstd format doesn't guarantee the presense of uncompressed frame size, we check if any
@@ -1018,7 +1058,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
             free(zstdOutFrameRefs);
             free(zstdInFrameRefs);
             free(zstdFrameInfo);
-            free(zstdData);
+            free(zstdDataFree);
             if (NULL != zstFilePathStorage)
                 free(zstFilePathStorage);
 
@@ -1553,7 +1593,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
     free(zstdOutFrameRefs);
     free(zstdInFrameRefs);
     free(zstdFrameInfo);
-    free(zstdData);
+    free(zstdDataFree);
     if (NULL != zstFilePathStorage)
         free(zstFilePathStorage);
 


### PR DESCRIPTION
This PR brings various small improvements and fixes:
- Adds support for per-IHV shader variant choice
- Updates `d3d12aid.h` containing TDR detection
- Fixes timestamp allocation
- Fixes `Counters` buffer being not updated / readable after the second stage
- Fixes crash in the demo when specified device by id isn't present
- Adds command line options to choose a range of frames to decompress from the package supplied input `.zst` file
- Adds validation of decompressed data at block level to support counting blocks that failed decompression per type for easier diagnostic