### PR TITLE
Merge fix for Nvidia shader selection path

### DIFF
--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -622,7 +622,8 @@ ZSTDGPU_ENUM(Status) zstdgpu_CreatePersistentContext(zstdgpu_PersistentContext *
             // Nvidia
             ZSTDGPU_KERNEL_MAP(DecompressLiterals, DecompressLiterals_LdsStoreCache32_16);
             context->DecompressLiterals_LdsStoreCache_StreamsPerGroup = 16;
-            ZSTDGPU_KERNEL_MAP(DecompressSequences, DecompressSequences_LdsFseCache32);
+            ZSTDGPU_KERNEL_MAP(DecompressSequences, DecompressSequences_SingleStream_LdsFseCache32);
+            context->DecompressSequences_StreamsPerGroup = 1;
             ZSTDGPU_KERNEL_MAP(ExecuteSequences, ExecuteSequences64);
         }
         else if (featureOptions1.WaveLaneCountMax == 128)


### PR DESCRIPTION
Addresses the merge issue by selecting the same DecompressSequences and StreamsPerGroup size as the default for Nvidia.