### PR TITLE
Map NVIDIA to ExecuteSequences64

### DIFF
--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -8,7 +8,10 @@
  *
  * Advanced Technology Group (ATG)
  * Author(s):   Pavel Martishevsky (pamartis@microsoft.com)
+ * 
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  */
+
 
 #include <stdint.h>
 #include <assert.h>
@@ -597,6 +600,14 @@ ZSTDGPU_ENUM(Status) zstdgpu_CreatePersistentContext(zstdgpu_PersistentContext *
             ZSTDGPU_KERNEL_MAP(DecompressSequences, DecompressSequences_Scalar32);
             ZSTDGPU_KERNEL_MAP(ExecuteSequences, ExecuteSequences64);
         }
+        else if (desc.VendorId == 0x10de)
+        {
+            // Nvidia
+            ZSTDGPU_KERNEL_MAP(DecompressLiterals, DecompressLiterals_LdsStoreCache32_16);
+            context->DecompressLiterals_LdsStoreCache_StreamsPerGroup = 16;
+            ZSTDGPU_KERNEL_MAP(DecompressSequences, DecompressSequences_LdsFseCache32);
+            ZSTDGPU_KERNEL_MAP(ExecuteSequences, ExecuteSequences64);
+        }
         else if (featureOptions1.WaveLaneCountMax == 128)
         {
             ZSTDGPU_KERNEL_MAP(DecompressLiterals, DecompressLiterals_LdsStoreCache128_8);
@@ -604,7 +615,7 @@ ZSTDGPU_ENUM(Status) zstdgpu_CreatePersistentContext(zstdgpu_PersistentContext *
             ZSTDGPU_KERNEL_MAP(DecompressSequences, DecompressSequences_LdsFseCache128);
             ZSTDGPU_KERNEL_MAP(ExecuteSequences, ExecuteSequences128);
         }
-        else //if (desc.VendorId == 0x10de || desc.VendorId == 0x8086 || featureOptions1.WaveLaneCountMax == 32)
+        else //if (desc.VendorId == 0x8086 || featureOptions1.WaveLaneCountMax == 32)
         {
             ZSTDGPU_KERNEL_MAP(DecompressLiterals, DecompressLiterals_LdsStoreCache32_16);
             context->DecompressLiterals_LdsStoreCache_StreamsPerGroup = 16;


### PR DESCRIPTION
Query adapter VendorId to enable vendor-specific shader variant selection, since WaveLaneCountMax alone is insufficient. NVIDIA reports 32, causing it to fall into the generic path with ExecuteSequences32. For NVIDIA (0x10de), select ExecuteSequences64 instead: the 64-thread group is split by the compiler into two 32-lane warps that co-schedule on the same SM, improving SM occupancy (~50% to ~87.5%) and reducing ExecuteSequences execution time by ~20% in profiling.

Tested on Turing and Blackwell.