### PR TITLE
zstdgpu/indirect-dispatch: Converts dispatches to indirect dispatches and make them support 32-bit threadgroup count

### DIFF
--- a/zstd/zstdgpu/Shaders/ZstdGpuComputeDestSequenceOffsets.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuComputeDestSequenceOffsets.hlsl
@@ -47,7 +47,7 @@ void main(uint2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
     #include "../zstdgpu_srt_decl_undef.h"
 
     const uint32_t seqIdx = i;
-    const uint32_t seqStreamCnt = srt.inCounters[kzstdgpu_CounterIndex_Seq_Streams];
+    const uint32_t seqStreamCnt = srt.inCounters[0].Seq_Streams;
     const uint32_t seqStreamIdx = zstdgpu_BinarySearch(srt.inPerSeqStreamSeqStart, 0, seqStreamCnt, seqIdx);
     const uint32_t seqIdxBeg = srt.inPerSeqStreamSeqStart[seqStreamIdx];
 
@@ -61,7 +61,7 @@ void main(uint2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
 
     const uint32_t blockIdx = srt.inSeqRefs[seqStreamIdx].blockId;
 
-    const uint32_t frameCnt = srt.inCounters[kzstdgpu_CounterIndex_Frames];
+    const uint32_t frameCnt = srt.inCounters[0].Frames;
     const uint32_t frameIdx = zstdgpu_BinarySearch(srt.inPerFrameBlockCountAll, 0, frameCnt, blockIdx);
 
     const zstdgpu_OffsetAndSize dstFrameOffsAndSize = srt.inUnCompressedFramesRefs[frameIdx];

--- a/zstd/zstdgpu/Shaders/ZstdGpuComputeDestSequenceOffsets.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuComputeDestSequenceOffsets.hlsl
@@ -19,6 +19,7 @@
 struct Consts
 {
     uint32_t tgOffset;
+    uint32_t workItemCount;
 };
 
 ConstantBuffer<Consts>          Constants                           : register(b0);
@@ -29,7 +30,7 @@ ZSTDGPU_COMPUTE_DEST_SEQUENCE_OFFSETS_SRT()
 
 #define NUM_THREADS 256
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=7), UAV(u0, numDescriptors=1)), RootConstants(b0, num32BitConstants=1)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=7), UAV(u0, numDescriptors=1)), RootConstants(b0, num32BitConstants=2)")]
 [numthreads(NUM_THREADS, 1, 1)]
 void main(uint2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
 {

--- a/zstd/zstdgpu/Shaders/ZstdGpuComputePrefixSum.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuComputePrefixSum.hlsl
@@ -21,6 +21,7 @@
 
 struct Consts
 {
+    uint32_t tgOffset;
     uint32_t elemToPrefixCount;
     uint32_t literalsPerGroup;
 };
@@ -40,10 +41,11 @@ RWStructuredBuffer<zstdgpu_Counters>  ZstdCounters                        : regi
 RWStructuredBuffer<uint32_t>          ZstdDispatchArgs                    : register(u5);
 RWStructuredBuffer<uint32_t>          ZstdDispatchCnts                    : register(u6);
 
-[RootSignature("UAV(u0), UAV(u1), UAV(u2), UAV(u3), UAV(u4), UAV(u5), UAV(u6), RootConstants(b0, num32BitConstants=2)")]
+[RootSignature("UAV(u0), UAV(u1), UAV(u2), UAV(u3), UAV(u4), UAV(u5), UAV(u6), RootConstants(b0, num32BitConstants=3)")]
 [numthreads(kzstdgpu_TgSizeX_PrefixSum_LiteralCount, 1, 1)]
-void main(uint i : SV_DispatchThreadId)
+void main(uint2 groupId : SV_GroupId, uint threadId : SV_GroupThreadId)
 {
+    const uint32_t i = zstdgpu_ConvertTo32BitGroupId(groupId, Constants.tgOffset) * kzstdgpu_TgSizeX_PrefixSum_LiteralCount + threadId;
     const uint32_t blockSize = min(kzstdgpu_TgSizeX_PrefixSum_LiteralCount, WaveGetLaneCount());
     const uint32_t thisBlockIndex = WaveReadLaneFirst(i / blockSize);
     const uint32_t thisLocalIndex = i % blockSize;

--- a/zstd/zstdgpu/Shaders/ZstdGpuComputePrefixSum.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuComputePrefixSum.hlsl
@@ -38,8 +38,9 @@ RWStructuredBuffer<uint32_t>    ZstdLitGroupCountToPrefixLookback   : register(u
 
 RWStructuredBuffer<zstdgpu_Counters>  ZstdCounters                        : register(u4);
 RWStructuredBuffer<uint32_t>          ZstdDispatchArgs                    : register(u5);
+RWStructuredBuffer<uint32_t>          ZstdDispatchCnts                    : register(u6);
 
-[RootSignature("UAV(u0), UAV(u1), UAV(u2), UAV(u3), UAV(u4), UAV(u5), RootConstants(b0, num32BitConstants=2)")]
+[RootSignature("UAV(u0), UAV(u1), UAV(u2), UAV(u3), UAV(u4), UAV(u5), UAV(u6), RootConstants(b0, num32BitConstants=2)")]
 [numthreads(kzstdgpu_TgSizeX_PrefixSum_LiteralCount, 1, 1)]
 void main(uint i : SV_DispatchThreadId)
 {
@@ -139,6 +140,6 @@ void main(uint i : SV_DispatchThreadId)
     {
         const uint32_t totalGroups = ZstdLitGroupCountToPrefix[i];
         ZstdCounters[0].DecompressLiteralsGroups = totalGroups;
-        zstdgpu_EmitDispatch(ZstdDispatchArgs, kzstdgpu_DispatchSlot_DecompressLiterals, totalGroups, 1);
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_DecompressLiterals, totalGroups, 1);
     }
 }

--- a/zstd/zstdgpu/Shaders/ZstdGpuComputePrefixSum.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuComputePrefixSum.hlsl
@@ -36,7 +36,7 @@ RWStructuredBuffer<uint32_t>    ZstdLitStreamCountToPrefixLookback  : register(u
 globallycoherent
 RWStructuredBuffer<uint32_t>    ZstdLitGroupCountToPrefixLookback   : register(u3);
 
-RWStructuredBuffer<uint32_t>    ZstdCounters                        : register(u4);
+RWStructuredBuffer<zstdgpu_Counters> ZstdCounters                        : register(u4);
 
 [RootSignature("UAV(u0), UAV(u1), UAV(u2), UAV(u3), UAV(u4), RootConstants(b0, num32BitConstants=2)")]
 [numthreads(kzstdgpu_TgSizeX_PrefixSum_LiteralCount, 1, 1)]
@@ -136,6 +136,6 @@ void main(uint i : SV_DispatchThreadId)
     // to be dispatched for literal decompression
     if (i == Constants.elemToPrefixCount - 1)
     {
-        ZstdCounters[kzstdgpu_CounterIndex_DecompressLiteralsGroups] = ZstdLitGroupCountToPrefix[i];
+        ZstdCounters[0].DecompressLiteralsGroups = ZstdLitGroupCountToPrefix[i];
     }
 }

--- a/zstd/zstdgpu/Shaders/ZstdGpuComputePrefixSum.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuComputePrefixSum.hlsl
@@ -22,7 +22,7 @@
 struct Consts
 {
     uint32_t tgOffset;
-    uint32_t elemToPrefixCount;
+    uint32_t workItemCount;
     uint32_t literalsPerGroup;
 };
 
@@ -48,7 +48,7 @@ void main(uint2 groupId : SV_GroupId, uint threadId : SV_GroupThreadId)
     const uint32_t thisBlockIndex = WaveReadLaneFirst(i / blockSize);
     const uint32_t thisLocalIndex = i % blockSize;
 
-    if (i >= Constants.elemToPrefixCount)
+    if (i >= Constants.workItemCount)
         return;
 
     const uint32_t lastLocalIndex = WaveActiveCountBits(true) - 1u;
@@ -136,7 +136,7 @@ void main(uint2 groupId : SV_GroupId, uint threadId : SV_GroupThreadId)
 
     // NOTE(pamartis): the last thread in the dispatch writes its "inclusive" prefix sum because it's the total number of threadgroups
     // to be dispatched for literal decompression
-    if (i == Constants.elemToPrefixCount - 1)
+    if (i == Constants.workItemCount - 1)
     {
         ZstdCounters[0].DecompressLiteralsGroups = ZstdLitGroupCountToPrefix[i];
     }

--- a/zstd/zstdgpu/Shaders/ZstdGpuComputePrefixSum.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuComputePrefixSum.hlsl
@@ -17,7 +17,7 @@
  * Author(s):   Pavel Martishevsky (pamartis@microsoft.com)
  */
 
-#include "../zstdgpu_structs.h"
+#include "../zstdgpu_shaders.h"
 
 struct Consts
 {
@@ -36,9 +36,10 @@ RWStructuredBuffer<uint32_t>    ZstdLitStreamCountToPrefixLookback  : register(u
 globallycoherent
 RWStructuredBuffer<uint32_t>    ZstdLitGroupCountToPrefixLookback   : register(u3);
 
-RWStructuredBuffer<zstdgpu_Counters> ZstdCounters                        : register(u4);
+RWStructuredBuffer<zstdgpu_Counters>  ZstdCounters                        : register(u4);
+RWStructuredBuffer<uint32_t>          ZstdDispatchArgs                    : register(u5);
 
-[RootSignature("UAV(u0), UAV(u1), UAV(u2), UAV(u3), UAV(u4), RootConstants(b0, num32BitConstants=2)")]
+[RootSignature("UAV(u0), UAV(u1), UAV(u2), UAV(u3), UAV(u4), UAV(u5), RootConstants(b0, num32BitConstants=2)")]
 [numthreads(kzstdgpu_TgSizeX_PrefixSum_LiteralCount, 1, 1)]
 void main(uint i : SV_DispatchThreadId)
 {
@@ -136,6 +137,8 @@ void main(uint i : SV_DispatchThreadId)
     // to be dispatched for literal decompression
     if (i == Constants.elemToPrefixCount - 1)
     {
-        ZstdCounters[0].DecompressLiteralsGroups = ZstdLitGroupCountToPrefix[i];
+        const uint32_t totalGroups = ZstdLitGroupCountToPrefix[i];
+        ZstdCounters[0].DecompressLiteralsGroups = totalGroups;
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, kzstdgpu_DispatchSlot_DecompressLiterals, totalGroups, 1);
     }
 }

--- a/zstd/zstdgpu/Shaders/ZstdGpuComputePrefixSum.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuComputePrefixSum.hlsl
@@ -37,11 +37,9 @@ RWStructuredBuffer<uint32_t>    ZstdLitStreamCountToPrefixLookback  : register(u
 globallycoherent
 RWStructuredBuffer<uint32_t>    ZstdLitGroupCountToPrefixLookback   : register(u3);
 
-RWStructuredBuffer<zstdgpu_Counters>  ZstdCounters                        : register(u4);
-RWStructuredBuffer<uint32_t>          ZstdDispatchArgs                    : register(u5);
-RWStructuredBuffer<uint32_t>          ZstdDispatchCnts                    : register(u6);
+RWStructuredBuffer<zstdgpu_Counters>  ZstdCounters                 : register(u4);
 
-[RootSignature("UAV(u0), UAV(u1), UAV(u2), UAV(u3), UAV(u4), UAV(u5), UAV(u6), RootConstants(b0, num32BitConstants=3)")]
+[RootSignature("UAV(u0), UAV(u1), UAV(u2), UAV(u3), UAV(u4), RootConstants(b0, num32BitConstants=3)")]
 [numthreads(kzstdgpu_TgSizeX_PrefixSum_LiteralCount, 1, 1)]
 void main(uint2 groupId : SV_GroupId, uint threadId : SV_GroupThreadId)
 {
@@ -140,8 +138,6 @@ void main(uint2 groupId : SV_GroupId, uint threadId : SV_GroupThreadId)
     // to be dispatched for literal decompression
     if (i == Constants.elemToPrefixCount - 1)
     {
-        const uint32_t totalGroups = ZstdLitGroupCountToPrefix[i];
-        ZstdCounters[0].DecompressLiteralsGroups = totalGroups;
-        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_DecompressLiterals, totalGroups, 1);
+        ZstdCounters[0].DecompressLiteralsGroups = ZstdLitGroupCountToPrefix[i];
     }
 }

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecodeHuffmanWeights.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecodeHuffmanWeights.hlsl
@@ -20,6 +20,7 @@
 struct Consts
 {
     uint32_t tgOffset;
+    uint32_t workItemCount;
     uint32_t ZstdCompressedBlockCount;
     uint32_t ZstdCompressedBufferSizeInBytes;
 };
@@ -34,7 +35,7 @@ ZSTDGPU_DECODE_HUFFMAN_WEIGHTS_SRT()
 #define __XBOX_ENABLE_WAVE32 1
 #endif
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=3), UAV(u0, numDescriptors=2)), RootConstants(b0, num32BitConstants=3)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=3), UAV(u0, numDescriptors=2)), RootConstants(b0, num32BitConstants=4)")]
 [numthreads(kzstdgpu_TgSizeX_DecodeHuffmanWeights, 1, 1)]
 void main(uint2 groupId2 : SV_GroupID, uint32_t i : SV_GroupThreadId)
 {

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecodeHuffmanWeights.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecodeHuffmanWeights.hlsl
@@ -19,6 +19,7 @@
 
 struct Consts
 {
+    uint32_t tgOffset;
     uint32_t ZstdCompressedBlockCount;
     uint32_t ZstdCompressedBufferSizeInBytes;
 };
@@ -33,7 +34,7 @@ ZSTDGPU_DECODE_HUFFMAN_WEIGHTS_SRT()
 #define __XBOX_ENABLE_WAVE32 1
 #endif
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=3), UAV(u0, numDescriptors=2)), RootConstants(b0, num32BitConstants=2)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=3), UAV(u0, numDescriptors=2)), RootConstants(b0, num32BitConstants=3)")]
 [numthreads(kzstdgpu_TgSizeX_DecodeHuffmanWeights, 1, 1)]
 void main(uint i : SV_DispatchThreadId)
 {

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecodeHuffmanWeights.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecodeHuffmanWeights.hlsl
@@ -36,8 +36,10 @@ ZSTDGPU_DECODE_HUFFMAN_WEIGHTS_SRT()
 
 [RootSignature("DescriptorTable(SRV(t0, numDescriptors=3), UAV(u0, numDescriptors=2)), RootConstants(b0, num32BitConstants=3)")]
 [numthreads(kzstdgpu_TgSizeX_DecodeHuffmanWeights, 1, 1)]
-void main(uint i : SV_DispatchThreadId)
+void main(uint2 groupId2 : SV_GroupID, uint32_t i : SV_GroupThreadId)
 {
+    i += zstdgpu_ConvertTo32BitGroupId(groupId2, Constants.tgOffset) * kzstdgpu_TgSizeX_DecodeHuffmanWeights;
+
     zstdgpu_DecodeHuffmanWeights_SRT srt;
     #include "../zstdgpu_srt_decl_copy.h"
     ZSTDGPU_DECODE_HUFFMAN_WEIGHTS_SRT()

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressHuffmanWeights.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressHuffmanWeights.hlsl
@@ -21,11 +21,18 @@
 ZSTDGPU_DECOMPRESS_HUFFMAN_WEIGHTS_SRT()
 #include "../zstdgpu_srt_decl_undef.h"
 
+struct Consts
+{
+    uint32_t tgOffset;
+};
+
+ConstantBuffer<Consts> Constants : register(b0);
+
 #ifdef __XBOX_SCARLETT
 #define __XBOX_ENABLE_WAVE32 1
 #endif
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=5), UAV(u0, numDescriptors=2))")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=5), UAV(u0, numDescriptors=2)), RootConstants(b0, num32BitConstants=1)")]
 [numthreads(kzstdgpu_TgSizeX_DecompressHuffmanWeights, 1, 1)]
 void main(uint i : SV_DispatchThreadId)
 {

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressHuffmanWeights.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressHuffmanWeights.hlsl
@@ -34,8 +34,10 @@ ConstantBuffer<Consts> Constants : register(b0);
 
 [RootSignature("DescriptorTable(SRV(t0, numDescriptors=5), UAV(u0, numDescriptors=2)), RootConstants(b0, num32BitConstants=1)")]
 [numthreads(kzstdgpu_TgSizeX_DecompressHuffmanWeights, 1, 1)]
-void main(uint i : SV_DispatchThreadId)
+void main(uint2 groupId : SV_GroupID, uint32_t i : SV_GroupThreadId)
 {
+    i += zstdgpu_ConvertTo32BitGroupId(groupId, Constants.tgOffset) * kzstdgpu_TgSizeX_DecompressHuffmanWeights;
+
     zstdgpu_DecompressHuffmanWeights_SRT srt;
 
     #include "../zstdgpu_srt_decl_copy.h"

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressHuffmanWeights.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressHuffmanWeights.hlsl
@@ -24,6 +24,7 @@ ZSTDGPU_DECOMPRESS_HUFFMAN_WEIGHTS_SRT()
 struct Consts
 {
     uint32_t tgOffset;
+    uint32_t workItemCount;
 };
 
 ConstantBuffer<Consts> Constants : register(b0);
@@ -32,7 +33,7 @@ ConstantBuffer<Consts> Constants : register(b0);
 #define __XBOX_ENABLE_WAVE32 1
 #endif
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=5), UAV(u0, numDescriptors=2)), RootConstants(b0, num32BitConstants=1)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=5), UAV(u0, numDescriptors=2)), RootConstants(b0, num32BitConstants=2)")]
 [numthreads(kzstdgpu_TgSizeX_DecompressHuffmanWeights, 1, 1)]
 void main(uint2 groupId : SV_GroupID, uint32_t i : SV_GroupThreadId)
 {

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressLiterals.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressLiterals.hlsl
@@ -39,8 +39,9 @@ groupshared uint32_t GS_Lds[kzstdgpu_DecompressLiterals_LdsSize];
 
 [RootSignature("DescriptorTable(SRV(t0, numDescriptors=9), UAV(u0, numDescriptors=1)),RootConstants(b0, num32BitConstants=2)")]
 [numthreads(kzstdgpu_TgSizeX_DecompressLiterals, 1, 1)]
-void main(uint groupId : SV_GroupId, uint i : SV_GroupThreadId)
+void main(uint2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
 {
+    const uint32_t groupId = zstdgpu_ConvertTo32BitGroupId(groupId2, Constants.tgOffset);
     zstdgpu_DecompressLiterals_SRT srt;
 
     #include "../zstdgpu_srt_decl_copy.h"

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressLiterals.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressLiterals.hlsl
@@ -19,6 +19,7 @@
 struct Consts
 {
     uint32_t tgOffset;
+    uint32_t workItemCount;
     uint32_t huffmanTableSlotCount;
 };
 
@@ -37,7 +38,7 @@ groupshared uint32_t GS_Lds[kzstdgpu_DecompressLiterals_LdsSize];
 #define __XBOX_ENABLE_WAVE32 1
 #endif
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=9), UAV(u0, numDescriptors=1)),RootConstants(b0, num32BitConstants=2)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=9), UAV(u0, numDescriptors=1)),RootConstants(b0, num32BitConstants=3)")]
 [numthreads(kzstdgpu_TgSizeX_DecompressLiterals, 1, 1)]
 void main(uint2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
 {

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressLiterals.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressLiterals.hlsl
@@ -47,7 +47,7 @@ void main(uint groupId : SV_GroupId, uint i : SV_GroupThreadId)
     #include "../zstdgpu_srt_decl_undef.h"
     srt.huffmanTableSlotCount   = Constants.huffmanTableSlotCount;
 
-    if (groupId >= srt.inCounters[kzstdgpu_CounterIndex_DecompressLiteralsGroups])
+    if (groupId >= srt.inCounters[0].DecompressLiteralsGroups)
         return;
 
     zstdgpu_ShaderEntry_DecompressLiterals(srt, groupId, i, kzstdgpu_TgSizeX_DecompressLiterals);

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressLiterals.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressLiterals.hlsl
@@ -18,6 +18,7 @@
 
 struct Consts
 {
+    uint32_t tgOffset;
     uint32_t huffmanTableSlotCount;
 };
 
@@ -36,7 +37,7 @@ groupshared uint32_t GS_Lds[kzstdgpu_DecompressLiterals_LdsSize];
 #define __XBOX_ENABLE_WAVE32 1
 #endif
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=9), UAV(u0, numDescriptors=1)),RootConstants(b0, num32BitConstants=1)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=9), UAV(u0, numDescriptors=1)),RootConstants(b0, num32BitConstants=2)")]
 [numthreads(kzstdgpu_TgSizeX_DecompressLiterals, 1, 1)]
 void main(uint groupId : SV_GroupId, uint i : SV_GroupThreadId)
 {

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressLiterals_LdsStoreCache.hlsli
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressLiterals_LdsStoreCache.hlsli
@@ -72,8 +72,10 @@ groupshared uint32_t GS_Lds[kzstdgpu_DecompressLiterals_LdsStoreCache_LdsSize];
 
 [RootSignature("DescriptorTable(SRV(t0, numDescriptors=9), UAV(u0, numDescriptors=2)), RootConstants(b0, num32BitConstants=2)")]
 [numthreads(kzstdgpu_TgSizeX_DecompressLiterals_LdsStoreCache, 1, 1)]
-void main(uint groupId : SV_GroupId, uint i : SV_GroupThreadId)
+void main(uint2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
 {
+    const uint32_t groupId = zstdgpu_ConvertTo32BitGroupId(groupId2, Constants.tgOffset);
+
     zstdgpu_DecompressLiterals_SRT srt;
 
     #include "../zstdgpu_srt_decl_copy.h"

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressLiterals_LdsStoreCache.hlsli
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressLiterals_LdsStoreCache.hlsli
@@ -80,7 +80,7 @@ void main(uint groupId : SV_GroupId, uint i : SV_GroupThreadId)
     #include "../zstdgpu_srt_decl_undef.h"
     srt.huffmanTableSlotCount   = Constants.huffmanTableSlotCount;
 
-    if (groupId >= srt.inCounters[kzstdgpu_CounterIndex_DecompressLiteralsGroups])
+    if (groupId >= srt.inCounters[0].DecompressLiteralsGroups)
         return;
 
     uint32_t htIndex = 0;
@@ -109,7 +109,7 @@ void main(uint groupId : SV_GroupId, uint i : SV_GroupThreadId)
     const uint32_t stateCnt = WaveReadLaneFirst(srt.inHuffmanTableRankIndex[htIndex * kzstdgpu_MaxCount_HuffmanWeightRanks + bitsMax]);
     const uint32_t statePairCnt = stateCnt >> 1u;
 
-    // Expand Huffman Table — pack two symbol+bitcnt pairs per dword
+    // Expand Huffman Table -- pack two symbol+bitcnt pairs per dword
     ZSTDGPU_FOR_WORK_ITEMS(statePairId, statePairCnt, i, kzstdgpu_TgSizeX_DecompressLiterals_LdsStoreCache)
     {
         const uint32_t stateId0 = statePairId << 1u;

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressLiterals_LdsStoreCache.hlsli
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressLiterals_LdsStoreCache.hlsli
@@ -57,6 +57,7 @@ ZSTDGPU_DECOMPRESS_LITERALS_LDS_STORE_CACHE(0, DecompressLiterals_LdsStoreCache)
 struct Consts
 {
     uint32_t tgOffset;
+    uint32_t workItemCount;
     uint32_t huffmanTableSlotCount;
 };
 
@@ -70,7 +71,7 @@ groupshared uint32_t GS_Lds[kzstdgpu_DecompressLiterals_LdsStoreCache_LdsSize];
 #define ZSTDGPU_LDS GS_Lds
 #include "../zstdgpu_lds_hlsl.h"
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=9), UAV(u0, numDescriptors=2)), RootConstants(b0, num32BitConstants=2)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=9), UAV(u0, numDescriptors=2)), RootConstants(b0, num32BitConstants=3)")]
 [numthreads(kzstdgpu_TgSizeX_DecompressLiterals_LdsStoreCache, 1, 1)]
 void main(uint2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
 {

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressLiterals_LdsStoreCache.hlsli
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressLiterals_LdsStoreCache.hlsli
@@ -56,6 +56,7 @@ ZSTDGPU_DECOMPRESS_LITERALS_LDS_STORE_CACHE(0, DecompressLiterals_LdsStoreCache)
 
 struct Consts
 {
+    uint32_t tgOffset;
     uint32_t huffmanTableSlotCount;
 };
 
@@ -69,7 +70,7 @@ groupshared uint32_t GS_Lds[kzstdgpu_DecompressLiterals_LdsStoreCache_LdsSize];
 #define ZSTDGPU_LDS GS_Lds
 #include "../zstdgpu_lds_hlsl.h"
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=9), UAV(u0, numDescriptors=2)), RootConstants(b0, num32BitConstants=1)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=9), UAV(u0, numDescriptors=2)), RootConstants(b0, num32BitConstants=2)")]
 [numthreads(kzstdgpu_TgSizeX_DecompressLiterals_LdsStoreCache, 1, 1)]
 void main(uint groupId : SV_GroupId, uint i : SV_GroupThreadId)
 {

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_MultiStream.hlsli
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_MultiStream.hlsli
@@ -28,6 +28,7 @@
 struct Consts
 {
     uint32_t tgOffset;
+    uint32_t workItemCount;
 };
 
 ConstantBuffer<Consts> Constants : register(b0);
@@ -36,7 +37,7 @@ ConstantBuffer<Consts> Constants : register(b0);
 ZSTDGPU_DECOMPRESS_SEQUENCES_SRT()
 #include "../zstdgpu_srt_decl_undef.h"
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=6), UAV(u0, numDescriptors=7)), RootConstants(b0, num32BitConstants=1)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=6), UAV(u0, numDescriptors=7)), RootConstants(b0, num32BitConstants=2)")]
 [numthreads(kzstdgpu_DecompressSequences_StreamsPerTG, 1, 1)]
 void main(uint32_t2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
 {

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_MultiStream.hlsli
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_MultiStream.hlsli
@@ -40,12 +40,7 @@ ZSTDGPU_DECOMPRESS_SEQUENCES_SRT()
 [numthreads(kzstdgpu_DecompressSequences_StreamsPerTG, 1, 1)]
 void main(uint32_t2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
 {
-#if defined(__XBOX_SCARLETT) || defined(__XBOX_ONE)
-    const uint32_t groupId = groupId2.x;
-#else
-    const uint32_t groupId = Constants.tgOffset + groupId2.y * 65535 + groupId2.x;
-#endif
-
+    const uint32_t groupId = zstdgpu_ConvertTo32BitGroupId(groupId2, Constants.tgOffset);
     zstdgpu_DecompressSequences_SRT srt;
 
     #include "../zstdgpu_srt_decl_copy.h"

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_MultiStream_LdsOutCache.hlsli
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_MultiStream_LdsOutCache.hlsli
@@ -54,12 +54,7 @@ groupshared uint32_t Lds[kzstdgpu_DecompressSequences_MultiStream_LdsOutCache_Ld
 [numthreads(NUM_THREADS, 1, 1)]
 void main(uint32_t2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
 {
-#if defined(__XBOX_SCARLETT) || defined(__XBOX_ONE)
-    const uint32_t groupId = groupId2.x;
-#else
-    const uint32_t groupId = Constants.tgOffset + groupId2.y * 65535 + groupId2.x;
-#endif
-
+    const uint32_t groupId = zstdgpu_ConvertTo32BitGroupId(groupId2, Constants.tgOffset);
     zstdgpu_DecompressSequences_SRT srt;
 
     #include "../zstdgpu_srt_decl_copy.h"

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_MultiStream_LdsOutCache.hlsli
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_MultiStream_LdsOutCache.hlsli
@@ -38,6 +38,7 @@
 struct Consts
 {
     uint32_t tgOffset;
+    uint32_t workItemCount;
 };
 
 ConstantBuffer<Consts> Constants : register(b0);
@@ -50,7 +51,7 @@ groupshared uint32_t Lds[kzstdgpu_DecompressSequences_MultiStream_LdsOutCache_Ld
 #define ZSTDGPU_LDS Lds
 #include "../zstdgpu_lds_hlsl.h"
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=6), UAV(u0, numDescriptors=7)), RootConstants(b0, num32BitConstants=1)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=6), UAV(u0, numDescriptors=7)), RootConstants(b0, num32BitConstants=2)")]
 [numthreads(NUM_THREADS, 1, 1)]
 void main(uint32_t2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
 {

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_SingleStream.hlsli
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_SingleStream.hlsli
@@ -59,11 +59,7 @@ groupshared uint32_t Lds[kzstdgpu_DecompressSequences_SingleStream_LdsFseCache_L
 [numthreads(kzstdgpu_TgSizeX_DecompressSequences_SingleStream, 1, 1)]
 void main(uint32_t2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
 {
-#if defined(__XBOX_SCARLETT) || defined(__XBOX_ONE)
-    const uint32_t groupId = groupId2.x;
-#else
-    const uint32_t groupId = Constants.tgOffset + groupId2.y * 65535 + groupId2.x;
-#endif
+    const uint32_t groupId = zstdgpu_ConvertTo32BitGroupId(groupId2, Constants.tgOffset);
     zstdgpu_DecompressSequences_SRT srt;
 
     #include "../zstdgpu_srt_decl_copy.h"

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_SingleStream.hlsli
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_SingleStream.hlsli
@@ -37,6 +37,7 @@
 struct Consts
 {
     uint32_t tgOffset;
+    uint32_t workItemCount;
 };
 
 ConstantBuffer<Consts> Constants : register(b0);
@@ -55,7 +56,7 @@ groupshared uint32_t Lds[kzstdgpu_DecompressSequences_SingleStream_LdsFseCache_L
 #   error 'kzstdgpu_TgSizeX_DecompressSequences_SingleStream' must be defined before including this '.hlsli'
 #endif
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=6), UAV(u0, numDescriptors=7)), RootConstants(b0, num32BitConstants=1)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=6), UAV(u0, numDescriptors=7)), RootConstants(b0, num32BitConstants=2)")]
 [numthreads(kzstdgpu_TgSizeX_DecompressSequences_SingleStream, 1, 1)]
 void main(uint32_t2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
 {

--- a/zstd/zstdgpu/Shaders/ZstdGpuFinaliseSequenceOffsets.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuFinaliseSequenceOffsets.hlsl
@@ -23,6 +23,7 @@
 struct Consts
 {
     uint32_t tgOffset;
+    uint32_t workItemCount;
 };
 
 ConstantBuffer<Consts> Constants : register(b0);
@@ -31,7 +32,7 @@ ConstantBuffer<Consts> Constants : register(b0);
 ZSTDGPU_FINALISE_SEQUENCE_OFFSETS_SRT()
 #include "../zstdgpu_srt_decl_undef.h"
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=8), UAV(u0, numDescriptors=1)), RootConstants(b0, num32BitConstants=1)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=8), UAV(u0, numDescriptors=1)), RootConstants(b0, num32BitConstants=2)")]
 [numthreads(kzstdgpu_TgSizeX_FinaliseSequenceOffsets, 1, 1)]
 void main(uint2 groupId : SV_GroupId, uint i : SV_GroupThreadId)
 {

--- a/zstd/zstdgpu/Shaders/ZstdGpuFinaliseSequenceOffsets.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuFinaliseSequenceOffsets.hlsl
@@ -41,11 +41,7 @@ void main(uint2 groupId : SV_GroupId, uint i : SV_GroupThreadId)
     ZSTDGPU_FINALISE_SEQUENCE_OFFSETS_SRT()
     #include "../zstdgpu_srt_decl_undef.h"
 
-#if defined(__XBOX_SCARLETT) || defined(__XBOX_ONE)
-    i += groupId.x * kzstdgpu_TgSizeX_FinaliseSequenceOffsets;
-#else
-    i += (Constants.tgOffset + groupId.y * 65535 + groupId.x) * kzstdgpu_TgSizeX_FinaliseSequenceOffsets;
-#endif
+    i += zstdgpu_ConvertTo32BitGroupId(groupId, Constants.tgOffset) * kzstdgpu_TgSizeX_FinaliseSequenceOffsets;
 
     zstdgpu_ShaderEntry_FinaliseSequenceOffsets(srt, i);
 }

--- a/zstd/zstdgpu/Shaders/ZstdGpuGroupCompressedLiterals.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuGroupCompressedLiterals.hlsl
@@ -26,11 +26,12 @@ RWStructuredBuffer<uint32_t>                            ZstdLitStreamMap        
 struct Consts
 {
     uint32_t tgOffset;
+    uint32_t workItemCount;
 };
 
 ConstantBuffer<Consts> Constants : register(b0);
 
-[RootSignature("SRV(t0), SRV(t1), SRV(t2), UAV(u0), RootConstants(b0, num32BitConstants=1)")]
+[RootSignature("SRV(t0), SRV(t1), SRV(t2), UAV(u0), RootConstants(b0, num32BitConstants=2)")]
 [numthreads(32, 1, 1)]
 void main(uint2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
 {

--- a/zstd/zstdgpu/Shaders/ZstdGpuGroupCompressedLiterals.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuGroupCompressedLiterals.hlsl
@@ -23,7 +23,14 @@ StructuredBuffer<zstdgpu_CompressedLiteralHuffmanBucket> ZstdLitStreamHuffmanBuc
 StructuredBuffer<zstdgpu_Counters>                      ZstdCounters                : register(t2);
 RWStructuredBuffer<uint32_t>                            ZstdLitStreamMap            : register(u0);
 
-[RootSignature("SRV(t0), SRV(t1), SRV(t2), UAV(u0)")]
+struct Consts
+{
+    uint32_t tgOffset;
+};
+
+ConstantBuffer<Consts> Constants : register(b0);
+
+[RootSignature("SRV(t0), SRV(t1), SRV(t2), UAV(u0), RootConstants(b0, num32BitConstants=1)")]
 [numthreads(32, 1, 1)]
 void main(uint litStreamId : SV_DispatchThreadId)
 {

--- a/zstd/zstdgpu/Shaders/ZstdGpuGroupCompressedLiterals.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuGroupCompressedLiterals.hlsl
@@ -20,14 +20,14 @@
 
 StructuredBuffer<uint32_t>                              ZstdLitStreamCountPrefix    : register(t0);
 StructuredBuffer<zstdgpu_CompressedLiteralHuffmanBucket> ZstdLitStreamHuffmanBuckets : register(t1);
-StructuredBuffer<uint32_t>                              ZstdCounters                : register(t2);
+StructuredBuffer<zstdgpu_Counters>                      ZstdCounters                : register(t2);
 RWStructuredBuffer<uint32_t>                            ZstdLitStreamMap            : register(u0);
 
 [RootSignature("SRV(t0), SRV(t1), SRV(t2), UAV(u0)")]
 [numthreads(32, 1, 1)]
 void main(uint litStreamId : SV_DispatchThreadId)
 {
-    if (litStreamId >= ZstdCounters[kzstdgpu_CounterIndex_HUF_Streams])
+    if (litStreamId >= ZstdCounters[0].HUF_Streams)
         return;
 
     const zstdgpu_CompressedLiteralHuffmanBucket bucket = ZstdLitStreamHuffmanBuckets[litStreamId];

--- a/zstd/zstdgpu/Shaders/ZstdGpuGroupCompressedLiterals.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuGroupCompressedLiterals.hlsl
@@ -16,7 +16,7 @@
  * Author(s):   Pavel Martishevsky (pamartis@microsoft.com)
  */
 
-#include "../zstdgpu_structs.h"
+#include "../zstdgpu_shaders.h"
 
 StructuredBuffer<uint32_t>                              ZstdLitStreamCountPrefix    : register(t0);
 StructuredBuffer<zstdgpu_CompressedLiteralHuffmanBucket> ZstdLitStreamHuffmanBuckets : register(t1);
@@ -32,8 +32,10 @@ ConstantBuffer<Consts> Constants : register(b0);
 
 [RootSignature("SRV(t0), SRV(t1), SRV(t2), UAV(u0), RootConstants(b0, num32BitConstants=1)")]
 [numthreads(32, 1, 1)]
-void main(uint litStreamId : SV_DispatchThreadId)
+void main(uint2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
 {
+    const uint32_t groupId = zstdgpu_ConvertTo32BitGroupId(groupId2, Constants.tgOffset);
+    const uint32_t litStreamId = groupId * 32 + i;
     if (litStreamId >= ZstdCounters[0].HUF_Streams)
         return;
 

--- a/zstd/zstdgpu/Shaders/ZstdGpuInitFseTable.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuInitFseTable.hlsl
@@ -45,6 +45,7 @@
 struct Consts
 {
     uint32_t tgOffset;
+    uint32_t workItemCount;
     uint32_t tableStartIndex;
     uint32_t tableDataStart;
     uint32_t tableDataCount;
@@ -65,7 +66,7 @@ groupshared uint32_t Lds[kzstdgpu_InitFseTable_Experimental_LdsSize];
 #define ZSTDGPU_LDS Lds
 #include "../zstdgpu_lds_hlsl.h"
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors = 2), UAV(u0, numDescriptors=1)), RootConstants(b0, num32BitConstants=4)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors = 2), UAV(u0, numDescriptors=1)), RootConstants(b0, num32BitConstants=5)")]
 [numthreads(kzstdgpu_TgSizeX_InitFseTable, 1, 1)]
 void main(uint2 groupId2 : SV_GroupId, uint32_t i : SV_GroupThreadId)
 {

--- a/zstd/zstdgpu/Shaders/ZstdGpuInitFseTable.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuInitFseTable.hlsl
@@ -44,6 +44,7 @@
 
 struct Consts
 {
+    uint32_t tgOffset;
     uint32_t tableStartIndex;
     uint32_t tableDataStart;
     uint32_t tableDataCount;
@@ -64,7 +65,7 @@ groupshared uint32_t Lds[kzstdgpu_InitFseTable_Experimental_LdsSize];
 #define ZSTDGPU_LDS Lds
 #include "../zstdgpu_lds_hlsl.h"
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors = 2), UAV(u0, numDescriptors=1)), RootConstants(b0, num32BitConstants=3)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors = 2), UAV(u0, numDescriptors=1)), RootConstants(b0, num32BitConstants=4)")]
 [numthreads(kzstdgpu_TgSizeX_InitFseTable, 1, 1)]
 void main(uint32_t groupId : SV_GroupId, uint32_t i : SV_GroupThreadId)
 {

--- a/zstd/zstdgpu/Shaders/ZstdGpuInitFseTable.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuInitFseTable.hlsl
@@ -67,8 +67,10 @@ groupshared uint32_t Lds[kzstdgpu_InitFseTable_Experimental_LdsSize];
 
 [RootSignature("DescriptorTable(SRV(t0, numDescriptors = 2), UAV(u0, numDescriptors=1)), RootConstants(b0, num32BitConstants=4)")]
 [numthreads(kzstdgpu_TgSizeX_InitFseTable, 1, 1)]
-void main(uint32_t groupId : SV_GroupId, uint32_t i : SV_GroupThreadId)
+void main(uint2 groupId2 : SV_GroupId, uint32_t i : SV_GroupThreadId)
 {
+    const uint32_t groupId = zstdgpu_ConvertTo32BitGroupId(groupId2, Constants.tgOffset);
+
     zstdgpu_InitFseTable_SRT srt;
 
     #include "../zstdgpu_srt_decl_copy.h"

--- a/zstd/zstdgpu/Shaders/ZstdGpuInitHuffmanTable.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuInitHuffmanTable.hlsl
@@ -19,6 +19,7 @@
 
 struct Consts
 {
+    uint32_t tgOffset;
     uint32_t HuffmanTableBase;
 };
 
@@ -37,7 +38,7 @@ groupshared uint32_t GS_Lds[kzstdgpu_InitHuffmanTable_LdsSize];
 #define __XBOX_ENABLE_WAVE32 1
 #endif
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=2), UAV(u0, numDescriptors=3)), RootConstants(b0, num32BitConstants=1)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=2), UAV(u0, numDescriptors=3)), RootConstants(b0, num32BitConstants=2)")]
 [numthreads(kzstdgpu_TgSizeX_DecompressLiterals, 1, 1)]
 void main(uint groupId : SV_GroupId, uint i : SV_GroupThreadId)
 {

--- a/zstd/zstdgpu/Shaders/ZstdGpuInitHuffmanTable.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuInitHuffmanTable.hlsl
@@ -20,6 +20,7 @@
 struct Consts
 {
     uint32_t tgOffset;
+    uint32_t workItemCount;
     uint32_t HuffmanTableBase;
 };
 
@@ -38,7 +39,7 @@ groupshared uint32_t GS_Lds[kzstdgpu_InitHuffmanTable_LdsSize];
 #define __XBOX_ENABLE_WAVE32 1
 #endif
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=2), UAV(u0, numDescriptors=3)), RootConstants(b0, num32BitConstants=2)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=2), UAV(u0, numDescriptors=3)), RootConstants(b0, num32BitConstants=3)")]
 [numthreads(kzstdgpu_TgSizeX_DecompressLiterals, 1, 1)]
 void main(uint2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
 {

--- a/zstd/zstdgpu/Shaders/ZstdGpuInitHuffmanTable.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuInitHuffmanTable.hlsl
@@ -40,13 +40,15 @@ groupshared uint32_t GS_Lds[kzstdgpu_InitHuffmanTable_LdsSize];
 
 [RootSignature("DescriptorTable(SRV(t0, numDescriptors=2), UAV(u0, numDescriptors=3)), RootConstants(b0, num32BitConstants=2)")]
 [numthreads(kzstdgpu_TgSizeX_DecompressLiterals, 1, 1)]
-void main(uint groupId : SV_GroupId, uint i : SV_GroupThreadId)
+void main(uint2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
 {
     zstdgpu_InitHuffmanTable_SRT srt;
 
     #include "../zstdgpu_srt_decl_copy.h"
     ZSTDGPU_INIT_HUFFMAN_TABLE_SRT()
     #include "../zstdgpu_srt_decl_undef.h"
+
+    uint32_t groupId = zstdgpu_ConvertTo32BitGroupId(groupId2, Constants.tgOffset);
 
     groupId = (Constants.HuffmanTableBase != 0) ? (Constants.HuffmanTableBase - 1 - groupId) : groupId;
 

--- a/zstd/zstdgpu/Shaders/ZstdGpuInitHuffmanTableAndDecompressLiterals.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuInitHuffmanTableAndDecompressLiterals.hlsl
@@ -52,7 +52,7 @@ void main(uint groupId : SV_GroupId, uint i : SV_GroupThreadId)
     #include "../zstdgpu_srt_decl_undef.h"
     srt.huffmanTableSlotCount   = Constants.huffmanTableSlotCount;
 
-    if (groupId >= srt.inCounters[kzstdgpu_CounterIndex_DecompressLiteralsGroups])
+    if (groupId >= srt.inCounters[0].DecompressLiteralsGroups)
         return;
 
     zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(srt, groupId, i);

--- a/zstd/zstdgpu/Shaders/ZstdGpuInitResources.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuInitResources.hlsl
@@ -1,11 +1,10 @@
 /**
  * ZstdGpuInitResources.hlsl
  *
- * A compute shader that initializes various resources to their defauls.
+ * A compute shader that initializes various resources to their defaults.
  *      - Counters for various entities
- *      - Arguments for indirect Dispatch calls
- *      - Default FSE tables
- *      - Lookback resources
+ *      - Default FSE tables and RLE entries
+ *      - Per-frame sequence stream min index
  *
  * The caller needs to call Dispatch(zstdgpu_InitResources_GetDispatchSizeX, 1, 1)
  *
@@ -36,7 +35,7 @@ ConstantBuffer<Consts> Constants : register(b0);
 ZSTDGPU_INIT_RESOURCES_SRT()
 #include "../zstdgpu_srt_decl_undef.h"
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=1), UAV(u0, numDescriptors=20)), RootConstants(b0, num32BitConstants=4)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=1), UAV(u0, numDescriptors=4)), RootConstants(b0, num32BitConstants=4)")]
 [numthreads(kzstdgpu_TgSizeX_InitCounters, 1, 1)]
 void main(uint i : SV_DispatchThreadId)
 {

--- a/zstd/zstdgpu/Shaders/ZstdGpuMemset.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuMemset.hlsl
@@ -1,0 +1,37 @@
+/**
+ * ZstdGpuMemset.hlsl
+ *
+ * A generic compute shader that fills a buffer region with a constant uint32 value.
+ *
+ * Copyright (c) Microsoft. All rights reserved.
+ * This code is licensed under the MIT License (MIT).
+ * THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+ * ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+ * IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+ *
+ * Advanced Technology Group (ATG)
+ * Author(s):   Pavel Martishevsky (pamartis@microsoft.com)
+ */
+
+#include "../zstdgpu_shaders.h"
+
+struct Consts
+{
+    uint32_t tgOffset;
+    uint32_t workItemCount;
+    uint32_t value;
+};
+
+ConstantBuffer<Consts> Constants : register(b0);
+
+RWStructuredBuffer<uint32_t> ZstdBuffer : register(u0);
+
+[RootSignature("UAV(u0), RootConstants(b0, num32BitConstants=3)")]
+[numthreads(kzstdgpu_TgSizeX_Memset, 1, 1)]
+void main(uint2 groupId : SV_GroupId, uint threadId : SV_GroupThreadId)
+{
+    const uint32_t i = zstdgpu_ConvertTo32BitGroupId(groupId, Constants.tgOffset) * kzstdgpu_TgSizeX_Memset + threadId;
+    if (i < Constants.workItemCount)
+        ZstdBuffer[i] = Constants.value;
+}

--- a/zstd/zstdgpu/Shaders/ZstdGpuMemsetMemcpy.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuMemsetMemcpy.hlsl
@@ -18,11 +18,11 @@
 
 struct Consts
 {
+    uint32_t tgOffset;
     uint32_t byteCount;
     uint32_t blockCount;
     uint32_t frameCount;
     uint32_t flags;
-    uint32_t tgOffset;
 };
 
 ConstantBuffer<Consts>                  Constants                           : register(b0);
@@ -43,11 +43,7 @@ StructuredBuffer<uint32_t>              ZstdInGlobalBlockIndexTyped         : re
 [numthreads(kzstdgpu_TgSizeX_MemsetMemcpy, 1, 1)]
 void main(uint2 groupId : SV_GroupId, uint i : SV_GroupThreadId)
 {
-#if defined(__XBOX_SCARLETT) || defined(__XBOX_ONE)
-    i += groupId.x * kzstdgpu_TgSizeX_MemsetMemcpy;
-#else
-    i += (Constants.tgOffset + groupId.y * 65535 + groupId.x) * kzstdgpu_TgSizeX_MemsetMemcpy;
-#endif
+    i += zstdgpu_ConvertTo32BitGroupId(groupId, Constants.tgOffset) * kzstdgpu_TgSizeX_MemsetMemcpy;
 
     if (i >= Constants.byteCount)
         return;

--- a/zstd/zstdgpu/Shaders/ZstdGpuMemsetMemcpy.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuMemsetMemcpy.hlsl
@@ -19,7 +19,7 @@
 struct Consts
 {
     uint32_t tgOffset;
-    uint32_t byteCount;
+    uint32_t workItemCount;
     uint32_t blockCount;
     uint32_t frameCount;
     uint32_t flags;
@@ -45,7 +45,7 @@ void main(uint2 groupId : SV_GroupId, uint i : SV_GroupThreadId)
 {
     i += zstdgpu_ConvertTo32BitGroupId(groupId, Constants.tgOffset) * kzstdgpu_TgSizeX_MemsetMemcpy;
 
-    if (i >= Constants.byteCount)
+    if (i >= Constants.workItemCount)
         return;
 
     const uint32_t blockIdx = zstdgpu_BinarySearch(ZstdInBlockSizePrefixTyped, 0, Constants.blockCount, i);

--- a/zstd/zstdgpu/Shaders/ZstdGpuParseCompressedBlocks.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuParseCompressedBlocks.hlsl
@@ -23,7 +23,7 @@
 struct Consts
 {
     uint32_t tgOffset;
-    uint32_t compressedBlockCount;
+    uint32_t workItemCount;
     uint32_t compressedBufferSizeInBytes;
     uint32_t frameCount;
 };
@@ -49,7 +49,7 @@ void main(uint2 groupId : SV_GroupId, uint threadId : SV_GroupThreadId)
     ZSTDGPU_PARSE_COMPRESSED_BLOCKS_SRT()
     #include "../zstdgpu_srt_decl_undef.h"
 
-    srt.compressedBlockCount        = Constants.compressedBlockCount;
+    srt.compressedBlockCount        = Constants.workItemCount;
     srt.compressedBufferSizeInBytes = Constants.compressedBufferSizeInBytes;
     srt.frameCount                  = Constants.frameCount;
 

--- a/zstd/zstdgpu/Shaders/ZstdGpuParseCompressedBlocks.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuParseCompressedBlocks.hlsl
@@ -22,6 +22,7 @@
 
 struct Consts
 {
+    uint32_t tgOffset;
     uint32_t compressedBlockCount;
     uint32_t compressedBufferSizeInBytes;
     uint32_t frameCount;
@@ -37,10 +38,11 @@ ZSTDGPU_PARSE_COMPRESSED_BLOCKS_SRT()
 #define __XBOX_ENABLE_WAVE32 1
 #endif
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=4), UAV(u0, numDescriptors=16)), RootConstants(b0, num32BitConstants=3)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=4), UAV(u0, numDescriptors=16)), RootConstants(b0, num32BitConstants=4)")]
 [numthreads(kzstdgpu_TgSizeX_ParseCompressedBlocks, 1, 1)]
-void main(uint i : SV_DispatchThreadId)
+void main(uint2 groupId : SV_GroupId, uint threadId : SV_GroupThreadId)
 {
+    const uint32_t i = zstdgpu_ConvertTo32BitGroupId(groupId, Constants.tgOffset) * kzstdgpu_TgSizeX_ParseCompressedBlocks + threadId;
     zstdgpu_ParseCompressedBlocks_SRT srt;
 
     #include "../zstdgpu_srt_decl_copy.h"

--- a/zstd/zstdgpu/Shaders/ZstdGpuPrefixSequenceOffsets.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuPrefixSequenceOffsets.hlsl
@@ -19,7 +19,7 @@
 
 struct Consts
 {
-    uint32_t elemToPrefixCount;
+    uint32_t tgOffset;
     uint32_t frameCount;
 };
 
@@ -44,19 +44,22 @@ StructuredBuffer<uint32_t>      ZstdFrameBlockCountAll              : register(t
 
 StructuredBuffer<zstdgpu_SeqStreamInfo> ZstdSeqRefs                 : register(t2);
 
+StructuredBuffer<zstdgpu_Counters>     ZstdCounters                 : register(t3);
+
 #if defined(__XBOX_SCARLETT)
 #   define __XBOX_ENABLE_WAVE32 1
 #endif
 
-[RootSignature("UAV(u0), UAV(u1), UAV(u2), UAV(u3), UAV(u4), UAV(u5), SRV(t0), SRV(t1), SRV(t2), RootConstants(b0, num32BitConstants=2)")]
+[RootSignature("UAV(u0), UAV(u1), UAV(u2), UAV(u3), UAV(u4), UAV(u5), SRV(t0), SRV(t1), SRV(t2), SRV(t3), RootConstants(b0, num32BitConstants=2)")]
 [numthreads(kzstdgpu_TgSizeX_PrefixSequenceOffsets, 1, 1)]
-void main(uint i : SV_DispatchThreadId)
+void main(uint2 groupId : SV_GroupId, uint threadId : SV_GroupThreadId)
 {
+    const uint32_t i = zstdgpu_ConvertTo32BitGroupId(groupId, Constants.tgOffset) * kzstdgpu_TgSizeX_PrefixSequenceOffsets + threadId;
     const uint32_t blockSize = min(kzstdgpu_TgSizeX_PrefixSequenceOffsets, WaveGetLaneCount());
     const uint32_t thisBlockIndex = WaveReadLaneFirst(i / blockSize);
     const uint32_t thisLocalIndex = i % blockSize;
 
-    if (i >= Constants.elemToPrefixCount)
+    if (i >= ZstdCounters[0].Seq_Streams)
         return;
 
     // NOTE(pamartis): Given an exclusive prefix sum of compressed block counts per block (ZstdFrameBlockCountCMP)

--- a/zstd/zstdgpu/Shaders/ZstdGpuPrefixSequenceOffsets.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuPrefixSequenceOffsets.hlsl
@@ -20,6 +20,7 @@
 struct Consts
 {
     uint32_t tgOffset;
+    uint32_t workItemCount;
     uint32_t frameCount;
 };
 
@@ -50,7 +51,7 @@ StructuredBuffer<zstdgpu_Counters>     ZstdCounters                 : register(t
 #   define __XBOX_ENABLE_WAVE32 1
 #endif
 
-[RootSignature("UAV(u0), UAV(u1), UAV(u2), UAV(u3), UAV(u4), UAV(u5), SRV(t0), SRV(t1), SRV(t2), SRV(t3), RootConstants(b0, num32BitConstants=2)")]
+[RootSignature("UAV(u0), UAV(u1), UAV(u2), UAV(u3), UAV(u4), UAV(u5), SRV(t0), SRV(t1), SRV(t2), SRV(t3), RootConstants(b0, num32BitConstants=3)")]
 [numthreads(kzstdgpu_TgSizeX_PrefixSequenceOffsets, 1, 1)]
 void main(uint2 groupId : SV_GroupId, uint threadId : SV_GroupThreadId)
 {

--- a/zstd/zstdgpu/Shaders/ZstdGpuPrefixSum.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuPrefixSum.hlsl
@@ -19,7 +19,7 @@
 struct Consts
 {
     uint32_t tgOffset;
-    uint32_t elemToPrefixCount;
+    uint32_t workItemCount;
     uint32_t outputInclusive;
 };
 
@@ -36,7 +36,7 @@ RWStructuredBuffer<uint32_t>    ZstdInCountsOutPrefixLookback       : register(u
 void main(uint2 groupId : SV_GroupId, uint threadId : SV_GroupThreadId)
 {
     const uint32_t i = zstdgpu_ConvertTo32BitGroupId(groupId, Constants.tgOffset) * kzstdgpu_TgSizeX_PrefixSum + threadId;
-    if (i >= Constants.elemToPrefixCount)
+    if (i >= Constants.workItemCount)
         return;
 
     const uint32_t count = ZstdInCountsOutPrefix[i];

--- a/zstd/zstdgpu/Shaders/ZstdGpuPrefixSum.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuPrefixSum.hlsl
@@ -18,6 +18,7 @@
 
 struct Consts
 {
+    uint32_t tgOffset;
     uint32_t elemToPrefixCount;
     uint32_t outputInclusive;
 };
@@ -30,10 +31,11 @@ globallycoherent
 RWStructuredBuffer<uint32_t>    ZstdInCountsOutPrefixLookback       : register(u1);
 
 
-[RootSignature("UAV(u0), UAV(u1), RootConstants(b0, num32BitConstants=2)")]
+[RootSignature("UAV(u0), UAV(u1), RootConstants(b0, num32BitConstants=3)")]
 [numthreads(kzstdgpu_TgSizeX_PrefixSum, 1, 1)]
-void main(uint i : SV_DispatchThreadId)
+void main(uint2 groupId : SV_GroupId, uint threadId : SV_GroupThreadId)
 {
+    const uint32_t i = zstdgpu_ConvertTo32BitGroupId(groupId, Constants.tgOffset) * kzstdgpu_TgSizeX_PrefixSum + threadId;
     if (i >= Constants.elemToPrefixCount)
         return;
 

--- a/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
@@ -49,6 +49,7 @@ void main()
     zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_GroupCompressedLiterals,  ZstdCounters[0].HUF_Streams,    32);
     zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_DecompressSequences,      ZstdCounters[0].Seq_Streams,              Consts.decompressSequences_StreamsPerTG);
     zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_FinaliseSequenceOffsets,  ZstdCounters[0].Seq_Streams_DecodedItems, kzstdgpu_TgSizeX_FinaliseSequenceOffsets);
+    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_PrefixSequenceOffsets,    ZstdCounters[0].Seq_Streams,              kzstdgpu_TgSizeX_PrefixSequenceOffsets);
 
     // NOTE: DecompressLiterals slot is written by ComputePrefixSum (runs after this shader)
 

--- a/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
@@ -25,40 +25,52 @@ RWStructuredBuffer<uint32_t>          ZstdDispatchCnts : register(u2);
 struct UpdateDispatchArgsConsts
 {
     uint32_t decompressSequences_StreamsPerTG;
+    uint32_t stage;
 };
 
 ConstantBuffer<UpdateDispatchArgsConsts> Consts : register(b0);
 
-[RootSignature("UAV(u0), UAV(u1), UAV(u2), RootConstants(b0, num32BitConstants=1)")]
+[RootSignature("UAV(u0), UAV(u1), UAV(u2), RootConstants(b0, num32BitConstants=2)")]
 [numthreads(1, 1, 1)]
 void main()
 {
-    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_FseHufW,         ZstdCounters[0].FseHufW,        1);
-    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_FseLLen,         ZstdCounters[0].FseLLen,        1);
-    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_FseOffs,         ZstdCounters[0].FseOffs,        1);
-    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_FseMLen,         ZstdCounters[0].FseMLen,        1);
-    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_HUF_WgtStreams,  ZstdCounters[0].HUF_WgtStreams, 1);
+    if (Consts.stage == 0)
+    {
+        // Block-count dependent slots (valid after Stage 0 ParseFrames :: Count Blocks)
+        const uint32_t allBlockCount = ZstdCounters[0].Blocks_RAW + ZstdCounters[0].Blocks_RLE + ZstdCounters[0].Blocks_CMP;
+        const uint32_t cmpBlockCount = ZstdCounters[0].Blocks_CMP;
 
-    // NOTE(pamartis): The number of groups running the decompression of Huffman weights depends on the number FSE tables
-    // for Huffman weights because those numbers are the same because each FSE table decompresses its own Huffman weights' stream.
-    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_DecompressHuffmanWeights, ZstdCounters[0].FseHufW,        kzstdgpu_TgSizeX_DecompressHuffmanWeights);
+        // the arguments dependent on block counts/sizes -- these could be computed after ParseFrames
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_ComputePrefixSum,         cmpBlockCount,                            kzstdgpu_TgSizeX_PrefixSum_LiteralCount);
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_PrefixBlockSizes,         allBlockCount,                            kzstdgpu_TgSizeX_PrefixSum);
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_MemcpyRAW,                ZstdCounters[0].BlocksBytes_RAW,          kzstdgpu_TgSizeX_MemsetMemcpy);
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_MemsetRLE,                ZstdCounters[0].BlocksBytes_RLE,          kzstdgpu_TgSizeX_MemsetMemcpy);
 
-    // NOTE(pamartis): We also do decoding of uncompressed Huffman Weights stored as two nibbles per byte to make sure final representation
-    // (a byte per weight) becomes identical, so identical representation simplfies initialisation of Huffman tables to use during literal decoding
-    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_DecodeHuffmanWeights,     ZstdCounters[0].HUF_WgtStreams, kzstdgpu_TgSizeX_DecodeHuffmanWeights);
-    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_GroupCompressedLiterals,  ZstdCounters[0].HUF_Streams,    32);
-    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_DecompressSequences,      ZstdCounters[0].Seq_Streams,              Consts.decompressSequences_StreamsPerTG);
-    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_FinaliseSequenceOffsets,  ZstdCounters[0].Seq_Streams_DecodedItems, kzstdgpu_TgSizeX_FinaliseSequenceOffsets);
-    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_PrefixSequenceOffsets,    ZstdCounters[0].Seq_Streams,              kzstdgpu_TgSizeX_PrefixSequenceOffsets);
+        // the arguments dependent on various streams counts that are part of compressed blocks -- these could be computed after ParseCompressedBlocks
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_FseHufW,                  ZstdCounters[0].FseHufW,                  1);
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_FseLLen,                  ZstdCounters[0].FseLLen,                  1);
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_FseOffs,                  ZstdCounters[0].FseOffs,                  1);
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_FseMLen,                  ZstdCounters[0].FseMLen,                  1);
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_HUF_WgtStreams,           ZstdCounters[0].HUF_WgtStreams,           1);
 
-    const uint32_t allBlockCount = ZstdCounters[0].Blocks_RAW + ZstdCounters[0].Blocks_RLE + ZstdCounters[0].Blocks_CMP;
-    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_ComputePrefixSum,         ZstdCounters[0].Blocks_CMP,               kzstdgpu_TgSizeX_PrefixSum_LiteralCount);
-    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_PrefixBlockSizes,         allBlockCount,                            kzstdgpu_TgSizeX_PrefixSum);
-    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_MemcpyRAW,                ZstdCounters[0].BlocksBytes_RAW,          kzstdgpu_TgSizeX_MemsetMemcpy);
-    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_MemsetRLE,                ZstdCounters[0].BlocksBytes_RLE,          kzstdgpu_TgSizeX_MemsetMemcpy);
+        // NOTE(pamartis): The number of groups running the decompression of Huffman weights depends on the number FSE tables
+        // for Huffman weights because those numbers are the same because each FSE table decompresses its own Huffman weights' stream.
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_DecompressHuffmanWeights, ZstdCounters[0].FseHufW,                  kzstdgpu_TgSizeX_DecompressHuffmanWeights);
 
-    // NOTE: DecompressLiterals slot is written by ComputePrefixSum (runs after this shader)
+        // NOTE(pamartis): We also do decoding of uncompressed Huffman Weights stored as two nibbles per byte to make sure final representation
+        // (a byte per weight) becomes identical, so identical representation simplfies initialisation of Huffman tables to use during literal decoding
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_DecodeHuffmanWeights,     ZstdCounters[0].HUF_WgtStreams,           kzstdgpu_TgSizeX_DecodeHuffmanWeights);
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_GroupCompressedLiterals,  ZstdCounters[0].HUF_Streams,              32);
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_DecompressSequences,      ZstdCounters[0].Seq_Streams,              Consts.decompressSequences_StreamsPerTG);
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_FinaliseSequenceOffsets,  ZstdCounters[0].Seq_Streams_DecodedItems, kzstdgpu_TgSizeX_FinaliseSequenceOffsets);
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_PrefixSequenceOffsets,    ZstdCounters[0].Seq_Streams,              kzstdgpu_TgSizeX_PrefixSequenceOffsets);
 
-    // Update derived counter field in Counters (kept for shader bounds checks)
-    ZstdCounters[0].DecompressSequencesGroups = ZSTDGPU_TG_COUNT(ZstdCounters[0].Seq_Streams, Consts.decompressSequences_StreamsPerTG);
+        // Update derived counter field in Counters (kept for shader bounds checks)
+        ZstdCounters[0].DecompressSequencesGroups = ZSTDGPU_TG_COUNT(ZstdCounters[0].Seq_Streams, Consts.decompressSequences_StreamsPerTG);
+    }
+    else
+    {
+        // The number of Groups required for `DecompressLiterals` is only calculated after `ComputePrefixSum`
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_DecompressLiterals,       ZstdCounters[0].DecompressLiteralsGroups, 1);
+    }
 }

--- a/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
@@ -1,8 +1,8 @@
 /**
  * ZstdGpuUpdateDispatchArgs.hlsl
  *
- * A compute shader that updates arguments for indirect Dispatch calls from
- * corresponding counters and threadgroup dimensions.
+ * A compute shader that reads source counters from the Counters and writes dispatch arguments
+ * into the DispatchArgs buffer. The shader also updates derived counter fields in the Counters buffer.
  * The shader needs to be dispatched as single threadgroup.
  *
  * Copyright (c) Microsoft. All rights reserved.
@@ -16,29 +16,38 @@
  * Author(s):   Pavel Martishevsky (pamartis@microsoft.com)
  */
 
-#include "../zstdgpu_structs.h"
+#include "../zstdgpu_shaders.h"
 
 #ifndef kzstdgpu_DecompressSequences_StreamsPerTG
 #define kzstdgpu_DecompressSequences_StreamsPerTG 8
 #endif
 
-RWStructuredBuffer<zstdgpu_Counters> ZstdCounters : register(u0);
+RWStructuredBuffer<zstdgpu_Counters>  ZstdCounters     : register(u0);
+RWStructuredBuffer<uint32_t>          ZstdDispatchArgs : register(u1);
 
-[RootSignature("UAV(u0)")]
+[RootSignature("UAV(u0), UAV(u1)")]
 [numthreads(1, 1, 1)]
 void main()
 {
     // NOTE(pamartis): This number of groups doing the decompression of Huffman weights depends on
     // the number FSE tables for Huffman weights because those numbers are the same.
     // This is because each FSE table decompresses its own Huffman weights' stream.
-    ZstdCounters[0].DecompressHuffmanWeightsGroups = ZSTDGPU_TG_COUNT(ZstdCounters[0].FseHufW, kzstdgpu_TgSizeX_DecompressHuffmanWeights);
+    zstdgpu_EmitDispatch(ZstdDispatchArgs, kzstdgpu_DispatchSlot_FseHufW,                   ZstdCounters[0].FseHufW,        1);
+    zstdgpu_EmitDispatch(ZstdDispatchArgs, kzstdgpu_DispatchSlot_FseLLen,                   ZstdCounters[0].FseLLen,        1);
+    zstdgpu_EmitDispatch(ZstdDispatchArgs, kzstdgpu_DispatchSlot_FseOffs,                   ZstdCounters[0].FseOffs,        1);
+    zstdgpu_EmitDispatch(ZstdDispatchArgs, kzstdgpu_DispatchSlot_FseMLen,                   ZstdCounters[0].FseMLen,        1);
+    zstdgpu_EmitDispatch(ZstdDispatchArgs, kzstdgpu_DispatchSlot_HUF_WgtStreams,            ZstdCounters[0].HUF_WgtStreams, 1);
+    zstdgpu_EmitDispatch(ZstdDispatchArgs, kzstdgpu_DispatchSlot_DecompressHuffmanWeights,  ZstdCounters[0].FseHufW,        kzstdgpu_TgSizeX_DecompressHuffmanWeights);
 
     // NOTE(pamartis): We also do decoding of uncompressed Huffman Weights stored as two nibbles
     // per byte to make sure final representation (a byte per weight) becomes identical, so it's
     // easier to use during literal decoding
-    ZstdCounters[0].DecodeHuffmanWeightsGroups = ZSTDGPU_TG_COUNT(ZstdCounters[0].HUF_WgtStreams, kzstdgpu_TgSizeX_DecodeHuffmanWeights);
+    zstdgpu_EmitDispatch(ZstdDispatchArgs, kzstdgpu_DispatchSlot_DecodeHuffmanWeights,     ZstdCounters[0].HUF_WgtStreams,  kzstdgpu_TgSizeX_DecodeHuffmanWeights);
+    zstdgpu_EmitDispatch(ZstdDispatchArgs, kzstdgpu_DispatchSlot_GroupCompressedLiterals,  ZstdCounters[0].HUF_Streams,     32);
+    zstdgpu_EmitDispatch(ZstdDispatchArgs, kzstdgpu_DispatchSlot_DecompressSequences,      ZstdCounters[0].Seq_Streams,     kzstdgpu_DecompressSequences_StreamsPerTG);
 
-    ZstdCounters[0].GroupCompressedLiteralsGroups = ZSTDGPU_TG_COUNT(ZstdCounters[0].HUF_Streams, 32);
+    // NOTE: DecompressLiterals slot is written by ComputePrefixSum (runs after this shader)
 
+    // Update derived counter field in Counters (kept for shader bounds checks)
     ZstdCounters[0].DecompressSequencesGroups = ZSTDGPU_TG_COUNT(ZstdCounters[0].Seq_Streams, kzstdgpu_DecompressSequences_StreamsPerTG);
 }

--- a/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
@@ -24,27 +24,27 @@
 
 RWStructuredBuffer<zstdgpu_Counters>  ZstdCounters     : register(u0);
 RWStructuredBuffer<uint32_t>          ZstdDispatchArgs : register(u1);
+RWStructuredBuffer<uint32_t>          ZstdDispatchCnts : register(u2);
 
-[RootSignature("UAV(u0), UAV(u1)")]
+[RootSignature("UAV(u0), UAV(u1), UAV(u2)")]
 [numthreads(1, 1, 1)]
 void main()
 {
-    // NOTE(pamartis): This number of groups doing the decompression of Huffman weights depends on
-    // the number FSE tables for Huffman weights because those numbers are the same.
-    // This is because each FSE table decompresses its own Huffman weights' stream.
-    zstdgpu_EmitDispatch(ZstdDispatchArgs, kzstdgpu_DispatchSlot_FseHufW,                   ZstdCounters[0].FseHufW,        1);
-    zstdgpu_EmitDispatch(ZstdDispatchArgs, kzstdgpu_DispatchSlot_FseLLen,                   ZstdCounters[0].FseLLen,        1);
-    zstdgpu_EmitDispatch(ZstdDispatchArgs, kzstdgpu_DispatchSlot_FseOffs,                   ZstdCounters[0].FseOffs,        1);
-    zstdgpu_EmitDispatch(ZstdDispatchArgs, kzstdgpu_DispatchSlot_FseMLen,                   ZstdCounters[0].FseMLen,        1);
-    zstdgpu_EmitDispatch(ZstdDispatchArgs, kzstdgpu_DispatchSlot_HUF_WgtStreams,            ZstdCounters[0].HUF_WgtStreams, 1);
-    zstdgpu_EmitDispatch(ZstdDispatchArgs, kzstdgpu_DispatchSlot_DecompressHuffmanWeights,  ZstdCounters[0].FseHufW,        kzstdgpu_TgSizeX_DecompressHuffmanWeights);
+    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_FseHufW,         ZstdCounters[0].FseHufW,        1);
+    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_FseLLen,         ZstdCounters[0].FseLLen,        1);
+    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_FseOffs,         ZstdCounters[0].FseOffs,        1);
+    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_FseMLen,         ZstdCounters[0].FseMLen,        1);
+    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_HUF_WgtStreams,  ZstdCounters[0].HUF_WgtStreams, 1);
 
-    // NOTE(pamartis): We also do decoding of uncompressed Huffman Weights stored as two nibbles
-    // per byte to make sure final representation (a byte per weight) becomes identical, so it's
-    // easier to use during literal decoding
-    zstdgpu_EmitDispatch(ZstdDispatchArgs, kzstdgpu_DispatchSlot_DecodeHuffmanWeights,     ZstdCounters[0].HUF_WgtStreams,  kzstdgpu_TgSizeX_DecodeHuffmanWeights);
-    zstdgpu_EmitDispatch(ZstdDispatchArgs, kzstdgpu_DispatchSlot_GroupCompressedLiterals,  ZstdCounters[0].HUF_Streams,     32);
-    zstdgpu_EmitDispatch(ZstdDispatchArgs, kzstdgpu_DispatchSlot_DecompressSequences,      ZstdCounters[0].Seq_Streams,     kzstdgpu_DecompressSequences_StreamsPerTG);
+    // NOTE(pamartis): The number of groups running the decompression of Huffman weights depends on the number FSE tables
+    // for Huffman weights because those numbers are the same because each FSE table decompresses its own Huffman weights' stream.
+    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_DecompressHuffmanWeights, ZstdCounters[0].FseHufW,        kzstdgpu_TgSizeX_DecompressHuffmanWeights);
+
+    // NOTE(pamartis): We also do decoding of uncompressed Huffman Weights stored as two nibbles per byte to make sure final representation
+    // (a byte per weight) becomes identical, so identical representation simplfies initialisation of Huffman tables to use during literal decoding
+    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_DecodeHuffmanWeights,     ZstdCounters[0].HUF_WgtStreams, kzstdgpu_TgSizeX_DecodeHuffmanWeights);
+    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_GroupCompressedLiterals,  ZstdCounters[0].HUF_Streams,    32);
+    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_DecompressSequences,      ZstdCounters[0].Seq_Streams,    kzstdgpu_DecompressSequences_StreamsPerTG);
 
     // NOTE: DecompressLiterals slot is written by ComputePrefixSum (runs after this shader)
 

--- a/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
@@ -18,15 +18,18 @@
 
 #include "../zstdgpu_shaders.h"
 
-#ifndef kzstdgpu_DecompressSequences_StreamsPerTG
-#define kzstdgpu_DecompressSequences_StreamsPerTG 8
-#endif
-
 RWStructuredBuffer<zstdgpu_Counters>  ZstdCounters     : register(u0);
 RWStructuredBuffer<uint32_t>          ZstdDispatchArgs : register(u1);
 RWStructuredBuffer<uint32_t>          ZstdDispatchCnts : register(u2);
 
-[RootSignature("UAV(u0), UAV(u1), UAV(u2)")]
+struct UpdateDispatchArgsConsts
+{
+    uint32_t decompressSequences_StreamsPerTG;
+};
+
+ConstantBuffer<UpdateDispatchArgsConsts> Consts : register(b0);
+
+[RootSignature("UAV(u0), UAV(u1), UAV(u2), RootConstants(b0, num32BitConstants=1)")]
 [numthreads(1, 1, 1)]
 void main()
 {
@@ -44,10 +47,10 @@ void main()
     // (a byte per weight) becomes identical, so identical representation simplfies initialisation of Huffman tables to use during literal decoding
     zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_DecodeHuffmanWeights,     ZstdCounters[0].HUF_WgtStreams, kzstdgpu_TgSizeX_DecodeHuffmanWeights);
     zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_GroupCompressedLiterals,  ZstdCounters[0].HUF_Streams,    32);
-    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_DecompressSequences,      ZstdCounters[0].Seq_Streams,    kzstdgpu_DecompressSequences_StreamsPerTG);
+    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_DecompressSequences,      ZstdCounters[0].Seq_Streams,    Consts.decompressSequences_StreamsPerTG);
 
     // NOTE: DecompressLiterals slot is written by ComputePrefixSum (runs after this shader)
 
     // Update derived counter field in Counters (kept for shader bounds checks)
-    ZstdCounters[0].DecompressSequencesGroups = ZSTDGPU_TG_COUNT(ZstdCounters[0].Seq_Streams, kzstdgpu_DecompressSequences_StreamsPerTG);
+    ZstdCounters[0].DecompressSequencesGroups = ZSTDGPU_TG_COUNT(ZstdCounters[0].Seq_Streams, Consts.decompressSequences_StreamsPerTG);
 }

--- a/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
@@ -47,7 +47,8 @@ void main()
     // (a byte per weight) becomes identical, so identical representation simplfies initialisation of Huffman tables to use during literal decoding
     zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_DecodeHuffmanWeights,     ZstdCounters[0].HUF_WgtStreams, kzstdgpu_TgSizeX_DecodeHuffmanWeights);
     zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_GroupCompressedLiterals,  ZstdCounters[0].HUF_Streams,    32);
-    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_DecompressSequences,      ZstdCounters[0].Seq_Streams,    Consts.decompressSequences_StreamsPerTG);
+    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_DecompressSequences,      ZstdCounters[0].Seq_Streams,              Consts.decompressSequences_StreamsPerTG);
+    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_FinaliseSequenceOffsets,  ZstdCounters[0].Seq_Streams_DecodedItems, kzstdgpu_TgSizeX_FinaliseSequenceOffsets);
 
     // NOTE: DecompressLiterals slot is written by ComputePrefixSum (runs after this shader)
 

--- a/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
@@ -22,7 +22,7 @@
 #define kzstdgpu_DecompressSequences_StreamsPerTG 8
 #endif
 
-RWStructuredBuffer<uint32_t> ZstdCounters : register(u0);
+RWStructuredBuffer<zstdgpu_Counters> ZstdCounters : register(u0);
 
 [RootSignature("UAV(u0)")]
 [numthreads(1, 1, 1)]
@@ -31,14 +31,14 @@ void main()
     // NOTE(pamartis): This number of groups doing the decompression of Huffman weights depends on
     // the number FSE tables for Huffman weights because those numbers are the same.
     // This is because each FSE table decompresses its own Huffman weights' stream.
-    ZstdCounters[kzstdgpu_CounterIndex_DecompressHuffmanWeightsGroups] = ZSTDGPU_TG_COUNT(ZstdCounters[kzstdgpu_CounterIndex_FseHufW], kzstdgpu_TgSizeX_DecompressHuffmanWeights);
+    ZstdCounters[0].DecompressHuffmanWeightsGroups = ZSTDGPU_TG_COUNT(ZstdCounters[0].FseHufW, kzstdgpu_TgSizeX_DecompressHuffmanWeights);
 
     // NOTE(pamartis): We also do decoding of uncompressed Huffman Weights stored as two nibbles
     // per byte to make sure final representation (a byte per weight) becomes identical, so it's
     // easier to use during literal decoding
-    ZstdCounters[kzstdgpu_CounterIndex_DecodeHuffmanWeightsGroups] = ZSTDGPU_TG_COUNT(ZstdCounters[kzstdgpu_CounterIndex_HUF_WgtStreams], kzstdgpu_TgSizeX_DecodeHuffmanWeights);
+    ZstdCounters[0].DecodeHuffmanWeightsGroups = ZSTDGPU_TG_COUNT(ZstdCounters[0].HUF_WgtStreams, kzstdgpu_TgSizeX_DecodeHuffmanWeights);
 
-    ZstdCounters[kzstdgpu_CounterIndex_GroupCompressedLiteralsGroups] = ZSTDGPU_TG_COUNT(ZstdCounters[kzstdgpu_CounterIndex_HUF_Streams], 32);
+    ZstdCounters[0].GroupCompressedLiteralsGroups = ZSTDGPU_TG_COUNT(ZstdCounters[0].HUF_Streams, 32);
 
-    ZstdCounters[kzstdgpu_CounterIndex_DecompressSequencesGroups] = ZSTDGPU_TG_COUNT(ZstdCounters[kzstdgpu_CounterIndex_Seq_Streams], kzstdgpu_DecompressSequences_StreamsPerTG);
+    ZstdCounters[0].DecompressSequencesGroups = ZSTDGPU_TG_COUNT(ZstdCounters[0].Seq_Streams, kzstdgpu_DecompressSequences_StreamsPerTG);
 }

--- a/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
@@ -51,6 +51,12 @@ void main()
     zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_FinaliseSequenceOffsets,  ZstdCounters[0].Seq_Streams_DecodedItems, kzstdgpu_TgSizeX_FinaliseSequenceOffsets);
     zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_PrefixSequenceOffsets,    ZstdCounters[0].Seq_Streams,              kzstdgpu_TgSizeX_PrefixSequenceOffsets);
 
+    const uint32_t allBlockCount = ZstdCounters[0].Blocks_RAW + ZstdCounters[0].Blocks_RLE + ZstdCounters[0].Blocks_CMP;
+    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_ComputePrefixSum,         ZstdCounters[0].Blocks_CMP,               kzstdgpu_TgSizeX_PrefixSum_LiteralCount);
+    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_PrefixBlockSizes,         allBlockCount,                            kzstdgpu_TgSizeX_PrefixSum);
+    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_MemcpyRAW,                ZstdCounters[0].BlocksBytes_RAW,          kzstdgpu_TgSizeX_MemsetMemcpy);
+    zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_MemsetRLE,                ZstdCounters[0].BlocksBytes_RLE,          kzstdgpu_TgSizeX_MemsetMemcpy);
+
     // NOTE: DecompressLiterals slot is written by ComputePrefixSum (runs after this shader)
 
     // Update derived counter field in Counters (kept for shader bounds checks)

--- a/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
@@ -46,6 +46,12 @@ void main()
         zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_MemcpyRAW,                ZstdCounters[0].BlocksBytes_RAW,          kzstdgpu_TgSizeX_MemsetMemcpy);
         zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_MemsetRLE,                ZstdCounters[0].BlocksBytes_RLE,          kzstdgpu_TgSizeX_MemsetMemcpy);
         zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_ParseCompressedBlocks,    cmpBlockCount,                            kzstdgpu_TgSizeX_ParseCompressedBlocks);
+
+        // Memset dispatch slots for InitResources Stage 1
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_Memset_CmpBlockLookback,    zstdgpu_GetLookbackBlockCount(cmpBlockCount),                    kzstdgpu_TgSizeX_Memset);
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_Memset_TableIndexLookback,  zstdgpu_GetHufFseTableIndexLookbackUInt32Count(cmpBlockCount),   kzstdgpu_TgSizeX_Memset);
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_Memset_LitStreamEnd,        cmpBlockCount + zstdgpu_GetLookbackBlockCount(cmpBlockCount),    kzstdgpu_TgSizeX_Memset);
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_Memset_AllBlockLookback,    zstdgpu_GetLookbackBlockCount(allBlockCount),                    kzstdgpu_TgSizeX_Memset);
     }
     else if (Consts.stage == 1)
     {

--- a/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
@@ -45,7 +45,10 @@ void main()
         zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_PrefixBlockSizes,         allBlockCount,                            kzstdgpu_TgSizeX_PrefixSum);
         zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_MemcpyRAW,                ZstdCounters[0].BlocksBytes_RAW,          kzstdgpu_TgSizeX_MemsetMemcpy);
         zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_MemsetRLE,                ZstdCounters[0].BlocksBytes_RLE,          kzstdgpu_TgSizeX_MemsetMemcpy);
-
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_ParseCompressedBlocks,    cmpBlockCount,                            kzstdgpu_TgSizeX_ParseCompressedBlocks);
+    }
+    else if (Consts.stage == 1)
+    {
         // the arguments dependent on various streams counts that are part of compressed blocks -- these could be computed after ParseCompressedBlocks
         zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_FseHufW,                  ZstdCounters[0].FseHufW,                  1);
         zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_FseLLen,                  ZstdCounters[0].FseLLen,                  1);

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -1309,7 +1309,7 @@ static void zstdgpu_Dispatch32Bit(ID3D12GraphicsCommandList *cmdList, uint32_t t
 }
 
 #define zstdgpu_DispatchIndirect(cmdList, counterName) \
-    cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, req->resData.gpuOnly.DispatchArgs, kzstdgpu_DispatchSlot_##counterName * kzstdgpu_DispatchSlot_StrideInUInt32 * sizeof(uint32_t), NULL, 0)
+    cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, req->resData.gpuOnly.DispatchArgs, kzstdgpu_DispatchSlot_##counterName * kzstdgpu_DispatchSlot_StrideInUInt32 * sizeof(uint32_t) + sizeof(uint32_t), NULL, 0)
 
 void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandList *cmdList)
 {
@@ -1626,6 +1626,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         d3d12aid_ComputeRsPs_Set(&req->UpdateDispatchArgs, cmdList);
         cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.Counters->GetGPUVirtualAddress());
         cmdList->SetComputeRootUnorderedAccessView(1, req->resData.gpuOnly.DispatchArgs->GetGPUVirtualAddress());
+        cmdList->SetComputeRootUnorderedAccessView(2, req->resData.gpuOnly.DispatchCnts->GetGPUVirtualAddress());
         ZSTDGPU_KERNEL_SCOPE(UpdateDispatchArgs, cmdList,
             cmdList->Dispatch(1, 1, 1);
         );
@@ -1643,13 +1644,14 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRootUnorderedAccessView(3, req->resData.gpuOnly.LitGroupEndPerHuffmanTable->GetGPUVirtualAddress() + req->zstdCmpBlockCount * sizeof(uint32_t));
         cmdList->SetComputeRootUnorderedAccessView(4, req->resData.gpuOnly.Counters->GetGPUVirtualAddress());
         cmdList->SetComputeRootUnorderedAccessView(5, req->resData.gpuOnly.DispatchArgs->GetGPUVirtualAddress());
-        cmdList->SetComputeRoot32BitConstant(6, req->zstdCmpBlockCount, 0);
+        cmdList->SetComputeRootUnorderedAccessView(6, req->resData.gpuOnly.DispatchCnts->GetGPUVirtualAddress());
+        cmdList->SetComputeRoot32BitConstant(7, req->zstdCmpBlockCount, 0);
 #if 0
         // NOTE(pamartis): Use this pass to with DecompressLiterals kernel
-        cmdList->SetComputeRoot32BitConstant(6, kzstdgpu_TgSizeX_DecompressLiterals, 1);
+        cmdList->SetComputeRoot32BitConstant(7, kzstdgpu_TgSizeX_DecompressLiterals, 1);
 #else
         // NOTE(pamartis): Use this path to with DecompressLiterals_LdsStoreCache* kernels
-        cmdList->SetComputeRoot32BitConstant(6, req->DecompressLiterals_LdsStoreCache_StreamsPerGroup, 1);
+        cmdList->SetComputeRoot32BitConstant(7, req->DecompressLiterals_LdsStoreCache_StreamsPerGroup, 1);
 #endif
         ZSTDGPU_KERNEL_SCOPE(ComputePrefixSum, cmdList,
             cmdList->Dispatch(ZSTDGPU_TG_COUNT(req->zstdCmpBlockCount, kzstdgpu_TgSizeX_PrefixSum_LiteralCount), 1, 1);
@@ -1660,14 +1662,17 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     if (req->zstdCmpBlockCount > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier with Resources for [Init FSE Table] and [Group Lilteral Streams]");
-        D3D12_RESOURCE_BARRIER barriers[13];
+        D3D12_RESOURCE_BARRIER barriers[14];
         uint32_t bc = 0;
         // last written by [Update Dispatch Args] and [Compute `Per-Huffman Table` Literal Stream Count Prefix]
         // next read by [Group Lilteral Streams] and [Init FSE Table] and [Decompress Literals]
         setResourceUavToSrvCopyIndirectSync(barriers, bc ++, req->resData.gpuOnly.Counters);
         // last written by [Update Dispatch Args] and [Compute `Per-Huffman Table` Literal Stream Count Prefix]
-        // next read by ExecuteIndirect calls
+        // next read by ExecuteIndirect calls as argument buffer
         setResourceState(barriers, bc ++, req->resData.gpuOnly.DispatchArgs, UNORDERED_ACCESS, INDIRECT_ARGUMENT);
+        // last written by [Update Dispatch Args] and [Compute `Per-Huffman Table` Literal Stream Count Prefix]
+        // next read by ExecuteIndirect calls as count buffer
+        setResourceState(barriers, bc ++, req->resData.gpuOnly.DispatchCnts, UNORDERED_ACCESS, INDIRECT_ARGUMENT);
         // last written by [Parse Compressed Blocks]
         // next read by [Init FSE Table]
         // CAN MOVE EARLIER

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -71,6 +71,7 @@
 #include "ZstdGpuInitHuffmanTable.h"
 #include "ZstdGpuInitHuffmanTableAndDecompressLiterals.h"
 #include "ZstdGpuInitResources.h"
+#include "ZstdGpuMemset.h"
 #include "ZstdGpuMemsetMemcpy.h"
 #include "ZstdGpuParseCompressedBlocks.h"
 #include "ZstdGpuParseFrames.h"
@@ -366,6 +367,7 @@ static void zstdgpu_ReCreate_SRTs(zstdgpu_SRTs & srts, ID3D12Device *device, con
     ZSTDGPU_KERNEL(InitHuffmanTable                                 ,   L"Init Huffman Table")                                                  \
     ZSTDGPU_KERNEL(InitHuffmanTableAndDecompressLiterals            ,   L"Init Huffman Table and Decompress Literals")                          \
     ZSTDGPU_KERNEL(InitResources                                    ,   L"Init Resources")                                                      \
+    ZSTDGPU_KERNEL(Memset                                           ,   L"Memset")                                                              \
     ZSTDGPU_KERNEL(MemsetMemcpy                                     ,   L"Memset-Memcpy")                                                       \
     ZSTDGPU_KERNEL(ParseCompressedBlocks                            ,   L"Parse Compressed Blocks")                                             \
     ZSTDGPU_KERNEL(ParseFrames                                      ,   L"Parse Frames")                                                        \
@@ -405,6 +407,7 @@ static const zstdgpu_CompiledShader kzstdgpu_CompiledShaders [] =
     ZSTDGPU_DISPATCH32_CMD_SIG(GroupCompressedLiterals  , 4)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(InitFseTable             , 1)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(InitHuffmanTable         , 1)    \
+    ZSTDGPU_DISPATCH32_CMD_SIG(Memset                   , 1)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(MemsetMemcpy             , 5)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(PrefixSequenceOffsets    , 10)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(PrefixSum                , 2)    \
@@ -421,6 +424,7 @@ static const zstdgpu_CompiledShader kzstdgpu_CompiledShaders [] =
     ZSTDGPU_KERNEL(InitFseTable)                    \
     ZSTDGPU_KERNEL(InitHuffmanTable)                \
     ZSTDGPU_KERNEL(InitResources)                   \
+    ZSTDGPU_KERNEL(Memset)                          \
     ZSTDGPU_KERNEL(MemsetMemcpy)                    \
     ZSTDGPU_KERNEL(ParseCompressedBlocks)           \
     ZSTDGPU_KERNEL(ParseFrames)                     \
@@ -1404,24 +1408,67 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRoot32BitConstant(1, req->zstdFrameCount, 2);
         cmdList->SetComputeRoot32BitConstant(1, initResourcesStage, 3);
         ZSTDGPU_KERNEL_SCOPE(InitResources_CountBlocks, cmdList,
-            cmdList->Dispatch(zstdgpu_InitResources_GetDispatchSizeX(allBlockCount, cmpBlockCount, req->zstdFrameCount, initResourcesStage), 1, 1);
+            cmdList->Dispatch(zstdgpu_InitResources_GetDispatchSizeX(initResourcesStage), 1, 1);
         );
 
         PIXEndEvent(cmdList);
     }
     {
+        const uint32_t lookbackCount = zstdgpu_GetLookbackBlockCount(req->zstdFrameCount);
+        const uint32_t tgCount = ZSTDGPU_TG_COUNT(lookbackCount, kzstdgpu_TgSizeX_Memset);
+
+        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[InitResources :: Memset :: Stage 0]");
+        d3d12aid_ComputeRsPs_Set(&req->Memset, cmdList);
+
+        cmdList->SetComputeRoot32BitConstant(1, 0 /* tgOffset */, 0);
+
+        cmdList->SetComputeRoot32BitConstant(1, req->zstdFrameCount /* workItemCount */, 1);
+        cmdList->SetComputeRoot32BitConstant(1, ~0u /* value */, 2);
+
+        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.PerFrameSeqStreamMinIdx->GetGPUVirtualAddress());
+        cmdList->Dispatch(ZSTDGPU_TG_COUNT(req->zstdFrameCount, kzstdgpu_TgSizeX_Memset), 1, 1);
+
+        cmdList->SetComputeRoot32BitConstant(1, lookbackCount /* workItemCount */, 1);
+        cmdList->SetComputeRoot32BitConstant(1, 0 /* value */, 2);
+
+        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.PerFrameBlockCountRAW->GetGPUVirtualAddress() + req->zstdFrameCount * sizeof(uint32_t));
+        cmdList->Dispatch(tgCount, 1, 1);
+        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.PerFrameBlockCountRLE->GetGPUVirtualAddress() + req->zstdFrameCount * sizeof(uint32_t));
+        cmdList->Dispatch(tgCount, 1, 1);
+        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.PerFrameBlockCountCMP->GetGPUVirtualAddress() + req->zstdFrameCount * sizeof(uint32_t));
+        cmdList->Dispatch(tgCount, 1, 1);
+        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.PerFrameBlockCountAll->GetGPUVirtualAddress() + req->zstdFrameCount * sizeof(uint32_t));
+        cmdList->Dispatch(tgCount, 1, 1);
+        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.PerFrameBlockSizesRAW->GetGPUVirtualAddress() + req->zstdFrameCount * sizeof(uint32_t));
+        cmdList->Dispatch(tgCount, 1, 1);
+        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.PerFrameBlockSizesRLE->GetGPUVirtualAddress() + req->zstdFrameCount * sizeof(uint32_t));
+        cmdList->Dispatch(tgCount, 1, 1);
+
+        PIXEndEvent(cmdList);
+    }
+    {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [Parse Frames :: Count Blocks]");
-        D3D12_RESOURCE_BARRIER barriers[7];
-        // last written by [Init Resources :: Stage 0]
+
+        D3D12_RESOURCE_BARRIER barriers[8];
+        uint32_t bc = 0;
+
+        // last written by [Init Resources :: Stage 0] and [InitResources :: Memset :: Stage 0]
         // next written/atomically updated by [Parse Frames :: Count Blocks]
-        setResourceUavSync(barriers, 0, req->resData.gpuOnly.Counters);
-        setResourceUavSync(barriers, 1, req->resData.gpuOnly.PerFrameBlockCountRAW);
-        setResourceUavSync(barriers, 2, req->resData.gpuOnly.PerFrameBlockCountRLE);
-        setResourceUavSync(barriers, 3, req->resData.gpuOnly.PerFrameBlockCountCMP);
-        setResourceUavSync(barriers, 4, req->resData.gpuOnly.PerFrameBlockCountAll);
-        setResourceUavSync(barriers, 5, req->resData.gpuOnly.PerFrameBlockSizesRAW);
-        setResourceUavSync(barriers, 6, req->resData.gpuOnly.PerFrameBlockSizesRLE);
-        cmdList->ResourceBarrier(_countof(barriers), barriers);
+        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.Counters);
+        // last written by [InitResources :: Memset :: Stage 0]
+        // next written/updated by [Parse Compressed Blocks]
+        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameSeqStreamMinIdx);
+        // last written by [InitResources :: Memset :: Stage 0]
+        // next written by [Parse Frames :: Block Counts]
+        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountRAW);
+        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountRLE);
+        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountCMP);
+        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountAll);
+        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockSizesRAW);
+        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockSizesRLE);
+
+        ZSTDGPU_ASSERT(bc == _countof(barriers));
+        cmdList->ResourceBarrier(bc, barriers);
         PIXEndEvent(cmdList);
     }
     {
@@ -1437,8 +1484,8 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXEndEvent(cmdList);
     }
     {
-        // Resources needed by for Parse Frames
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [PrefixSum :: Block Counts]");
+
         D3D12_RESOURCE_BARRIER barriers[7];
         // next written/atomically updated by [Parse Frames :: Count Blocks]
         // next written by [PrefixSum :: Block Counts] to store prefix sum instead of counts
@@ -1551,8 +1598,47 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRoot32BitConstant(1, req->zstdFrameCount, 2);
         cmdList->SetComputeRoot32BitConstant(1, initResourcesStage, 3);
         ZSTDGPU_KERNEL_SCOPE(InitResources, cmdList,
-            cmdList->Dispatch(zstdgpu_InitResources_GetDispatchSizeX(allBlockCount, req->zstdCmpBlockCount, req->zstdFrameCount, initResourcesStage), 1, 1);
+            cmdList->Dispatch(zstdgpu_InitResources_GetDispatchSizeX(initResourcesStage), 1, 1);
         );
+
+        PIXEndEvent(cmdList);
+    }
+    if (req->zstdCmpBlockCount > 0)
+    {
+        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[InitResources :: Memset :: Stage 1]");
+        d3d12aid_ComputeRsPs_Set(&req->Memset, cmdList);
+
+        // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
+        cmdList->SetComputeRoot32BitConstant(1, 0 /* value */, 2);
+
+        // Group 1: CmpBlockLookback-sized regions (6 UAV rebinds, same dispatch slot)
+        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.LitGroupEndPerHuffmanTable->GetGPUVirtualAddress() + req->zstdCmpBlockCount * sizeof(uint32_t));
+        zstdgpu_DispatchIndirect(cmdList, Memset, Memset_CmpBlockLookback);
+        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.PerSeqStreamFinalOffset1->GetGPUVirtualAddress() + req->zstdCmpBlockCount * sizeof(uint32_t));
+        zstdgpu_DispatchIndirect(cmdList, Memset, Memset_CmpBlockLookback);
+        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.PerSeqStreamFinalOffset2->GetGPUVirtualAddress() + req->zstdCmpBlockCount * sizeof(uint32_t));
+        zstdgpu_DispatchIndirect(cmdList, Memset, Memset_CmpBlockLookback);
+        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.PerSeqStreamFinalOffset3->GetGPUVirtualAddress() + req->zstdCmpBlockCount * sizeof(uint32_t));
+        zstdgpu_DispatchIndirect(cmdList, Memset, Memset_CmpBlockLookback);
+        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.SeqCountPrefixLookback->GetGPUVirtualAddress());
+        zstdgpu_DispatchIndirect(cmdList, Memset, Memset_CmpBlockLookback);
+        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.BlockSeqCountPrefixLookback->GetGPUVirtualAddress());
+        zstdgpu_DispatchIndirect(cmdList, Memset, Memset_CmpBlockLookback);
+
+        // Group 2: TableIndexLookback
+        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.TableIndexLookback->GetGPUVirtualAddress());
+        zstdgpu_DispatchIndirect(cmdList, Memset, Memset_TableIndexLookback);
+
+        // Group 3: LitStreamEndPerHuffmanTable (prefix + lookback region)
+        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.LitStreamEndPerHuffmanTable->GetGPUVirtualAddress());
+        zstdgpu_DispatchIndirect(cmdList, Memset, Memset_LitStreamEnd);
+
+        // Group 4: BlockSizePrefix lookback (allBlockCount-sized)
+        {
+            const uint32_t allBlockCount = req->zstdRawBlockCount + req->zstdRleBlockCount + req->zstdCmpBlockCount;
+            cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.BlockSizePrefix->GetGPUVirtualAddress() + allBlockCount * sizeof(uint32_t));
+        }
+        zstdgpu_DispatchIndirect(cmdList, Memset, Memset_AllBlockLookback);
 
         PIXEndEvent(cmdList);
     }
@@ -1594,17 +1680,17 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             // so TODO: check if can remove
             setResourceUavSync(barriers, bc + 1, req->resData.gpuOnly.FseInfos);
             setResourceUavSync(barriers, bc + 2, req->resData.gpuOnly.FseProbs);
-            // last written by [Init Resources :: Stage 1] -- only "lookback" sub-buffer
+            // last written by [InitResources :: Memset :: Stage 1]
             // next written/updated by [Parse Compressed Blocks] -- both "lookback" and "prefix" sub-buffers
             setResourceUavSync(barriers, bc + 3, req->resData.gpuOnly.TableIndexLookback);
-            // last written by [Init Resources :: Stage 1]
+            // last written by [InitResources :: Memset :: Stage 1]
             // next written/updated by [Parse Compressed Blocks]
             setResourceUavSync(barriers, bc + 4, req->resData.gpuOnly.LitStreamEndPerHuffmanTable);
             setResourceUavSync(barriers, bc + 5, req->resData.gpuOnly.PerFrameSeqStreamMinIdx);
             // last written by [Parse Frames :: Collect Blocks]
             // next read by [Parse Compressed Blocks]
             setResourceUavToSrvSync(barriers, bc + 6, req->resData.gpuOnly.BlocksCMPRefs);
-            // last written by [Init Resources :: Stage 1]
+            // last written by [InitResources :: Memset :: Stage 1]
             // next written/updated by [Parse Compressed Blocks]
             setResourceUavSync(barriers, bc + 7, req->resData.gpuOnly.SeqCountPrefixLookback);
             setResourceUavSync(barriers, bc + 8, req->resData.gpuOnly.BlockSeqCountPrefixLookback);
@@ -1615,8 +1701,8 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             // next written/updated by [Parse Compressed Blocks] - sets literal size to be uncompressed block size
             setResourceUavSync(barriers, bc + 10, req->resData.gpuOnly.BlockSizePrefix);
             //
-            // [DUMMY] Because PerFrameBlockCountCMP was bound as UAV to InitResources (but wasn't actually written), COMMON state promotion sets its state
-            // to UAV, and later read in ParseCompressedBlocks, so we set Read state to make sure VALIDATION LAYER doesn't complain
+            // [NOTE] PerFrameBlockCountCMP is bound as UAV by [InitResources :: Memset :: Stage 1] and [Parse Frames],
+            // and later read by ParseCompressedBlocks as SRV, so we transition to read state
             setResourceUavToSrvSync(barriers, bc + 11, req->resData.gpuOnly.PerFrameBlockCountCMP);
             bc += 12;
         }

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -396,6 +396,14 @@ static const zstdgpu_CompiledShader kzstdgpu_CompiledShaders [] =
 #undef ZSTDGPU_KERNEL
 };
 
+#define ZSTDGPU_DISPATCH32_CMD_SIG_LIST()                       \
+    ZSTDGPU_DISPATCH32_CMD_SIG(DecodeHuffmanWeights     , 1)    \
+    ZSTDGPU_DISPATCH32_CMD_SIG(DecompressHuffmanWeights , 1)    \
+    ZSTDGPU_DISPATCH32_CMD_SIG(DecompressLiterals       , 1)    \
+    ZSTDGPU_DISPATCH32_CMD_SIG(GroupCompressedLiterals  , 4)    \
+    ZSTDGPU_DISPATCH32_CMD_SIG(InitFseTable             , 1)    \
+    ZSTDGPU_DISPATCH32_CMD_SIG(InitHuffmanTable         , 1)
+
 #define ZSTDGPU_RUNTIME_KERNEL_LIST_SHARED()        \
     ZSTDGPU_KERNEL(ComputeDestSequenceOffsets)      \
     ZSTDGPU_KERNEL(ComputePrefixSum)                \
@@ -468,6 +476,10 @@ struct zstdgpu_PersistentContextImpl
     ID3D12Device            *device;
     ID3D12CommandSignature  *dispatchCmdSig;
 
+    #define ZSTDGPU_DISPATCH32_CMD_SIG(name, rootParamIdx) ID3D12CommandSignature *name##_CmdSig;
+        ZSTDGPU_DISPATCH32_CMD_SIG_LIST()
+    #undef ZSTDGPU_DISPATCH32_CMD_SIG
+
     #define ZSTDGPU_KERNEL(name) d3d12aid_ComputeRsPs name;
         ZSTDGPU_RUNTIME_KERNEL_LIST()
     #undef ZSTDGPU_KERNEL
@@ -488,6 +500,10 @@ struct zstdgpu_PerRequestContextImpl
     void                    *thisMemoryBlock;
     ID3D12Device            *device;
     ID3D12CommandSignature  *dispatchCmdSig;
+
+    #define ZSTDGPU_DISPATCH32_CMD_SIG(name, rootParamIdx) ID3D12CommandSignature *name##_CmdSig;
+        ZSTDGPU_DISPATCH32_CMD_SIG_LIST()
+    #undef ZSTDGPU_DISPATCH32_CMD_SIG
 
     #define ZSTDGPU_KERNEL(name) d3d12aid_ComputeRsPs name;
         ZSTDGPU_RUNTIME_KERNEL_LIST()
@@ -566,15 +582,23 @@ ZSTDGPU_ENUM(Status) zstdgpu_CreatePersistentContext(zstdgpu_PersistentContext *
         context->device = device;
         device->AddRef();
 
-        D3D12_INDIRECT_ARGUMENT_DESC dispatchArgDesc;
-        dispatchArgDesc.Type = D3D12_INDIRECT_ARGUMENT_TYPE_DISPATCH;
+        D3D12_INDIRECT_ARGUMENT_DESC dispatchArgDesc[2];
+        dispatchArgDesc[0].Type = D3D12_INDIRECT_ARGUMENT_TYPE_DISPATCH;
 
-        D3D12_COMMAND_SIGNATURE_DESC dispatchCmdSigDesc;
-        dispatchCmdSigDesc.ByteStride           = sizeof(uint32_t) * 3;
-        dispatchCmdSigDesc.NumArgumentDescs     = 1;
-        dispatchCmdSigDesc.pArgumentDescs       = &dispatchArgDesc;
-        dispatchCmdSigDesc.NodeMask             = 0x1;
-        D3D12AID_CHECK(device->CreateCommandSignature(&dispatchCmdSigDesc, NULL, D3D12AID_IID_PPV_ARGS(&context->dispatchCmdSig)));
+        D3D12_COMMAND_SIGNATURE_DESC cmdSigDesc;
+        cmdSigDesc.ByteStride       = sizeof(uint32_t) * 3;
+        cmdSigDesc.NumArgumentDescs = 1;
+        cmdSigDesc.pArgumentDescs   = dispatchArgDesc;
+        cmdSigDesc.NodeMask         = 0x1;
+        D3D12AID_CHECK(device->CreateCommandSignature(&cmdSigDesc, NULL, D3D12AID_IID_PPV_ARGS(&context->dispatchCmdSig)));
+
+        dispatchArgDesc[0].Type                              = D3D12_INDIRECT_ARGUMENT_TYPE_CONSTANT;
+        dispatchArgDesc[0].Constant.DestOffsetIn32BitValues  = 0;
+        dispatchArgDesc[0].Constant.Num32BitValuesToSet      = 1;
+        dispatchArgDesc[1].Type                              = D3D12_INDIRECT_ARGUMENT_TYPE_DISPATCH;
+
+        cmdSigDesc.ByteStride        = sizeof(uint32_t) * kzstdgpu_DispatchSlot_CmdStrideInUInt32;
+        cmdSigDesc.NumArgumentDescs  = 2;
 
         #define ZSTDGPU_KERNEL_GET(name) &kzstdgpu_CompiledShaders[kzstdgpu_CompiledShaderId_##name];
         #define ZSTDGPU_KERNEL_MAP(runtime, compiled) shader##runtime = ZSTDGPU_KERNEL_GET(compiled)
@@ -655,6 +679,14 @@ ZSTDGPU_ENUM(Status) zstdgpu_CreatePersistentContext(zstdgpu_PersistentContext *
             ZSTDGPU_RUNTIME_KERNEL_LIST()
         #undef ZSTDGPU_KERNEL
 
+        /** NOTE(pamartis): generate CommandSignatures through macro list specifying what kernels/root signatures need command signatures for indirect dispatch */
+        #define ZSTDGPU_DISPATCH32_CMD_SIG(name, rootParamIdx)              \
+            dispatchArgDesc[0].Constant.RootParameterIndex = rootParamIdx;  \
+            D3D12AID_CHECK(device->CreateCommandSignature(&cmdSigDesc, context->name.rs, D3D12AID_IID_PPV_ARGS(&context->name##_CmdSig)));
+
+            ZSTDGPU_DISPATCH32_CMD_SIG_LIST()
+        #undef ZSTDGPU_DISPATCH32_CMD_SIG
+
         *outPersistentContext = context;
         return ZSTDGPU_ENUM_CONST(StatusSuccess);
     }
@@ -674,6 +706,11 @@ ZSTDGPU_ENUM(Status) zstdgpu_DestroyPersistentContext(void **outMemoryBlock, uin
         #undef ZSTDGPU_KERNEL
 
         D3D12AID_SAFE_RELEASE(inPersistentContext->dispatchCmdSig);
+
+        #define ZSTDGPU_DISPATCH32_CMD_SIG(name, rootParamIdx) D3D12AID_SAFE_RELEASE(inPersistentContext->name##_CmdSig);
+            ZSTDGPU_DISPATCH32_CMD_SIG_LIST()
+        #undef ZSTDGPU_DISPATCH32_CMD_SIG
+
         D3D12AID_SAFE_RELEASE(inPersistentContext->device);
 
         if (NULL != outMemoryBlock)
@@ -709,6 +746,12 @@ ZSTDGPU_ENUM(Status) zstdgpu_CreatePerRequestContext(zstdgpu_PerRequestContext *
 
         context->dispatchCmdSig = persistentContext->dispatchCmdSig;
         context->dispatchCmdSig->AddRef();
+
+        #define ZSTDGPU_DISPATCH32_CMD_SIG(name, rootParamIdx)                      \
+            context->name##_CmdSig = persistentContext->name##_CmdSig;    \
+            context->name##_CmdSig->AddRef();
+            ZSTDGPU_DISPATCH32_CMD_SIG_LIST()
+        #undef ZSTDGPU_DISPATCH32_CMD_SIG
 
         /** NOTE(pamartis): generate PipelineState / RootSignature initialisation through macro list */
         #define ZSTDGPU_KERNEL(name)                \
@@ -787,6 +830,11 @@ ZSTDGPU_ENUM(Status) zstdgpu_DestroyPerRequestContext(void **outMemoryBlock, uin
         #undef ZSTDGPU_KERNEL
 
         D3D12AID_SAFE_RELEASE(inPerRequestContext->dispatchCmdSig);
+
+        #define ZSTDGPU_DISPATCH32_CMD_SIG(name, rootParamIdx) D3D12AID_SAFE_RELEASE(inPerRequestContext->name##_CmdSig);
+            ZSTDGPU_DISPATCH32_CMD_SIG_LIST()
+        #undef ZSTDGPU_DISPATCH32_CMD_SIG
+
         D3D12AID_SAFE_RELEASE(inPerRequestContext->device);
 
         if (NULL != outMemoryBlock)
@@ -1308,8 +1356,8 @@ static void zstdgpu_Dispatch32Bit(ID3D12GraphicsCommandList *cmdList, uint32_t t
 #endif
 }
 
-#define zstdgpu_DispatchIndirect(cmdList, counterName) \
-    cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, req->resData.gpuOnly.DispatchArgs, kzstdgpu_DispatchSlot_##counterName * kzstdgpu_DispatchSlot_StrideInUInt32 * sizeof(uint32_t) + sizeof(uint32_t), NULL, 0)
+#define zstdgpu_DispatchIndirect(cmdList, kernelName, counterName) \
+    cmdList->ExecuteIndirect(req->kernelName##_CmdSig, kzstdgpu_DispatchSlot_CmdsPerSlot, req->resData.gpuOnly.DispatchArgs, kzstdgpu_DispatchSlot_##counterName * kzstdgpu_DispatchSlot_StrideInUInt32 * sizeof(uint32_t), req->resData.gpuOnly.DispatchCnts, kzstdgpu_DispatchSlot_##counterName * sizeof(uint32_t));
 
 void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandList *cmdList)
 {
@@ -1721,7 +1769,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRootUnorderedAccessView(3, req->resData.gpuOnly.LitStreamRemap->GetGPUVirtualAddress());
 
         ZSTDGPU_KERNEL_SCOPE(GroupCompressedLiterals, cmdList,
-            zstdgpu_DispatchIndirect(cmdList, GroupCompressedLiterals);
+            zstdgpu_DispatchIndirect(cmdList, GroupCompressedLiterals, GroupCompressedLiterals);
         );
 
         PIXEndEvent(cmdList);
@@ -1743,7 +1791,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 1);
             cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartHufW(0, req->zstdCmpBlockCount), 2);
             cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_HufW, 3);
-            zstdgpu_DispatchIndirect(cmdList, FseHufW);
+            zstdgpu_DispatchIndirect(cmdList, InitFseTable, FseHufW);
             PIXEndEvent(cmdList);
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Literal Lengths");
@@ -1751,7 +1799,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 1);
             cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartLLen(0, req->zstdCmpBlockCount), 2);
             cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_LLen, 3);
-            zstdgpu_DispatchIndirect(cmdList, FseLLen);
+            zstdgpu_DispatchIndirect(cmdList, InitFseTable, FseLLen);
             PIXEndEvent(cmdList);
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Offsets");
@@ -1759,7 +1807,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 1);
             cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartOffs(0, req->zstdCmpBlockCount), 2);
             cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_Offs, 3);
-            zstdgpu_DispatchIndirect(cmdList, FseOffs);
+            zstdgpu_DispatchIndirect(cmdList, InitFseTable, FseOffs);
             PIXEndEvent(cmdList);
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Match Lengths");
@@ -1767,7 +1815,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 1);
             cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartMLen(0, req->zstdCmpBlockCount), 2);
             cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_MLen, 3);
-            zstdgpu_DispatchIndirect(cmdList, FseMLen);
+            zstdgpu_DispatchIndirect(cmdList, InitFseTable, FseMLen);
             PIXEndEvent(cmdList);
             PIXEndEvent(cmdList);
         });
@@ -1795,7 +1843,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         BIND_RS_PS_SRT(DecompressHuffmanWeights);
 
         ZSTDGPU_KERNEL_SCOPE(DecompressHuffmanWeights, cmdList,
-            zstdgpu_DispatchIndirect(cmdList, DecompressHuffmanWeights);
+            zstdgpu_DispatchIndirect(cmdList, DecompressHuffmanWeights, DecompressHuffmanWeights);
         );
         PIXEndEvent(cmdList);
     }
@@ -1808,7 +1856,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRoot32BitConstant(1, req->resInfo.CompressedData_ByteSize, 2);
 
         ZSTDGPU_KERNEL_SCOPE(DecodeHuffmanWeights, cmdList,
-            zstdgpu_DispatchIndirect(cmdList, DecodeHuffmanWeights);
+            zstdgpu_DispatchIndirect(cmdList, DecodeHuffmanWeights, DecodeHuffmanWeights);
         );
         PIXEndEvent(cmdList);
     }
@@ -1838,14 +1886,14 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Path: FSE-compressed Huffman Weights]");
             {
                 cmdList->SetComputeRoot32BitConstant(1, /** HuffmaTableIndexBase*/0, 1);
-                zstdgpu_DispatchIndirect(cmdList, FseHufW);
+                zstdgpu_DispatchIndirect(cmdList, InitHuffmanTable, FseHufW);
             }
             PIXEndEvent(cmdList);
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Path: Uncompressed Huffman Weights]");
             {
                 cmdList->SetComputeRoot32BitConstant(1, /** HuffmaTableIndexBase = zstdCmpBlockCount meaning indices are reversed */req->zstdCmpBlockCount, 1);
-                zstdgpu_DispatchIndirect(cmdList, HUF_WgtStreams);
+                zstdgpu_DispatchIndirect(cmdList, InitHuffmanTable, HUF_WgtStreams);
             }
             PIXEndEvent(cmdList);
         });
@@ -1873,7 +1921,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 1);
 
         ZSTDGPU_KERNEL_SCOPE(DecompressLiterals, cmdList,
-            zstdgpu_DispatchIndirect(cmdList, DecompressLiterals);
+            zstdgpu_DispatchIndirect(cmdList, DecompressLiterals, DecompressLiterals);
         );
         PIXEndEvent(cmdList);
     }

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -400,6 +400,7 @@ static const zstdgpu_CompiledShader kzstdgpu_CompiledShaders [] =
     ZSTDGPU_DISPATCH32_CMD_SIG(DecodeHuffmanWeights     , 1)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(DecompressHuffmanWeights , 1)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(DecompressLiterals       , 1)    \
+    ZSTDGPU_DISPATCH32_CMD_SIG(DecompressSequences      , 1)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(GroupCompressedLiterals  , 4)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(InitFseTable             , 1)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(InitHuffmanTable         , 1)
@@ -1675,6 +1676,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.Counters->GetGPUVirtualAddress());
         cmdList->SetComputeRootUnorderedAccessView(1, req->resData.gpuOnly.DispatchArgs->GetGPUVirtualAddress());
         cmdList->SetComputeRootUnorderedAccessView(2, req->resData.gpuOnly.DispatchCnts->GetGPUVirtualAddress());
+        cmdList->SetComputeRoot32BitConstant(3, req->DecompressSequences_StreamsPerGroup, 0);
         ZSTDGPU_KERNEL_SCOPE(UpdateDispatchArgs, cmdList,
             cmdList->Dispatch(1, 1, 1);
         );
@@ -1942,9 +1944,8 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Decompress Sequences]");
         BIND_RS_PS_SRT(DecompressSequences);
 
-        const uint32_t tgCount = ZSTDGPU_TG_COUNT(req->zstdSeqStreamCount, req->DecompressSequences_StreamsPerGroup);
         ZSTDGPU_KERNEL_SCOPE(DecompressSequences, cmdList,
-            zstdgpu_Dispatch32Bit(cmdList, tgCount, 1, 0);
+            zstdgpu_DispatchIndirect(cmdList, DecompressSequences, DecompressSequences);
         );
         PIXEndEvent(cmdList);
     }

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -923,7 +923,7 @@ ZSTDGPU_ENUM(Status) zstdgpu_GetGpuMemoryRequirement(uint32_t *outDefaultHeapByt
 
     if (proceed)
     {
-        #define CNTRS(name) req->resData.gpu2Cpu.CountersCpu[kzstdgpu_CounterIndex_##name]
+        #define CNTRS(name) req->resData.gpu2Cpu.CountersCpu->name
         if (stageIndex == 0)
         {
             zstdgpu_ResourceInfo_Stage_0_Init(&req->resInfo, req->zstdFrameCount, req->zstdCompressedFramesByteCount, ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_GpuMemory) == req->setupInputsType ? 1u : 0u);
@@ -1091,7 +1091,7 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithInteralMemory(zstdgpu_PerRequestContext r
 
     if (proceed)
     {
-        #define CNTRS(name) req->resData.gpu2Cpu.CountersCpu[kzstdgpu_CounterIndex_##name]
+        #define CNTRS(name) req->resData.gpu2Cpu.CountersCpu->name
 
         // NOTE(pamartis): Recompute memory information for a given stage
         if (stageIndex == 0)
@@ -1309,7 +1309,7 @@ static void zstdgpu_Dispatch32Bit(ID3D12GraphicsCommandList *cmdList, uint32_t t
 }
 
 #define zstdgpu_DispatchIndirect(cmdList, counterName) \
-    cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, req->resData.gpuOnly.Counters, kzstdgpu_CounterIndex_##counterName * sizeof(uint32_t), NULL, 0)
+    cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, req->resData.gpuOnly.Counters, offsetof(zstdgpu_Counters, counterName), NULL, 0)
 
 void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandList *cmdList)
 {
@@ -2143,9 +2143,9 @@ ZSTDGPU_API void zstdgpu_RetrieveGpuResults(zstdgpu_ResourceDataCpu *outGpuResou
     zstdgpu_ResourceDataCpu_InitFromResourceDataGpu(outGpuResources, &req->resData);
 
     // HACK (pamartis): we copy block counts for now, because validation needs it, but we never compute block count on GPU
-    outGpuResources->Counters[kzstdgpu_CounterIndex_Blocks_RAW] = req->zstdRawBlockCount;
-    outGpuResources->Counters[kzstdgpu_CounterIndex_Blocks_RLE] = req->zstdRleBlockCount;
-    outGpuResources->Counters[kzstdgpu_CounterIndex_Blocks_CMP] = req->zstdCmpBlockCount;
+    outGpuResources->Counters->Blocks_RAW = req->zstdRawBlockCount;
+    outGpuResources->Counters->Blocks_RLE = req->zstdRleBlockCount;
+    outGpuResources->Counters->Blocks_CMP = req->zstdCmpBlockCount;
 }
 
 ZSTDGPU_API void zstdgpu_ReadbackTimestamps(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandList *cmdList)

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -1309,7 +1309,7 @@ static void zstdgpu_Dispatch32Bit(ID3D12GraphicsCommandList *cmdList, uint32_t t
 }
 
 #define zstdgpu_DispatchIndirect(cmdList, counterName) \
-    cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, req->resData.gpuOnly.Counters, offsetof(zstdgpu_Counters, counterName), NULL, 0)
+    cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, req->resData.gpuOnly.DispatchArgs, kzstdgpu_DispatchSlot_##counterName * kzstdgpu_DispatchSlot_StrideInUInt32 * sizeof(uint32_t), NULL, 0)
 
 void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandList *cmdList)
 {
@@ -1625,6 +1625,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Update Dispatch Args]");
         d3d12aid_ComputeRsPs_Set(&req->UpdateDispatchArgs, cmdList);
         cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.Counters->GetGPUVirtualAddress());
+        cmdList->SetComputeRootUnorderedAccessView(1, req->resData.gpuOnly.DispatchArgs->GetGPUVirtualAddress());
         ZSTDGPU_KERNEL_SCOPE(UpdateDispatchArgs, cmdList,
             cmdList->Dispatch(1, 1, 1);
         );
@@ -1641,13 +1642,14 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRootUnorderedAccessView(2, req->resData.gpuOnly.LitStreamEndPerHuffmanTable->GetGPUVirtualAddress() + req->zstdCmpBlockCount * sizeof(uint32_t));
         cmdList->SetComputeRootUnorderedAccessView(3, req->resData.gpuOnly.LitGroupEndPerHuffmanTable->GetGPUVirtualAddress() + req->zstdCmpBlockCount * sizeof(uint32_t));
         cmdList->SetComputeRootUnorderedAccessView(4, req->resData.gpuOnly.Counters->GetGPUVirtualAddress());
-        cmdList->SetComputeRoot32BitConstant(5, req->zstdCmpBlockCount, 0);
+        cmdList->SetComputeRootUnorderedAccessView(5, req->resData.gpuOnly.DispatchArgs->GetGPUVirtualAddress());
+        cmdList->SetComputeRoot32BitConstant(6, req->zstdCmpBlockCount, 0);
 #if 0
         // NOTE(pamartis): Use this pass to with DecompressLiterals kernel
-        cmdList->SetComputeRoot32BitConstant(5, kzstdgpu_TgSizeX_DecompressLiterals, 1);
+        cmdList->SetComputeRoot32BitConstant(6, kzstdgpu_TgSizeX_DecompressLiterals, 1);
 #else
         // NOTE(pamartis): Use this path to with DecompressLiterals_LdsStoreCache* kernels
-        cmdList->SetComputeRoot32BitConstant(5, req->DecompressLiterals_LdsStoreCache_StreamsPerGroup, 1);
+        cmdList->SetComputeRoot32BitConstant(6, req->DecompressLiterals_LdsStoreCache_StreamsPerGroup, 1);
 #endif
         ZSTDGPU_KERNEL_SCOPE(ComputePrefixSum, cmdList,
             cmdList->Dispatch(ZSTDGPU_TG_COUNT(req->zstdCmpBlockCount, kzstdgpu_TgSizeX_PrefixSum_LiteralCount), 1, 1);
@@ -1658,42 +1660,48 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     if (req->zstdCmpBlockCount > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier with Resources for [Init FSE Table] and [Group Lilteral Streams]");
-        D3D12_RESOURCE_BARRIER barriers[12];
+        D3D12_RESOURCE_BARRIER barriers[13];
+        uint32_t bc = 0;
         // last written by [Update Dispatch Args] and [Compute `Per-Huffman Table` Literal Stream Count Prefix]
-        // next read by [Group Lilteral Streams] and [Init FSE Table]
-        setResourceUavToSrvCopyIndirectSync(barriers, 0, req->resData.gpuOnly.Counters);
+        // next read by [Group Lilteral Streams] and [Init FSE Table] and [Decompress Literals]
+        setResourceUavToSrvCopyIndirectSync(barriers, bc ++, req->resData.gpuOnly.Counters);
+        // last written by [Update Dispatch Args] and [Compute `Per-Huffman Table` Literal Stream Count Prefix]
+        // next read by ExecuteIndirect calls
+        setResourceState(barriers, bc ++, req->resData.gpuOnly.DispatchArgs, UNORDERED_ACCESS, INDIRECT_ARGUMENT);
         // last written by [Parse Compressed Blocks]
         // next read by [Init FSE Table]
         // CAN MOVE EARLIER
-        setResourceUavToSrvSync(barriers, 1, req->resData.gpuOnly.FseProbs);
-        setResourceUavToSrvSync(barriers, 2, req->resData.gpuOnly.FseInfos);
+        setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.FseProbs);
+        setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.FseInfos);
         // last written by [Compute `Per-Huffman Table` Literal Stream Count Prefix]
         // next read by [Group Lilteral Streams]
-        setResourceUavToSrvSync(barriers, 3, req->resData.gpuOnly.LitStreamEndPerHuffmanTable);
+        setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.LitStreamEndPerHuffmanTable);
         // last written by [Parse Compressed Blocks]
         // next read by [Group Lilteral Streams]
-        setResourceUavToSrvSync(barriers, 4, req->resData.gpuOnly.LitStreamBuckets);
+        setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.LitStreamBuckets);
         // last written by [Parse Compressed Blocks]
         // last read by [DEBUG READBACK]
-        setResourceUavToSrvSync(barriers, 5, req->resData.gpuOnly.CompressedBlocks);
+        setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.CompressedBlocks);
         // last written by [Parse Compressed Blocks]
         // next read by [Decompress Huffman Weights] and [Decode Uncompressed Huffman Weights] and [DEBUG READBACK]
-        setResourceUavToSrvSync(barriers, 6, req->resData.gpuOnly.HufRefs);
+        setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.HufRefs);
         // last written by [Compute `Per-Huffman Table` Literal Stream Count Prefix]
         // next read by [Init Huffman Table and Decompress Literals]
-        setResourceUavToSrvSync(barriers, 7, req->resData.gpuOnly.LitGroupEndPerHuffmanTable);
+        setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.LitGroupEndPerHuffmanTable);
         //
-        setResourceUavToSrvSync(barriers, 8, req->resData.gpuOnly.TableIndexLookback);
+        setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.TableIndexLookback);
         // last written by [Parse Compressed Blocks]
         // next read by [Init Huffman Table and Decompress Literals]
-        setResourceUavToSrvSync(barriers, 9, req->resData.gpuOnly.LitRefs);
+        setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.LitRefs);
         // last written by [Parse Compressed Blocks]
         // next read by [Decompress Sequences]
-        setResourceUavToSrvSync(barriers, 10, req->resData.gpuOnly.SeqRefs);
+        setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.SeqRefs);
         // last written by [Parse Compressed Blocks]
         // next written by [Decompress Huffman Weights] and read as UAV by [Decode Uncompressed Huffman Weights]
-        setResourceUavSync(barriers, 11, req->resData.gpuOnly.DecompressedHuffmanWeightCount);
-        cmdList->ResourceBarrier(_countof(barriers), barriers);
+        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.DecompressedHuffmanWeightCount);
+
+        ZSTDGPU_ASSERT(bc <= _countof(barriers));
+        cmdList->ResourceBarrier(bc, barriers);
         PIXEndEvent(cmdList);
     }
 
@@ -1708,7 +1716,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRootUnorderedAccessView(3, req->resData.gpuOnly.LitStreamRemap->GetGPUVirtualAddress());
 
         ZSTDGPU_KERNEL_SCOPE(GroupCompressedLiterals, cmdList,
-            zstdgpu_DispatchIndirect(cmdList, GroupCompressedLiteralsGroups);
+            zstdgpu_DispatchIndirect(cmdList, GroupCompressedLiterals);
         );
 
         PIXEndEvent(cmdList);
@@ -1782,7 +1790,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         BIND_RS_PS_SRT(DecompressHuffmanWeights);
 
         ZSTDGPU_KERNEL_SCOPE(DecompressHuffmanWeights, cmdList,
-            zstdgpu_DispatchIndirect(cmdList, DecompressHuffmanWeightsGroups);
+            zstdgpu_DispatchIndirect(cmdList, DecompressHuffmanWeights);
         );
         PIXEndEvent(cmdList);
     }
@@ -1795,7 +1803,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRoot32BitConstant(1, req->resInfo.CompressedData_ByteSize, 1);
 
         ZSTDGPU_KERNEL_SCOPE(DecodeHuffmanWeights, cmdList,
-            zstdgpu_DispatchIndirect(cmdList, DecodeHuffmanWeightsGroups);
+            zstdgpu_DispatchIndirect(cmdList, DecodeHuffmanWeights);
         );
         PIXEndEvent(cmdList);
     }
@@ -1860,7 +1868,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 0);
 
         ZSTDGPU_KERNEL_SCOPE(DecompressLiterals, cmdList,
-            zstdgpu_DispatchIndirect(cmdList, DecompressLiteralsGroups);
+            zstdgpu_DispatchIndirect(cmdList, DecompressLiterals);
         );
         PIXEndEvent(cmdList);
     }

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -408,7 +408,7 @@ static const zstdgpu_CompiledShader kzstdgpu_CompiledShaders [] =
     ZSTDGPU_DISPATCH32_CMD_SIG(MemsetMemcpy             , 5)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(PrefixSequenceOffsets    , 10)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(PrefixSum                , 2)    \
-    ZSTDGPU_DISPATCH32_CMD_SIG(ComputePrefixSum         , 7)
+    ZSTDGPU_DISPATCH32_CMD_SIG(ComputePrefixSum         , 5)
 
 #define ZSTDGPU_RUNTIME_KERNEL_LIST_SHARED()        \
     ZSTDGPU_KERNEL(ComputeDestSequenceOffsets)      \
@@ -1688,9 +1688,25 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRootUnorderedAccessView(1, req->resData.gpuOnly.DispatchArgs->GetGPUVirtualAddress());
         cmdList->SetComputeRootUnorderedAccessView(2, req->resData.gpuOnly.DispatchCnts->GetGPUVirtualAddress());
         cmdList->SetComputeRoot32BitConstant(3, req->DecompressSequences_StreamsPerGroup, 0);
+        cmdList->SetComputeRoot32BitConstant(3, 0 /* stage */, 1);
         ZSTDGPU_KERNEL_SCOPE(UpdateDispatchArgs, cmdList,
             cmdList->Dispatch(1, 1, 1);
         );
+        PIXEndEvent(cmdList);
+    }
+
+    if (req->zstdCmpBlockCount > 0)
+    {
+        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [Compute `Per-Huffman Table` Literal Stream Count Prefix]");
+        D3D12_RESOURCE_BARRIER barriers[3];
+        // last written by [Update Dispatch Args]
+        // next read by [Compute `Per-Huffman Table` Literal Stream Count Prefix] via ExecuteIndirect
+        setResourceState(barriers, 0, req->resData.gpuOnly.DispatchArgs, UNORDERED_ACCESS, INDIRECT_ARGUMENT);
+        setResourceState(barriers, 1, req->resData.gpuOnly.DispatchCnts, UNORDERED_ACCESS, INDIRECT_ARGUMENT);
+        // last written by [Update Dispatch Args]
+        // next read/written by [Compute `Per-Huffman Table` Literal Stream Count Prefix]
+        setResourceUavSync(barriers, 2, req->resData.gpuOnly.Counters);
+        cmdList->ResourceBarrier(_countof(barriers), barriers);
         PIXEndEvent(cmdList);
     }
 
@@ -1704,18 +1720,48 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRootUnorderedAccessView(2, req->resData.gpuOnly.LitStreamEndPerHuffmanTable->GetGPUVirtualAddress() + req->zstdCmpBlockCount * sizeof(uint32_t));
         cmdList->SetComputeRootUnorderedAccessView(3, req->resData.gpuOnly.LitGroupEndPerHuffmanTable->GetGPUVirtualAddress() + req->zstdCmpBlockCount * sizeof(uint32_t));
         cmdList->SetComputeRootUnorderedAccessView(4, req->resData.gpuOnly.Counters->GetGPUVirtualAddress());
-        cmdList->SetComputeRootUnorderedAccessView(5, req->resData.gpuOnly.DispatchArgs->GetGPUVirtualAddress());
-        cmdList->SetComputeRootUnorderedAccessView(6, req->resData.gpuOnly.DispatchCnts->GetGPUVirtualAddress());
-        cmdList->SetComputeRoot32BitConstant(7, req->zstdCmpBlockCount, 1);
+        cmdList->SetComputeRoot32BitConstant(5, req->zstdCmpBlockCount, 1);
 #if 0
         // NOTE(pamartis): Use this pass to with DecompressLiterals kernel
-        cmdList->SetComputeRoot32BitConstant(7, kzstdgpu_TgSizeX_DecompressLiterals, 2);
+        cmdList->SetComputeRoot32BitConstant(5, kzstdgpu_TgSizeX_DecompressLiterals, 2);
 #else
         // NOTE(pamartis): Use this path to with DecompressLiterals_LdsStoreCache* kernels
-        cmdList->SetComputeRoot32BitConstant(7, req->DecompressLiterals_LdsStoreCache_StreamsPerGroup, 2);
+        cmdList->SetComputeRoot32BitConstant(5, req->DecompressLiterals_LdsStoreCache_StreamsPerGroup, 2);
 #endif
         ZSTDGPU_KERNEL_SCOPE(ComputePrefixSum, cmdList,
             zstdgpu_DispatchIndirect(cmdList, ComputePrefixSum, ComputePrefixSum);
+        );
+        PIXEndEvent(cmdList);
+    }
+
+    // NOTE(pamartis): `ComputePrefixSum` writes `DecompressLiteralsGroups` to `Counters`.
+    // A separate `UpdateDispatchArgs` pass populates `DecompressLiterals` dispatch slot
+    // because `ComputePrefixSum` can't write DispatchArgs (it's in INDIRECT_ARGUMENT state).
+    if (req->zstdCmpBlockCount > 0)
+    {
+        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [Update Dispatch Args :: DecompressLiterals]");
+        D3D12_RESOURCE_BARRIER barriers[3];
+        // last written by [Compute `Per-Huffman Table` Literal Stream Count Prefix]
+        // next read by [Update Dispatch Args :: DecompressLiterals]
+        setResourceUavSync(barriers, 0, req->resData.gpuOnly.Counters);
+        // last read by [Compute `Per-Huffman Table` Literal Stream Count Prefix] as INDIRECT_ARGUMENT
+        // next written by [Update Dispatch Args :: DecompressLiterals]
+        setResourceState(barriers, 1, req->resData.gpuOnly.DispatchArgs, INDIRECT_ARGUMENT, UNORDERED_ACCESS);
+        setResourceState(barriers, 2, req->resData.gpuOnly.DispatchCnts, INDIRECT_ARGUMENT, UNORDERED_ACCESS);
+        cmdList->ResourceBarrier(_countof(barriers), barriers);
+        PIXEndEvent(cmdList);
+    }
+    if (req->zstdCmpBlockCount > 0)
+    {
+        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Update Dispatch Args :: DecompressLiterals]");
+        d3d12aid_ComputeRsPs_Set(&req->UpdateDispatchArgs, cmdList);
+        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.Counters->GetGPUVirtualAddress());
+        cmdList->SetComputeRootUnorderedAccessView(1, req->resData.gpuOnly.DispatchArgs->GetGPUVirtualAddress());
+        cmdList->SetComputeRootUnorderedAccessView(2, req->resData.gpuOnly.DispatchCnts->GetGPUVirtualAddress());
+        cmdList->SetComputeRoot32BitConstant(3, req->DecompressSequences_StreamsPerGroup, 0);
+        cmdList->SetComputeRoot32BitConstant(3, 1 /* stage */, 1);
+        ZSTDGPU_KERNEL_SCOPE(UpdateDispatchArgs_DecompressLiterals, cmdList,
+            cmdList->Dispatch(1, 1, 1);
         );
         PIXEndEvent(cmdList);
     }

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -1740,33 +1740,33 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Huffman Weights");
             uint32_t tableStartIndex = 0;
-            cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 0);
-            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartHufW(0, req->zstdCmpBlockCount), 1);
-            cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_HufW, 2);
+            cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 1);
+            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartHufW(0, req->zstdCmpBlockCount), 2);
+            cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_HufW, 3);
             zstdgpu_DispatchIndirect(cmdList, FseHufW);
             PIXEndEvent(cmdList);
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Literal Lengths");
             tableStartIndex += req->zstdCmpBlockCount;
-            cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 0);
-            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartLLen(0, req->zstdCmpBlockCount), 1);
-            cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_LLen, 2);
+            cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 1);
+            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartLLen(0, req->zstdCmpBlockCount), 2);
+            cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_LLen, 3);
             zstdgpu_DispatchIndirect(cmdList, FseLLen);
             PIXEndEvent(cmdList);
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Offsets");
             tableStartIndex += req->zstdCmpBlockCount + 1;
-            cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 0);
-            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartOffs(0, req->zstdCmpBlockCount), 1);
-            cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_Offs, 2);
+            cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 1);
+            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartOffs(0, req->zstdCmpBlockCount), 2);
+            cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_Offs, 3);
             zstdgpu_DispatchIndirect(cmdList, FseOffs);
             PIXEndEvent(cmdList);
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Match Lengths");
             tableStartIndex += req->zstdCmpBlockCount + 1;
-            cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 0);
-            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartMLen(0, req->zstdCmpBlockCount), 1);
-            cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_MLen, 2);
+            cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 1);
+            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartMLen(0, req->zstdCmpBlockCount), 2);
+            cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_MLen, 3);
             zstdgpu_DispatchIndirect(cmdList, FseMLen);
             PIXEndEvent(cmdList);
             PIXEndEvent(cmdList);
@@ -1804,8 +1804,8 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Decode Uncompressed Huffman Weights]");
         BIND_RS_PS_SRT(DecodeHuffmanWeights);
-        cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 0);
-        cmdList->SetComputeRoot32BitConstant(1, req->resInfo.CompressedData_ByteSize, 1);
+        cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 1);
+        cmdList->SetComputeRoot32BitConstant(1, req->resInfo.CompressedData_ByteSize, 2);
 
         ZSTDGPU_KERNEL_SCOPE(DecodeHuffmanWeights, cmdList,
             zstdgpu_DispatchIndirect(cmdList, DecodeHuffmanWeights);
@@ -1837,14 +1837,14 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         {
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Path: FSE-compressed Huffman Weights]");
             {
-                cmdList->SetComputeRoot32BitConstant(1, /** HuffmaTableIndexBase*/0, 0);
+                cmdList->SetComputeRoot32BitConstant(1, /** HuffmaTableIndexBase*/0, 1);
                 zstdgpu_DispatchIndirect(cmdList, FseHufW);
             }
             PIXEndEvent(cmdList);
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Path: Uncompressed Huffman Weights]");
             {
-                cmdList->SetComputeRoot32BitConstant(1, /** HuffmaTableIndexBase = zstdCmpBlockCount meaning indices are reversed */req->zstdCmpBlockCount, 0);
+                cmdList->SetComputeRoot32BitConstant(1, /** HuffmaTableIndexBase = zstdCmpBlockCount meaning indices are reversed */req->zstdCmpBlockCount, 1);
                 zstdgpu_DispatchIndirect(cmdList, HUF_WgtStreams);
             }
             PIXEndEvent(cmdList);
@@ -1870,7 +1870,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Decompress Literals]");
         BIND_RS_PS_SRT(DecompressLiterals);
-        cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 0);
+        cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 1);
 
         ZSTDGPU_KERNEL_SCOPE(DecompressLiterals, cmdList,
             zstdgpu_DispatchIndirect(cmdList, DecompressLiterals);

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -1308,6 +1308,9 @@ static void zstdgpu_Dispatch32Bit(ID3D12GraphicsCommandList *cmdList, uint32_t t
 #endif
 }
 
+#define zstdgpu_DispatchIndirect(cmdList, counterName) \
+    cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, req->resData.gpuOnly.Counters, kzstdgpu_CounterIndex_##counterName * sizeof(uint32_t), NULL, 0)
+
 void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandList *cmdList)
 {
     {
@@ -1703,10 +1706,9 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRootShaderResourceView(1, req->resData.gpuOnly.LitStreamBuckets->GetGPUVirtualAddress());
         cmdList->SetComputeRootShaderResourceView(2, req->resData.gpuOnly.Counters->GetGPUVirtualAddress());
         cmdList->SetComputeRootUnorderedAccessView(3, req->resData.gpuOnly.LitStreamRemap->GetGPUVirtualAddress());
-        ID3D12Resource* argBuf = req->resData.gpuOnly.Counters;
 
         ZSTDGPU_KERNEL_SCOPE(GroupCompressedLiterals, cmdList,
-            cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_GroupCompressedLiteralsGroups * sizeof(uint32_t), NULL, 0);
+            zstdgpu_DispatchIndirect(cmdList, GroupCompressedLiteralsGroups);
         );
 
         PIXEndEvent(cmdList);
@@ -1722,14 +1724,13 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
             // NOTE: we run 4 ExecuteIndirects (per argument) in order to be able to (but we don't do this for prototype)
             // switch PSO to more optimial (depending on maximal FSE table size) because D3D12 doesn't allow to switch PSOs in ExecuteIndirect.
-            ID3D12Resource* argBuf = req->resData.gpuOnly.Counters;
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Huffman Weights");
             uint32_t tableStartIndex = 0;
             cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 0);
             cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartHufW(0, req->zstdCmpBlockCount), 1);
             cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_HufW, 2);
-            cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_FseHufW * sizeof(uint32_t), NULL, 0);
+            zstdgpu_DispatchIndirect(cmdList, FseHufW);
             PIXEndEvent(cmdList);
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Literal Lengths");
@@ -1737,7 +1738,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 0);
             cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartLLen(0, req->zstdCmpBlockCount), 1);
             cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_LLen, 2);
-            cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_FseLLen * sizeof(uint32_t), NULL, 0);
+            zstdgpu_DispatchIndirect(cmdList, FseLLen);
             PIXEndEvent(cmdList);
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Offsets");
@@ -1745,7 +1746,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 0);
             cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartOffs(0, req->zstdCmpBlockCount), 1);
             cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_Offs, 2);
-            cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_FseOffs * sizeof(uint32_t), NULL, 0);
+            zstdgpu_DispatchIndirect(cmdList, FseOffs);
             PIXEndEvent(cmdList);
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Match Lengths");
@@ -1753,7 +1754,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 0);
             cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartMLen(0, req->zstdCmpBlockCount), 1);
             cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_MLen, 2);
-            cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_FseMLen * sizeof(uint32_t), NULL, 0);
+            zstdgpu_DispatchIndirect(cmdList, FseMLen);
             PIXEndEvent(cmdList);
             PIXEndEvent(cmdList);
         });
@@ -1780,9 +1781,8 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Decompress Huffman Weights]");
         BIND_RS_PS_SRT(DecompressHuffmanWeights);
 
-        ID3D12Resource* argBuf = req->resData.gpuOnly.Counters;
         ZSTDGPU_KERNEL_SCOPE(DecompressHuffmanWeights, cmdList,
-            cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_DecompressHuffmanWeightsGroups * sizeof(uint32_t), NULL, 0);
+            zstdgpu_DispatchIndirect(cmdList, DecompressHuffmanWeightsGroups);
         );
         PIXEndEvent(cmdList);
     }
@@ -1794,9 +1794,8 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 0);
         cmdList->SetComputeRoot32BitConstant(1, req->resInfo.CompressedData_ByteSize, 1);
 
-        ID3D12Resource* argBuf = req->resData.gpuOnly.Counters;
         ZSTDGPU_KERNEL_SCOPE(DecodeHuffmanWeights, cmdList,
-            cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_DecodeHuffmanWeightsGroups * sizeof(uint32_t), NULL, 0);
+            zstdgpu_DispatchIndirect(cmdList, DecodeHuffmanWeightsGroups);
         );
         PIXEndEvent(cmdList);
     }
@@ -1820,21 +1819,20 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Pre-Init Huffman Table]");
         BIND_RS_PS_SRT(InitHuffmanTable);
-        ID3D12Resource* argBuf = req->resData.gpuOnly.Counters;
 
         ZSTDGPU_KERNEL_SCOPE(InitHuffmanTable, cmdList,
         {
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Path: FSE-compressed Huffman Weights]");
             {
                 cmdList->SetComputeRoot32BitConstant(1, /** HuffmaTableIndexBase*/0, 0);
-                cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_FseHufW * sizeof(uint32_t), NULL, 0);
+                zstdgpu_DispatchIndirect(cmdList, FseHufW);
             }
             PIXEndEvent(cmdList);
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Path: Uncompressed Huffman Weights]");
             {
                 cmdList->SetComputeRoot32BitConstant(1, /** HuffmaTableIndexBase = zstdCmpBlockCount meaning indices are reversed */req->zstdCmpBlockCount, 0);
-                cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_HUF_WgtStreams * sizeof(uint32_t), NULL, 0);
+                zstdgpu_DispatchIndirect(cmdList, HUF_WgtStreams);
             }
             PIXEndEvent(cmdList);
         });
@@ -1861,9 +1859,8 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         BIND_RS_PS_SRT(DecompressLiterals);
         cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 0);
 
-        ID3D12Resource* argBuf = req->resData.gpuOnly.Counters;
         ZSTDGPU_KERNEL_SCOPE(DecompressLiterals, cmdList,
-            cmdList->ExecuteIndirect(req->dispatchCmdSig, 1, argBuf, kzstdgpu_CounterIndex_DecompressLiteralsGroups * sizeof(uint32_t), NULL, 0);
+            zstdgpu_DispatchIndirect(cmdList, DecompressLiteralsGroups);
         );
         PIXEndEvent(cmdList);
     }

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -408,7 +408,8 @@ static const zstdgpu_CompiledShader kzstdgpu_CompiledShaders [] =
     ZSTDGPU_DISPATCH32_CMD_SIG(MemsetMemcpy             , 5)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(PrefixSequenceOffsets    , 10)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(PrefixSum                , 2)    \
-    ZSTDGPU_DISPATCH32_CMD_SIG(ComputePrefixSum         , 5)
+    ZSTDGPU_DISPATCH32_CMD_SIG(ComputePrefixSum         , 5)    \
+    ZSTDGPU_DISPATCH32_CMD_SIG(ParseCompressedBlocks    , 1)
 
 #define ZSTDGPU_RUNTIME_KERNEL_LIST_SHARED()        \
     ZSTDGPU_KERNEL(ComputeDestSequenceOffsets)      \
@@ -1438,7 +1439,7 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     {
         // Resources needed by for Parse Frames
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [PrefixSum :: Block Counts]");
-        D3D12_RESOURCE_BARRIER barriers[6];
+        D3D12_RESOURCE_BARRIER barriers[7];
         // next written/atomically updated by [Parse Frames :: Count Blocks]
         // next written by [PrefixSum :: Block Counts] to store prefix sum instead of counts
         setResourceUavSync(barriers, 0, req->resData.gpuOnly.PerFrameBlockCountRAW);
@@ -1447,6 +1448,10 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         setResourceUavSync(barriers, 3, req->resData.gpuOnly.PerFrameBlockCountAll);
         setResourceUavSync(barriers, 4, req->resData.gpuOnly.PerFrameBlockSizesRAW);
         setResourceUavSync(barriers, 5, req->resData.gpuOnly.PerFrameBlockSizesRLE);
+        // last written by [Parse Frames :: Count Blocks]
+        // next read by [Update Dispatch Args :: Stage 0] as RWStructuredBuffer (read-only)
+        // NOTE: stays in UNORDERED_ACCESS because UpdateDispatchArgs binds Counters as UAV
+        setResourceUavSync(barriers, 6, req->resData.gpuOnly.Counters);
         cmdList->ResourceBarrier(_countof(barriers), barriers);
         PIXEndEvent(cmdList);
     }
@@ -1494,9 +1499,22 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXEndEvent(cmdList);
     }
     {
-        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [Readback Counters :: After Block Count] and [Parse Compressed Blocks] and [Prefix Sequence Offsets] and [Finalise Sequence Offsets]");
-        D3D12_RESOURCE_BARRIER barriers[3];
-        // last written by [Parse Frames :: Count Blocks]
+        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Update Dispatch Args :: Stage 0]");
+        d3d12aid_ComputeRsPs_Set(&req->UpdateDispatchArgs, cmdList);
+        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.Counters->GetGPUVirtualAddress());
+        cmdList->SetComputeRootUnorderedAccessView(1, req->resData.gpuOnly.DispatchArgs->GetGPUVirtualAddress());
+        cmdList->SetComputeRootUnorderedAccessView(2, req->resData.gpuOnly.DispatchCnts->GetGPUVirtualAddress());
+        cmdList->SetComputeRoot32BitConstant(3, req->DecompressSequences_StreamsPerGroup, 0);
+        cmdList->SetComputeRoot32BitConstant(3, 0 /* stage */, 1);
+        ZSTDGPU_KERNEL_SCOPE(UpdateDispatchArgs_Stage0, cmdList,
+            cmdList->Dispatch(1, 1, 1);
+        );
+        PIXEndEvent(cmdList);
+    }
+    {
+        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [Readback Counters :: After Block Count] and [Parse Compressed Blocks]");
+        D3D12_RESOURCE_BARRIER barriers[5];
+        // last read by [Update Dispatch Args :: Stage 0]
         // next read by [Readback Counters :: After Block Count]
         setResourceState(barriers, 0, req->resData.gpuOnly.Counters, UNORDERED_ACCESS, COPY_SOURCE);
         // last written by [PrefixSum :: Block Counts]
@@ -1505,6 +1523,10 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         // last written by [PrefixSum :: Block Counts]
         // next read by [Prefix Sequence Offsets] and [Finalise Sequence Offsets]
         setResourceUavToSrvSync(barriers, 2, req->resData.gpuOnly.PerFrameBlockCountAll);
+        // last written by [Update Dispatch Args :: Stage 0]
+        // next read by ExecuteIndirect calls as argument/count buffers
+        setResourceState(barriers, 3, req->resData.gpuOnly.DispatchArgs, UNORDERED_ACCESS, INDIRECT_ARGUMENT);
+        setResourceState(barriers, 4, req->resData.gpuOnly.DispatchCnts, UNORDERED_ACCESS, INDIRECT_ARGUMENT);
         cmdList->ResourceBarrier(_countof(barriers), barriers);
         PIXEndEvent(cmdList);
     }
@@ -1633,12 +1655,12 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Parse Compressed Blocks]");
         BIND_RS_PS_SRT(ParseCompressedBlocks);
-        cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 0);
-        cmdList->SetComputeRoot32BitConstant(1, req->resInfo.CompressedData_ByteSize, 1);
-        cmdList->SetComputeRoot32BitConstant(1, req->zstdFrameCount, 2);
+        cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 1);
+        cmdList->SetComputeRoot32BitConstant(1, req->resInfo.CompressedData_ByteSize, 2);
+        cmdList->SetComputeRoot32BitConstant(1, req->zstdFrameCount, 3);
 
         ZSTDGPU_KERNEL_SCOPE(ParseCompressedBlocks, cmdList,
-            cmdList->Dispatch(ZSTDGPU_TG_COUNT(req->zstdCmpBlockCount, kzstdgpu_TgSizeX_ParseCompressedBlocks), 1, 1);
+            zstdgpu_DispatchIndirect(cmdList, ParseCompressedBlocks, ParseCompressedBlocks);
         );
         PIXEndEvent(cmdList);
     }
@@ -1646,7 +1668,7 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     if (req->zstdCmpBlockCount > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [Readback Counters :: After Block Parse] and [Update Dispatch Args] and [Compute `Per-Huffman Table` Literal Stream Count Prefix]");
-        D3D12_RESOURCE_BARRIER barriers[9];
+        D3D12_RESOURCE_BARRIER barriers[11];
         // last written by [Parse Compressed Blocks]
         // next read by [Readback Counters :: After Block Parse] and updated by [Update Dispatch Args]
         setResourceState(barriers, 0, req->resData.gpuOnly.Counters, UNORDERED_ACCESS, COPY_SOURCE);
@@ -1669,6 +1691,10 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         // last written by [Parse Compressed Blocks]
         // next read by [Finalise Sequence Offsets]
         setResourceUavToSrvSync(barriers, 8, req->resData.gpuOnly.PerSeqStreamSeqStart);
+        // last read by ExecuteIndirect as INDIRECT_ARGUMENT
+        // next written by [Update Dispatch Args :: Stage 2]
+        setResourceState(barriers, 9, req->resData.gpuOnly.DispatchArgs, INDIRECT_ARGUMENT, UNORDERED_ACCESS);
+        setResourceState(barriers, 10, req->resData.gpuOnly.DispatchCnts, INDIRECT_ARGUMENT, UNORDERED_ACCESS);
         cmdList->ResourceBarrier(_countof(barriers), barriers);
         PIXEndEvent(cmdList);
     }
@@ -1688,7 +1714,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRootUnorderedAccessView(1, req->resData.gpuOnly.DispatchArgs->GetGPUVirtualAddress());
         cmdList->SetComputeRootUnorderedAccessView(2, req->resData.gpuOnly.DispatchCnts->GetGPUVirtualAddress());
         cmdList->SetComputeRoot32BitConstant(3, req->DecompressSequences_StreamsPerGroup, 0);
-        cmdList->SetComputeRoot32BitConstant(3, 0 /* stage */, 1);
+        cmdList->SetComputeRoot32BitConstant(3, 1 /* stage */, 1);
         ZSTDGPU_KERNEL_SCOPE(UpdateDispatchArgs, cmdList,
             cmdList->Dispatch(1, 1, 1);
         );
@@ -1759,7 +1785,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRootUnorderedAccessView(1, req->resData.gpuOnly.DispatchArgs->GetGPUVirtualAddress());
         cmdList->SetComputeRootUnorderedAccessView(2, req->resData.gpuOnly.DispatchCnts->GetGPUVirtualAddress());
         cmdList->SetComputeRoot32BitConstant(3, req->DecompressSequences_StreamsPerGroup, 0);
-        cmdList->SetComputeRoot32BitConstant(3, 1 /* stage */, 1);
+        cmdList->SetComputeRoot32BitConstant(3, 2 /* stage */, 1);
         ZSTDGPU_KERNEL_SCOPE(UpdateDispatchArgs_DecompressLiterals, cmdList,
             cmdList->Dispatch(1, 1, 1);
         );

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -401,6 +401,7 @@ static const zstdgpu_CompiledShader kzstdgpu_CompiledShaders [] =
     ZSTDGPU_DISPATCH32_CMD_SIG(DecompressHuffmanWeights , 1)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(DecompressLiterals       , 1)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(DecompressSequences      , 1)    \
+    ZSTDGPU_DISPATCH32_CMD_SIG(FinaliseSequenceOffsets  , 1)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(GroupCompressedLiterals  , 4)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(InitFseTable             , 1)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(InitHuffmanTable         , 1)
@@ -2048,9 +2049,8 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Finalise Sequence Offsets]");
         BIND_RS_PS_SRT(FinaliseSequenceOffsets);
 
-        const uint32_t tgCount = ZSTDGPU_TG_COUNT(req->zstdUncompressedSequenceCount, kzstdgpu_TgSizeX_FinaliseSequenceOffsets);
         ZSTDGPU_KERNEL_SCOPE(FinaliseSequenceOffsets, cmdList,
-            zstdgpu_Dispatch32Bit(cmdList, tgCount, 1, 0);
+            zstdgpu_DispatchIndirect(cmdList, FinaliseSequenceOffsets, FinaliseSequenceOffsets);
         );
 
         PIXEndEvent(cmdList);

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -404,7 +404,8 @@ static const zstdgpu_CompiledShader kzstdgpu_CompiledShaders [] =
     ZSTDGPU_DISPATCH32_CMD_SIG(FinaliseSequenceOffsets  , 1)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(GroupCompressedLiterals  , 4)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(InitFseTable             , 1)    \
-    ZSTDGPU_DISPATCH32_CMD_SIG(InitHuffmanTable         , 1)
+    ZSTDGPU_DISPATCH32_CMD_SIG(InitHuffmanTable         , 1)    \
+    ZSTDGPU_DISPATCH32_CMD_SIG(PrefixSequenceOffsets    , 10)
 
 #define ZSTDGPU_RUNTIME_KERNEL_LIST_SHARED()        \
     ZSTDGPU_KERNEL(ComputeDestSequenceOffsets)      \
@@ -2014,11 +2015,11 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRootShaderResourceView(6, req->resData.gpuOnly.PerFrameSeqStreamMinIdx->GetGPUVirtualAddress());
         cmdList->SetComputeRootShaderResourceView(7, req->resData.gpuOnly.PerFrameBlockCountAll->GetGPUVirtualAddress());
         cmdList->SetComputeRootShaderResourceView(8, req->resData.gpuOnly.SeqRefs->GetGPUVirtualAddress());
-        cmdList->SetComputeRoot32BitConstant(9, req->zstdSeqStreamCount, 0);
-        cmdList->SetComputeRoot32BitConstant(9, req->zstdFrameCount, 1);
+        cmdList->SetComputeRootShaderResourceView(9, req->resData.gpuOnly.Counters->GetGPUVirtualAddress());
+        cmdList->SetComputeRoot32BitConstant(10, req->zstdFrameCount, 1);
 
         ZSTDGPU_KERNEL_SCOPE(PrefixSequenceOffsets, cmdList,
-            cmdList->Dispatch(ZSTDGPU_TG_COUNT(req->zstdSeqStreamCount, kzstdgpu_TgSizeX_PrefixSequenceOffsets), 1, 1);
+            zstdgpu_DispatchIndirect(cmdList, PrefixSequenceOffsets, PrefixSequenceOffsets);
         );
 
         PIXEndEvent(cmdList);

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -405,7 +405,10 @@ static const zstdgpu_CompiledShader kzstdgpu_CompiledShaders [] =
     ZSTDGPU_DISPATCH32_CMD_SIG(GroupCompressedLiterals  , 4)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(InitFseTable             , 1)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(InitHuffmanTable         , 1)    \
-    ZSTDGPU_DISPATCH32_CMD_SIG(PrefixSequenceOffsets    , 10)
+    ZSTDGPU_DISPATCH32_CMD_SIG(MemsetMemcpy             , 5)    \
+    ZSTDGPU_DISPATCH32_CMD_SIG(PrefixSequenceOffsets    , 10)    \
+    ZSTDGPU_DISPATCH32_CMD_SIG(PrefixSum                , 2)    \
+    ZSTDGPU_DISPATCH32_CMD_SIG(ComputePrefixSum         , 7)
 
 #define ZSTDGPU_RUNTIME_KERNEL_LIST_SHARED()        \
     ZSTDGPU_KERNEL(ComputeDestSequenceOffsets)      \
@@ -1452,8 +1455,14 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[PrefixSum :: Block Counts]");
         d3d12aid_ComputeRsPs_Set(&req->PrefixSum, cmdList);
-        cmdList->SetComputeRoot32BitConstant(2, req->zstdFrameCount, 0);
-        cmdList->SetComputeRoot32BitConstant(2, 0 /** outputInclusive */, 1);
+        /**
+         *  TODO(pamartis): This is `tgOffset` that should be set up by EmitDispatch on GPU
+         *  but because we haven't converted these dispatches to 32-bit indirect dispatches yet,
+         *  we setup the constant that shader expects
+         */
+        cmdList->SetComputeRoot32BitConstant(2, 0 /** tgOffset */, 0);
+        cmdList->SetComputeRoot32BitConstant(2, req->zstdFrameCount, 1);
+        cmdList->SetComputeRoot32BitConstant(2, 0 /** outputInclusive */, 2);
 
         ZSTDGPU_KERNEL_SCOPE(PrefixSum, cmdList,
         {
@@ -1697,16 +1706,16 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRootUnorderedAccessView(4, req->resData.gpuOnly.Counters->GetGPUVirtualAddress());
         cmdList->SetComputeRootUnorderedAccessView(5, req->resData.gpuOnly.DispatchArgs->GetGPUVirtualAddress());
         cmdList->SetComputeRootUnorderedAccessView(6, req->resData.gpuOnly.DispatchCnts->GetGPUVirtualAddress());
-        cmdList->SetComputeRoot32BitConstant(7, req->zstdCmpBlockCount, 0);
+        cmdList->SetComputeRoot32BitConstant(7, req->zstdCmpBlockCount, 1);
 #if 0
         // NOTE(pamartis): Use this pass to with DecompressLiterals kernel
-        cmdList->SetComputeRoot32BitConstant(7, kzstdgpu_TgSizeX_DecompressLiterals, 1);
+        cmdList->SetComputeRoot32BitConstant(7, kzstdgpu_TgSizeX_DecompressLiterals, 2);
 #else
         // NOTE(pamartis): Use this path to with DecompressLiterals_LdsStoreCache* kernels
-        cmdList->SetComputeRoot32BitConstant(7, req->DecompressLiterals_LdsStoreCache_StreamsPerGroup, 1);
+        cmdList->SetComputeRoot32BitConstant(7, req->DecompressLiterals_LdsStoreCache_StreamsPerGroup, 2);
 #endif
         ZSTDGPU_KERNEL_SCOPE(ComputePrefixSum, cmdList,
-            cmdList->Dispatch(ZSTDGPU_TG_COUNT(req->zstdCmpBlockCount, kzstdgpu_TgSizeX_PrefixSum_LiteralCount), 1, 1);
+            zstdgpu_DispatchIndirect(cmdList, ComputePrefixSum, ComputePrefixSum);
         );
         PIXEndEvent(cmdList);
     }
@@ -1992,11 +2001,11 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
         cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.BlockSizePrefix->GetGPUVirtualAddress());
         cmdList->SetComputeRootUnorderedAccessView(1, req->resData.gpuOnly.BlockSizePrefix->GetGPUVirtualAddress() + allBlockCount * sizeof(uint32_t));
-        cmdList->SetComputeRoot32BitConstant(2, allBlockCount, 0);
-        cmdList->SetComputeRoot32BitConstant(2, 1 /** outputInclusive */, 1);
+        cmdList->SetComputeRoot32BitConstant(2, allBlockCount, 1);
+        cmdList->SetComputeRoot32BitConstant(2, 1 /** outputInclusive */, 2);
 
         ZSTDGPU_KERNEL_SCOPE(PrefixBlockSizes, cmdList,
-            cmdList->Dispatch(ZSTDGPU_TG_COUNT(allBlockCount, kzstdgpu_TgSizeX_PrefixSum), 1, 1);
+            zstdgpu_DispatchIndirect(cmdList, PrefixSum, PrefixBlockSizes);
         );
 
         PIXEndEvent(cmdList);
@@ -2080,11 +2089,11 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
                 cmdList->SetComputeRootShaderResourceView(2, req->resData.gpuOnly.PerFrameBlockSizesRAW->GetGPUVirtualAddress());
                 cmdList->SetComputeRootShaderResourceView(3, req->resData.gpuOnly.BlocksRAWRefs->GetGPUVirtualAddress());
                 cmdList->SetComputeRootShaderResourceView(4, req->resData.gpuOnly.GlobalBlockIndexPerRawBlock->GetGPUVirtualAddress());
-                cmdList->SetComputeRoot32BitConstant(5, req->zstdRawByteCount, 0);
-                cmdList->SetComputeRoot32BitConstant(5, req->zstdRawBlockCount, 1);
-                cmdList->SetComputeRoot32BitConstant(5, req->zstdFrameCount, 2);
-                cmdList->SetComputeRoot32BitConstant(5, 1 /* flags */, 3);
-                zstdgpu_Dispatch32Bit(cmdList, ZSTDGPU_TG_COUNT(req->zstdRawByteCount, kzstdgpu_TgSizeX_MemsetMemcpy), 5, 4);
+                cmdList->SetComputeRoot32BitConstant(5, req->zstdRawByteCount, 1);
+                cmdList->SetComputeRoot32BitConstant(5, req->zstdRawBlockCount, 2);
+                cmdList->SetComputeRoot32BitConstant(5, req->zstdFrameCount, 3);
+                cmdList->SetComputeRoot32BitConstant(5, 1 /* flags */, 4);
+                zstdgpu_DispatchIndirect(cmdList, MemsetMemcpy, MemcpyRAW);
             }
             if (req->zstdRleByteCount > 0)
             {
@@ -2092,11 +2101,11 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
                 cmdList->SetComputeRootShaderResourceView(2, req->resData.gpuOnly.PerFrameBlockSizesRLE->GetGPUVirtualAddress());
                 cmdList->SetComputeRootShaderResourceView(3, req->resData.gpuOnly.BlocksRLERefs->GetGPUVirtualAddress());
                 cmdList->SetComputeRootShaderResourceView(4, req->resData.gpuOnly.GlobalBlockIndexPerRleBlock->GetGPUVirtualAddress());
-                cmdList->SetComputeRoot32BitConstant(5, req->zstdRleByteCount, 0);
-                cmdList->SetComputeRoot32BitConstant(5, req->zstdRleBlockCount, 1);
-                cmdList->SetComputeRoot32BitConstant(5, req->zstdFrameCount, 2);
-                cmdList->SetComputeRoot32BitConstant(5, 0 /* flags */, 3);
-                zstdgpu_Dispatch32Bit(cmdList, ZSTDGPU_TG_COUNT(req->zstdRleByteCount, kzstdgpu_TgSizeX_MemsetMemcpy), 5, 4);
+                cmdList->SetComputeRoot32BitConstant(5, req->zstdRleByteCount, 1);
+                cmdList->SetComputeRoot32BitConstant(5, req->zstdRleBlockCount, 2);
+                cmdList->SetComputeRoot32BitConstant(5, req->zstdFrameCount, 3);
+                cmdList->SetComputeRoot32BitConstant(5, 0 /* flags */, 4);
+                zstdgpu_DispatchIndirect(cmdList, MemsetMemcpy, MemsetRLE);
             }
         });
         PIXEndEvent(cmdList);

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -601,7 +601,7 @@ ZSTDGPU_ENUM(Status) zstdgpu_CreatePersistentContext(zstdgpu_PersistentContext *
 
         dispatchArgDesc[0].Type                              = D3D12_INDIRECT_ARGUMENT_TYPE_CONSTANT;
         dispatchArgDesc[0].Constant.DestOffsetIn32BitValues  = 0;
-        dispatchArgDesc[0].Constant.Num32BitValuesToSet      = 1;
+        dispatchArgDesc[0].Constant.Num32BitValuesToSet      = 2;
         dispatchArgDesc[1].Type                              = D3D12_INDIRECT_ARGUMENT_TYPE_DISPATCH;
 
         cmdSigDesc.ByteStride        = sizeof(uint32_t) * kzstdgpu_DispatchSlot_CmdStrideInUInt32;
@@ -1466,7 +1466,7 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
          *  we setup the constant that shader expects
          */
         cmdList->SetComputeRoot32BitConstant(2, 0 /** tgOffset */, 0);
-        cmdList->SetComputeRoot32BitConstant(2, req->zstdFrameCount, 1);
+        cmdList->SetComputeRoot32BitConstant(2, req->zstdFrameCount /** workItemCount */, 1);
         cmdList->SetComputeRoot32BitConstant(2, 0 /** outputInclusive */, 2);
 
         ZSTDGPU_KERNEL_SCOPE(PrefixSum, cmdList,
@@ -1655,7 +1655,7 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Parse Compressed Blocks]");
         BIND_RS_PS_SRT(ParseCompressedBlocks);
-        cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 1);
+        // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
         cmdList->SetComputeRoot32BitConstant(1, req->resInfo.CompressedData_ByteSize, 2);
         cmdList->SetComputeRoot32BitConstant(1, req->zstdFrameCount, 3);
 
@@ -1746,7 +1746,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRootUnorderedAccessView(2, req->resData.gpuOnly.LitStreamEndPerHuffmanTable->GetGPUVirtualAddress() + req->zstdCmpBlockCount * sizeof(uint32_t));
         cmdList->SetComputeRootUnorderedAccessView(3, req->resData.gpuOnly.LitGroupEndPerHuffmanTable->GetGPUVirtualAddress() + req->zstdCmpBlockCount * sizeof(uint32_t));
         cmdList->SetComputeRootUnorderedAccessView(4, req->resData.gpuOnly.Counters->GetGPUVirtualAddress());
-        cmdList->SetComputeRoot32BitConstant(5, req->zstdCmpBlockCount, 1);
+        // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
 #if 0
         // NOTE(pamartis): Use this pass to with DecompressLiterals kernel
         cmdList->SetComputeRoot32BitConstant(5, kzstdgpu_TgSizeX_DecompressLiterals, 2);
@@ -1852,6 +1852,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRootShaderResourceView(1, req->resData.gpuOnly.LitStreamBuckets->GetGPUVirtualAddress());
         cmdList->SetComputeRootShaderResourceView(2, req->resData.gpuOnly.Counters->GetGPUVirtualAddress());
         cmdList->SetComputeRootUnorderedAccessView(3, req->resData.gpuOnly.LitStreamRemap->GetGPUVirtualAddress());
+        // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
 
         ZSTDGPU_KERNEL_SCOPE(GroupCompressedLiterals, cmdList,
             zstdgpu_DispatchIndirect(cmdList, GroupCompressedLiterals, GroupCompressedLiterals);
@@ -1871,35 +1872,37 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             // NOTE: we run 4 ExecuteIndirects (per argument) in order to be able to (but we don't do this for prototype)
             // switch PSO to more optimial (depending on maximal FSE table size) because D3D12 doesn't allow to switch PSOs in ExecuteIndirect.
 
+            // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
+
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Huffman Weights");
             uint32_t tableStartIndex = 0;
-            cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 1);
-            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartHufW(0, req->zstdCmpBlockCount), 2);
-            cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_HufW, 3);
+            cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 2);
+            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartHufW(0, req->zstdCmpBlockCount), 3);
+            cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_HufW, 4);
             zstdgpu_DispatchIndirect(cmdList, InitFseTable, FseHufW);
             PIXEndEvent(cmdList);
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Literal Lengths");
             tableStartIndex += req->zstdCmpBlockCount;
-            cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 1);
-            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartLLen(0, req->zstdCmpBlockCount), 2);
-            cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_LLen, 3);
+            cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 2);
+            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartLLen(0, req->zstdCmpBlockCount), 3);
+            cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_LLen, 4);
             zstdgpu_DispatchIndirect(cmdList, InitFseTable, FseLLen);
             PIXEndEvent(cmdList);
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Offsets");
             tableStartIndex += req->zstdCmpBlockCount + 1;
-            cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 1);
-            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartOffs(0, req->zstdCmpBlockCount), 2);
-            cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_Offs, 3);
+            cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 2);
+            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartOffs(0, req->zstdCmpBlockCount), 3);
+            cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_Offs, 4);
             zstdgpu_DispatchIndirect(cmdList, InitFseTable, FseOffs);
             PIXEndEvent(cmdList);
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Match Lengths");
             tableStartIndex += req->zstdCmpBlockCount + 1;
-            cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 1);
-            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartMLen(0, req->zstdCmpBlockCount), 2);
-            cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_MLen, 3);
+            cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 2);
+            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartMLen(0, req->zstdCmpBlockCount), 3);
+            cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_MLen, 4);
             zstdgpu_DispatchIndirect(cmdList, InitFseTable, FseMLen);
             PIXEndEvent(cmdList);
             PIXEndEvent(cmdList);
@@ -1926,6 +1929,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Decompress Huffman Weights]");
         BIND_RS_PS_SRT(DecompressHuffmanWeights);
+        // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
 
         ZSTDGPU_KERNEL_SCOPE(DecompressHuffmanWeights, cmdList,
             zstdgpu_DispatchIndirect(cmdList, DecompressHuffmanWeights, DecompressHuffmanWeights);
@@ -1937,8 +1941,9 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Decode Uncompressed Huffman Weights]");
         BIND_RS_PS_SRT(DecodeHuffmanWeights);
-        cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 1);
-        cmdList->SetComputeRoot32BitConstant(1, req->resInfo.CompressedData_ByteSize, 2);
+        // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
+        cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 2);
+        cmdList->SetComputeRoot32BitConstant(1, req->resInfo.CompressedData_ByteSize, 3);
 
         ZSTDGPU_KERNEL_SCOPE(DecodeHuffmanWeights, cmdList,
             zstdgpu_DispatchIndirect(cmdList, DecodeHuffmanWeights, DecodeHuffmanWeights);
@@ -1965,19 +1970,20 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Pre-Init Huffman Table]");
         BIND_RS_PS_SRT(InitHuffmanTable);
+        // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
 
         ZSTDGPU_KERNEL_SCOPE(InitHuffmanTable, cmdList,
         {
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Path: FSE-compressed Huffman Weights]");
             {
-                cmdList->SetComputeRoot32BitConstant(1, /** HuffmaTableIndexBase*/0, 1);
+                cmdList->SetComputeRoot32BitConstant(1, /** HuffmaTableIndexBase*/0, 2);
                 zstdgpu_DispatchIndirect(cmdList, InitHuffmanTable, FseHufW);
             }
             PIXEndEvent(cmdList);
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Path: Uncompressed Huffman Weights]");
             {
-                cmdList->SetComputeRoot32BitConstant(1, /** HuffmaTableIndexBase = zstdCmpBlockCount meaning indices are reversed */req->zstdCmpBlockCount, 1);
+                cmdList->SetComputeRoot32BitConstant(1, /** HuffmaTableIndexBase = zstdCmpBlockCount meaning indices are reversed */req->zstdCmpBlockCount, 2);
                 zstdgpu_DispatchIndirect(cmdList, InitHuffmanTable, HUF_WgtStreams);
             }
             PIXEndEvent(cmdList);
@@ -2003,7 +2009,8 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Decompress Literals]");
         BIND_RS_PS_SRT(DecompressLiterals);
-        cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 1);
+        // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
+        cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 2);
 
         ZSTDGPU_KERNEL_SCOPE(DecompressLiterals, cmdList,
             zstdgpu_DispatchIndirect(cmdList, DecompressLiterals, DecompressLiterals);
@@ -2026,6 +2033,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Decompress Sequences]");
         BIND_RS_PS_SRT(DecompressSequences);
+        // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
 
         ZSTDGPU_KERNEL_SCOPE(DecompressSequences, cmdList,
             zstdgpu_DispatchIndirect(cmdList, DecompressSequences, DecompressSequences);
@@ -2073,7 +2081,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
         cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.BlockSizePrefix->GetGPUVirtualAddress());
         cmdList->SetComputeRootUnorderedAccessView(1, req->resData.gpuOnly.BlockSizePrefix->GetGPUVirtualAddress() + allBlockCount * sizeof(uint32_t));
-        cmdList->SetComputeRoot32BitConstant(2, allBlockCount, 1);
+        // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
         cmdList->SetComputeRoot32BitConstant(2, 1 /** outputInclusive */, 2);
 
         ZSTDGPU_KERNEL_SCOPE(PrefixBlockSizes, cmdList,
@@ -2097,7 +2105,8 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRootShaderResourceView(7, req->resData.gpuOnly.PerFrameBlockCountAll->GetGPUVirtualAddress());
         cmdList->SetComputeRootShaderResourceView(8, req->resData.gpuOnly.SeqRefs->GetGPUVirtualAddress());
         cmdList->SetComputeRootShaderResourceView(9, req->resData.gpuOnly.Counters->GetGPUVirtualAddress());
-        cmdList->SetComputeRoot32BitConstant(10, req->zstdFrameCount, 1);
+        // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
+        cmdList->SetComputeRoot32BitConstant(10, req->zstdFrameCount, 2);
 
         ZSTDGPU_KERNEL_SCOPE(PrefixSequenceOffsets, cmdList,
             zstdgpu_DispatchIndirect(cmdList, PrefixSequenceOffsets, PrefixSequenceOffsets);
@@ -2130,6 +2139,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Finalise Sequence Offsets]");
         BIND_RS_PS_SRT(FinaliseSequenceOffsets);
+        // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
 
         ZSTDGPU_KERNEL_SCOPE(FinaliseSequenceOffsets, cmdList,
             zstdgpu_DispatchIndirect(cmdList, FinaliseSequenceOffsets, FinaliseSequenceOffsets);
@@ -2161,7 +2171,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
                 cmdList->SetComputeRootShaderResourceView(2, req->resData.gpuOnly.PerFrameBlockSizesRAW->GetGPUVirtualAddress());
                 cmdList->SetComputeRootShaderResourceView(3, req->resData.gpuOnly.BlocksRAWRefs->GetGPUVirtualAddress());
                 cmdList->SetComputeRootShaderResourceView(4, req->resData.gpuOnly.GlobalBlockIndexPerRawBlock->GetGPUVirtualAddress());
-                cmdList->SetComputeRoot32BitConstant(5, req->zstdRawByteCount, 1);
+                // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
                 cmdList->SetComputeRoot32BitConstant(5, req->zstdRawBlockCount, 2);
                 cmdList->SetComputeRoot32BitConstant(5, req->zstdFrameCount, 3);
                 cmdList->SetComputeRoot32BitConstant(5, 1 /* flags */, 4);
@@ -2173,7 +2183,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
                 cmdList->SetComputeRootShaderResourceView(2, req->resData.gpuOnly.PerFrameBlockSizesRLE->GetGPUVirtualAddress());
                 cmdList->SetComputeRootShaderResourceView(3, req->resData.gpuOnly.BlocksRLERefs->GetGPUVirtualAddress());
                 cmdList->SetComputeRootShaderResourceView(4, req->resData.gpuOnly.GlobalBlockIndexPerRleBlock->GetGPUVirtualAddress());
-                cmdList->SetComputeRoot32BitConstant(5, req->zstdRleByteCount, 1);
+                // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
                 cmdList->SetComputeRoot32BitConstant(5, req->zstdRleBlockCount, 2);
                 cmdList->SetComputeRoot32BitConstant(5, req->zstdFrameCount, 3);
                 cmdList->SetComputeRoot32BitConstant(5, 0 /* flags */, 4);

--- a/zstd/zstdgpu/zstdgpu_reference_store.cpp
+++ b/zstd/zstdgpu/zstdgpu_reference_store.cpp
@@ -792,17 +792,17 @@ static ZSTDGPU_ENUM(Validate_Result) izstdgpu_ReferenceStore_Validate_OffsetsAnd
 
 ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_Blocks(const zstdgpu_ResourceDataCpu *resourceDataCpu)
 {
-    if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_Blocks_RAW] != GBlockIndexRAW)
+    if (resourceDataCpu->Counters->Blocks_RAW != GBlockIndexRAW)
         return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
-    if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_Blocks_RLE] != GBlockIndexRLE)
+    if (resourceDataCpu->Counters->Blocks_RLE != GBlockIndexRLE)
         return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
-    if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_Blocks_CMP] != GBlockIndexCMP)
+    if (resourceDataCpu->Counters->Blocks_CMP != GBlockIndexCMP)
         return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
     #define VALIDATE_BLOCKS(name) \
-        izstdgpu_ReferenceStore_Validate_OffsetsAndSizes(GZstd.Blocks##name##Refs, GBlockCount##name, resourceDataCpu->Blocks##name##Refs, resourceDataCpu->Counters[kzstdgpu_CounterIndex_Blocks_##name])
+        izstdgpu_ReferenceStore_Validate_OffsetsAndSizes(GZstd.Blocks##name##Refs, GBlockCount##name, resourceDataCpu->Blocks##name##Refs, resourceDataCpu->Counters->Blocks_##name)
 
         if (ZSTDGPU_ENUM_CONST(Validate_Success) != VALIDATE_BLOCKS(RAW))
             return ZSTDGPU_ENUM_CONST(Validate_Failed);
@@ -882,21 +882,21 @@ ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_FseTables(const zs
     const zstdgpu_ResourceDataCpu *ref = &GZstd;
     const zstdgpu_ResourceDataCpu *tst = resourceDataCpu;
 
-    if (tst->Counters[kzstdgpu_CounterIndex_Blocks_CMP] != GBlockCountCMP)
+    if (tst->Counters->Blocks_CMP != GBlockCountCMP)
         return ZSTDGPU_ENUM_CONST(Validate_Failed);
-    if (tst->Counters[kzstdgpu_CounterIndex_Blocks_CMP] != GBlockIndexCMP)
-        return ZSTDGPU_ENUM_CONST(Validate_Failed);
-
-    if (tst->Counters[kzstdgpu_CounterIndex_FseHufW] != GFseProbTableIndexHufW)
-        return ZSTDGPU_ENUM_CONST(Validate_Failed);
-    if (tst->Counters[kzstdgpu_CounterIndex_FseLLen] != GFseProbTableIndexLLen)
-        return ZSTDGPU_ENUM_CONST(Validate_Failed);
-    if (tst->Counters[kzstdgpu_CounterIndex_FseOffs] != GFseProbTableIndexOffs)
-        return ZSTDGPU_ENUM_CONST(Validate_Failed);
-    if (tst->Counters[kzstdgpu_CounterIndex_FseMLen] != GFseProbTableIndexMLen)
+    if (tst->Counters->Blocks_CMP != GBlockIndexCMP)
         return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
-    if (tst->Counters[kzstdgpu_CounterIndex_FseHufW] != GFseCompressedHuffmanWeightCount)
+    if (tst->Counters->FseHufW != GFseProbTableIndexHufW)
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
+    if (tst->Counters->FseLLen != GFseProbTableIndexLLen)
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
+    if (tst->Counters->FseOffs != GFseProbTableIndexOffs)
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
+    if (tst->Counters->FseMLen != GFseProbTableIndexMLen)
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
+
+    if (tst->Counters->FseHufW != GFseCompressedHuffmanWeightCount)
         return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
     for (uint32_t i = 0; i < GBlockCountCMP; ++i)
@@ -944,21 +944,21 @@ ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_FseTables(const zs
 
 ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_CompressedBlocksData(const zstdgpu_ResourceDataCpu *resourceDataCpu)
 {
-    if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_Blocks_CMP] != GBlockCountCMP)
+    if (resourceDataCpu->Counters->Blocks_CMP != GBlockCountCMP)
         return ZSTDGPU_ENUM_CONST(Validate_Failed);
-    if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_Blocks_CMP] != GBlockIndexCMP)
-        return ZSTDGPU_ENUM_CONST(Validate_Failed);
-
-    if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_FseHufW] != GFseProbTableIndexHufW)
-        return ZSTDGPU_ENUM_CONST(Validate_Failed);
-    if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_FseLLen] != GFseProbTableIndexLLen)
-        return ZSTDGPU_ENUM_CONST(Validate_Failed);
-    if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_FseOffs] != GFseProbTableIndexOffs)
-        return ZSTDGPU_ENUM_CONST(Validate_Failed);
-    if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_FseMLen] != GFseProbTableIndexMLen)
+    if (resourceDataCpu->Counters->Blocks_CMP != GBlockIndexCMP)
         return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
-    if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_FseHufW] != GFseCompressedHuffmanWeightCount)
+    if (resourceDataCpu->Counters->FseHufW != GFseProbTableIndexHufW)
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
+    if (resourceDataCpu->Counters->FseLLen != GFseProbTableIndexLLen)
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
+    if (resourceDataCpu->Counters->FseOffs != GFseProbTableIndexOffs)
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
+    if (resourceDataCpu->Counters->FseMLen != GFseProbTableIndexMLen)
+        return ZSTDGPU_ENUM_CONST(Validate_Failed);
+
+    if (resourceDataCpu->Counters->FseHufW != GFseCompressedHuffmanWeightCount)
         return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
     const zstdgpu_CompressedBlockData *refCmpBlocks = GZstd.CompressedBlocks;
@@ -1040,10 +1040,10 @@ ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_CompressedBlocksDa
 
 ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_DecompressedHuffmanWeights(const zstdgpu_ResourceDataCpu *resourceDataCpu)
 {
-    if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_Blocks_CMP] != GBlockCountCMP)
+    if (resourceDataCpu->Counters->Blocks_CMP != GBlockCountCMP)
         return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
-    if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_Blocks_CMP] != GBlockIndexCMP)
+    if (resourceDataCpu->Counters->Blocks_CMP != GBlockIndexCMP)
         return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
     const zstdgpu_ResourceDataCpu *ref = &GZstd;
@@ -1099,10 +1099,10 @@ ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_DecompressedHuffma
 
 ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_DecodedHuffmanWeights(const zstdgpu_ResourceDataCpu * resourceDataCpu)
 {
-    if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_Blocks_CMP] != GBlockCountCMP)
+    if (resourceDataCpu->Counters->Blocks_CMP != GBlockCountCMP)
         return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
-    if (resourceDataCpu->Counters[kzstdgpu_CounterIndex_Blocks_CMP] != GBlockIndexCMP)
+    if (resourceDataCpu->Counters->Blocks_CMP != GBlockIndexCMP)
         return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
 
@@ -1247,7 +1247,7 @@ ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_DecompressedSequen
             //izstdgpu_ReferenceStore_Validate_OffsetAndSize(&refSeqRefs[refSeqSteamIndex].dst, &tstSeqRefs[tstSeqSteamIndex].dst);
             {
                 const uint32_t refSeqOffsNext = (i == GBlockCountCMP - 1u) ? GSequenceCount                                                     : refData->PerSeqStreamSeqStart[refSeqSteamIndex + 1];
-                const uint32_t tstSeqOffsNext = (i == GBlockCountCMP - 1u) ? tstData->Counters[kzstdgpu_CounterIndex_Seq_Streams_DecodedItems]  : tstData->PerSeqStreamSeqStart[tstSeqSteamIndex + 1];
+                const uint32_t tstSeqOffsNext = (i == GBlockCountCMP - 1u) ? tstData->Counters->Seq_Streams_DecodedItems  : tstData->PerSeqStreamSeqStart[tstSeqSteamIndex + 1];
                 const uint32_t refSeqCount = refSeqOffsNext - refSeqOffs;
                 const uint32_t tstSeqCount = tstSeqOffsNext - tstSeqOffs;
 

--- a/zstd/zstdgpu/zstdgpu_resources.h
+++ b/zstd/zstdgpu/zstdgpu_resources.h
@@ -29,7 +29,7 @@
     ZSTDGPU_BUFFER(zstdgpu_OffsetAndSize                    , FramesRefs                    )
 
 #define ZSTDGPU_BUFFERS_LIST_READBACK_STAGE_0()                                                 \
-    ZSTDGPU_BUFFER(uint32_t                                 , Counters                      )   \
+    ZSTDGPU_BUFFER(zstdgpu_Counters                         , Counters                      )   \
     ZSTDGPU_BUFFER(uint32_t                                 , PerFrameBlockCountRAW         )   \
     ZSTDGPU_BUFFER(uint32_t                                 , PerFrameBlockCountRLE         )   \
     ZSTDGPU_BUFFER(uint32_t                                 , PerFrameBlockCountCMP         )   \
@@ -258,7 +258,7 @@ static void zstdgpu_ResourceInfo_Stage_0_InitSize(zstdgpu_ResourceInfo *outInfo,
     const uint32_t Frames_Count = frameCount;
     const uint32_t FramesRefs_Count = frameCount;
     const uint32_t CompressedData_Count = (dataCount + 3) / 4; // because CompressedData is in uint32_t
-    const uint32_t Counters_Count = kzstdgpu_CounterIndex_Count;
+    const uint32_t Counters_Count = 1;
     const uint32_t PerFrameBlockCountRAW_Count = frameCount + zstdgpu_GetLookbackBlockCount(frameCount);
     const uint32_t PerFrameBlockCountRLE_Count = PerFrameBlockCountRAW_Count;
     const uint32_t PerFrameBlockCountCMP_Count = PerFrameBlockCountRAW_Count;

--- a/zstd/zstdgpu/zstdgpu_resources.h
+++ b/zstd/zstdgpu/zstdgpu_resources.h
@@ -40,7 +40,8 @@
     ZSTDGPU_BUFFER(zstdgpu_FrameInfo                        , Frames                        )
 
 #define ZSTDGPU_BUFFERS_LIST_STAGE_0() \
-    ZSTDGPU_BUFFER(uint32_t                                 , DispatchArgs                  )
+    ZSTDGPU_BUFFER(uint32_t                                 , DispatchArgs                  )   \
+    ZSTDGPU_BUFFER(uint32_t                                 , DispatchCnts                  )
 
 #define ZSTDGPU_BUFFERS_LIST_UPLOAD_STAGE_2() /* empty so far*/
 
@@ -268,6 +269,7 @@ static void zstdgpu_ResourceInfo_Stage_0_InitSize(zstdgpu_ResourceInfo *outInfo,
     const uint32_t PerFrameBlockSizesRLE_Count = PerFrameBlockCountRLE_Count;
     const uint32_t PerFrameSeqStreamMinIdx_Count = frameCount;
     const uint32_t DispatchArgs_Count = kzstdgpu_DispatchSlot_Count * kzstdgpu_DispatchSlot_StrideInUInt32;
+    const uint32_t DispatchCnts_Count = kzstdgpu_DispatchSlot_Count;
 
     ZSTDGPU_ALL_BUFFERS_LIST_STAGE_0()
 }

--- a/zstd/zstdgpu/zstdgpu_resources.h
+++ b/zstd/zstdgpu/zstdgpu_resources.h
@@ -39,7 +39,8 @@
     ZSTDGPU_BUFFER(uint32_t                                 , PerFrameSeqStreamMinIdx       )   \
     ZSTDGPU_BUFFER(zstdgpu_FrameInfo                        , Frames                        )
 
-#define ZSTDGPU_BUFFERS_LIST_STAGE_0() /* empty so far*/
+#define ZSTDGPU_BUFFERS_LIST_STAGE_0() \
+    ZSTDGPU_BUFFER(uint32_t                                 , DispatchArgs                  )
 
 #define ZSTDGPU_BUFFERS_LIST_UPLOAD_STAGE_2() /* empty so far*/
 
@@ -266,6 +267,7 @@ static void zstdgpu_ResourceInfo_Stage_0_InitSize(zstdgpu_ResourceInfo *outInfo,
     const uint32_t PerFrameBlockSizesRAW_Count = PerFrameBlockCountRAW_Count;
     const uint32_t PerFrameBlockSizesRLE_Count = PerFrameBlockCountRLE_Count;
     const uint32_t PerFrameSeqStreamMinIdx_Count = frameCount;
+    const uint32_t DispatchArgs_Count = kzstdgpu_DispatchSlot_Count * kzstdgpu_DispatchSlot_StrideInUInt32;
 
     ZSTDGPU_ALL_BUFFERS_LIST_STAGE_0()
 }

--- a/zstd/zstdgpu/zstdgpu_resources.h
+++ b/zstd/zstdgpu/zstdgpu_resources.h
@@ -590,6 +590,13 @@ static void zstdgpu_ResourceDataGpu_Init_GpuOnly(zstdgpu_ResourceDataGpu *outRes
     ID3D12Heap *heap = outResData->gpuOnly_Heap[stageIndex];
     if (stageIndex == 0)
     {
+#if defined(_GAMING_XBOX)
+        bufDesc.Width = info->DispatchArgs_ByteSizeInternal;
+        bufDesc.Flags |= D3D12XBOX_RESOURCE_FLAG_ALLOW_INDIRECT_BUFFER;
+        outResData->gpuOnly.DispatchArgs = d3d12aid_Resource_CreateCommitted_WithHeapTypeAndFlags(device, &bufDesc, D3D12_HEAP_TYPE_DEFAULT, D3D12XBOX_HEAP_FLAG_ALLOW_INDIRECT_BUFFERS);
+        bufDesc.Flags &= ~D3D12XBOX_RESOURCE_FLAG_ALLOW_INDIRECT_BUFFER;
+#endif
+
         ZSTDGPU_ALL_BUFFERS_LIST_STAGE_0()
     }
     else if (stageIndex == 1)

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -64,10 +64,11 @@ static void zstdgpu_EmitDispatch(ZSTDGPU_RW_BUFFER(uint32_t) dispatchArgs, ZSTDG
     const uint32_t baseIdx = slot * kzstdgpu_DispatchSlot_StrideInUInt32;
 #if defined(_GAMING_XBOX) || defined(__XBOX_SCARLETT) || defined(__XBOX_ONE)
     // dispatch 0: no problems with # of threadgroup per dimension, support 32-bit
-    dispatchArgs[baseIdx + 0] = 0;  // tgOffset
-    dispatchArgs[baseIdx + 1] = tgCount;
-    dispatchArgs[baseIdx + 2] = 1;
+    dispatchArgs[baseIdx + 0] = 0;          // tgOffset
+    dispatchArgs[baseIdx + 1] = elemCount;  // workItemCount
+    dispatchArgs[baseIdx + 2] = tgCount;
     dispatchArgs[baseIdx + 3] = 1;
+    dispatchArgs[baseIdx + 4] = 1;
     dispatchCnts[slot] = 1;
 #else
     const uint32_t tgCountY = tgCount >> kzstdgpu_MaxCount_ThreadGroupsPerDimensionLog2;
@@ -76,30 +77,34 @@ static void zstdgpu_EmitDispatch(ZSTDGPU_RW_BUFFER(uint32_t) dispatchArgs, ZSTDG
     if (tgCountY > 0)
     {
         // dispatch 0: most of threadgroups are launched via 2d dispatch with the maximal possible number of threadgroups per dimension
-        dispatchArgs[baseIdx + 0] = 0;  // tgOffset
-        dispatchArgs[baseIdx + 1] = 1u << kzstdgpu_MaxCount_ThreadGroupsPerDimensionLog2;
-        dispatchArgs[baseIdx + 2] = tgCountY;
-        dispatchArgs[baseIdx + 3] = 1;
+        dispatchArgs[baseIdx + 0] = 0;          // tgOffset
+        dispatchArgs[baseIdx + 1] = elemCount;  // workItemCount
+        dispatchArgs[baseIdx + 2] = 1u << kzstdgpu_MaxCount_ThreadGroupsPerDimensionLog2;
+        dispatchArgs[baseIdx + 3] = tgCountY;
+        dispatchArgs[baseIdx + 4] = 1;
 
         // dispatch 1: the remaining threadgroups are launched via 1d dispatch
-        dispatchArgs[baseIdx + 4] = tgCountY << kzstdgpu_MaxCount_ThreadGroupsPerDimensionLog2;  // tgOffset
-        dispatchArgs[baseIdx + 5] = tgCountX;
-        dispatchArgs[baseIdx + 6] = 1;
-        dispatchArgs[baseIdx + 7] = 1;
+        dispatchArgs[baseIdx + 5] = tgCountY << kzstdgpu_MaxCount_ThreadGroupsPerDimensionLog2;  // tgOffset
+        dispatchArgs[baseIdx + 6] = elemCount;  // workItemCount
+        dispatchArgs[baseIdx + 7] = tgCountX;
+        dispatchArgs[baseIdx + 8] = 1;
+        dispatchArgs[baseIdx + 9] = 1;
         dispatchCnts[slot] = 2;
     }
     else
     {
         // dispatch 0: all threadgroups fit into the limit of single dimension
-        dispatchArgs[baseIdx + 0] = 0;  // tgOffset
-        dispatchArgs[baseIdx + 1] = tgCount;
-        dispatchArgs[baseIdx + 2] = 1;
+        dispatchArgs[baseIdx + 0] = 0;          // tgOffset
+        dispatchArgs[baseIdx + 1] = elemCount;  // workItemCount
+        dispatchArgs[baseIdx + 2] = tgCount;
         dispatchArgs[baseIdx + 3] = 1;
+        dispatchArgs[baseIdx + 4] = 1;
         // dispatch 1: zeroed (unused but written)
-        dispatchArgs[baseIdx + 4] = 0;
         dispatchArgs[baseIdx + 5] = 0;
-        dispatchArgs[baseIdx + 6] = 1;
-        dispatchArgs[baseIdx + 7] = 1;
+        dispatchArgs[baseIdx + 6] = elemCount;  // workItemCount
+        dispatchArgs[baseIdx + 7] = 0;
+        dispatchArgs[baseIdx + 8] = 1;
+        dispatchArgs[baseIdx + 9] = 1;
         dispatchCnts[slot] = 1;
     }
 #endif

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -46,6 +46,18 @@ static void zstdgpu_TypedStoreU16(ZSTDGPU_RW_TYPED_BUFFER(uint32_t, uint16_t) in
 #endif
 }
 
+#ifdef __hlsl_dx_compiler
+static uint32_t zstdgpu_ConvertTo32BitGroupId(uint32_t2 groupId, uint32_t tgOffset)
+{
+#if defined(__XBOX_SCARLETT) || defined(__XBOX_ONE)
+    // NOTE(pamartis): tgOffset is always zero and groupId.x contains 32-bit value
+    return groupId.x;
+#else
+    return tgOffset + ((groupId.y << kzstdgpu_MaxCount_ThreadGroupsPerDimensionLog2) + groupId.x);
+#endif
+}
+#endif
+
 static void zstdgpu_EmitDispatch(ZSTDGPU_RW_BUFFER(uint32_t) dispatchArgs, ZSTDGPU_RW_BUFFER(uint32_t) dispatchCnts, uint32_t slot, uint32_t elemCount, uint32_t elemsPerTGroup)
 {
     const uint32_t tgCount = ZSTDGPU_TG_COUNT(elemCount, elemsPerTGroup);

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -46,6 +46,14 @@ static void zstdgpu_TypedStoreU16(ZSTDGPU_RW_TYPED_BUFFER(uint32_t, uint16_t) in
 #endif
 }
 
+static void zstdgpu_EmitDispatch(ZSTDGPU_RW_BUFFER(uint32_t) dispatchArgs, uint32_t slot, uint32_t elemCount, uint32_t elemsPerTGroup)
+{
+    const uint32_t baseIdx = slot * kzstdgpu_DispatchSlot_StrideInUInt32;
+    dispatchArgs[baseIdx + 0] = ZSTDGPU_TG_COUNT(elemCount, elemsPerTGroup);
+    dispatchArgs[baseIdx + 1] = 1;
+    dispatchArgs[baseIdx + 2] = 1;
+}
+
 static uint32_t zstdgpu_GlobalExclusivePrefixSum(ZSTDGPU_RW_BUFFER_GLC(uint32_t) lookback,
                                                  uint32_t vgprExclusivePrefix,
                                                  uint32_t vgprCount,
@@ -535,35 +543,12 @@ static void zstdgpu_ShaderEntry_InitResources(ZSTDGPU_PARAM_INOUT(zstdgpu_InitRe
         if (threadId == 0)
         {
             srt.inoutCounters[0].FseHufW                                     = 0;
-            srt.inoutCounters[0].FseHufW_TGroupCount_Y                       = 1;
-            srt.inoutCounters[0].FseHufW_TGroupCount_Z                       = 1;
             srt.inoutCounters[0].FseLLen                                     = 1;
-            srt.inoutCounters[0].FseLLen_TGroupCount_Y                       = 1;
-            srt.inoutCounters[0].FseLLen_TGroupCount_Z                       = 1;
             srt.inoutCounters[0].FseOffs                                     = 1;
-            srt.inoutCounters[0].FseOffs_TGroupCount_Y                       = 1;
-            srt.inoutCounters[0].FseOffs_TGroupCount_Z                       = 1;
             srt.inoutCounters[0].FseMLen                                     = 1;
-            srt.inoutCounters[0].FseMLen_TGroupCount_Y                       = 1;
-            srt.inoutCounters[0].FseMLen_TGroupCount_Z                       = 1;
-            srt.inoutCounters[0].DecompressHuffmanWeightsGroups              = 0;
-            srt.inoutCounters[0].DecompressHuffmanWeightsGroups_TGroupCount_Y = 1;
-            srt.inoutCounters[0].DecompressHuffmanWeightsGroups_TGroupCount_Z = 1;
-            srt.inoutCounters[0].DecodeHuffmanWeightsGroups                  = 0;
-            srt.inoutCounters[0].DecodeHuffmanWeightsGroups_TGroupCount_Y    = 1;
-            srt.inoutCounters[0].DecodeHuffmanWeightsGroups_TGroupCount_Z    = 1;
-            srt.inoutCounters[0].GroupCompressedLiteralsGroups               = 0;
-            srt.inoutCounters[0].GroupCompressedLiteralsGroups_TGroupCount_Y = 1;
-            srt.inoutCounters[0].GroupCompressedLiteralsGroups_TGroupCount_Z = 1;
             srt.inoutCounters[0].DecompressLiteralsGroups                    = 0;
-            srt.inoutCounters[0].DecompressLiteralsGroups_TGroupCount_Y      = 1;
-            srt.inoutCounters[0].DecompressLiteralsGroups_TGroupCount_Z      = 1;
             srt.inoutCounters[0].DecompressSequencesGroups                   = 0;
-            srt.inoutCounters[0].DecompressSequencesGroups_TGroupCount_Y     = 1;
-            srt.inoutCounters[0].DecompressSequencesGroups_TGroupCount_Z     = 1;
             srt.inoutCounters[0].HUF_WgtStreams                              = 0;
-            srt.inoutCounters[0].HUF_WgtStreams_TGroupCount_Y                = 1;
-            srt.inoutCounters[0].HUF_WgtStreams_TGroupCount_Z                = 1;
             srt.inoutCounters[0].Seq_Streams_DecodedItems                    = 0;
             srt.inoutCounters[0].HUF_Streams_DecodedBytes                    = 0;
             srt.inoutCounters[0].Seq_Streams                                 = 0;

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -509,13 +509,13 @@ static inline void zstdgpu_ShaderEntry_ParseFrames(ZSTDGPU_PARAM_INOUT(zstdgpu_P
 
                 if (WaveIsFirstLane())
                 {
-                    InterlockedAdd(srt.inoutCounters[kzstdgpu_CounterIndex_Blocks_RAW], rawBlockCount);
-                    InterlockedAdd(srt.inoutCounters[kzstdgpu_CounterIndex_Blocks_RLE], rleBlockCount);
-                    InterlockedAdd(srt.inoutCounters[kzstdgpu_CounterIndex_Blocks_CMP], cmpBlockCount);
-                    InterlockedAdd(srt.inoutCounters[kzstdgpu_CounterIndex_BlocksBytes_RAW], rawBlockByteCount);
-                    InterlockedAdd(srt.inoutCounters[kzstdgpu_CounterIndex_BlocksBytes_RLE], rleBlockByteCount);
-                    InterlockedAdd(srt.inoutCounters[kzstdgpu_CounterIndex_Frames], frameCount);
-                    InterlockedAdd(srt.inoutCounters[kzstdgpu_CounterIndex_Frames_UncompressedByteSize], uncompSize);
+                    InterlockedAdd(srt.inoutCounters[0].Blocks_RAW, rawBlockCount);
+                    InterlockedAdd(srt.inoutCounters[0].Blocks_RLE, rleBlockCount);
+                    InterlockedAdd(srt.inoutCounters[0].Blocks_CMP, cmpBlockCount);
+                    InterlockedAdd(srt.inoutCounters[0].BlocksBytes_RAW, rawBlockByteCount);
+                    InterlockedAdd(srt.inoutCounters[0].BlocksBytes_RLE, rleBlockByteCount);
+                    InterlockedAdd(srt.inoutCounters[0].Frames, frameCount);
+                    InterlockedAdd(srt.inoutCounters[0].Frames_UncompressedByteSize, uncompSize);
                 }
             }
         }
@@ -529,51 +529,55 @@ static void zstdgpu_ShaderEntry_InitResources(ZSTDGPU_PARAM_INOUT(zstdgpu_InitRe
     // "Per-frame" resources are initialized during right before "Frame Parsing"
     if (srt.initResourcesStage == 0)
     {
-        ZSTDGPU_FOR_WORK_ITEMS(i, kzstdgpu_CounterIndex_Count, threadId, kzstdgpu_TgSizeX_InitCounters)
+        // Initialize counters struct: dispatch slots get (X, 1, 1), plain counters get 0
+        // FseHufW starts at 0 because we may have no Huffman weights to decompress
+        // FseLLen/Offs/MLen start at 1 because we always decode "Default" tables at index 0
+        if (threadId == 0)
         {
-            // Initialize default "Indirect Dispatch" arguments:
-            //  - (0, 1, 1) for Huffman Weights' FSE Tables
-            //  - (1, 1, 1) for Literal Lengths' FSE Tables
-            //  - (1, 1, 1) for Offsets' FSE Tables
-            //  - (1, 1, 1) for Match Lengths' FSE Tables
-            //  - (1, 1, 1) for the number of threadgroups to decompress FSE-compressed Huffman Weights
-            //  - (1, 1, 1) for the number of threadgroups to decompress UnCompressed Huffman Weights
-            //  - (1, 1, 1) for The number of threadgroups to group Huffman-compressed literals by Huffman Table
-            //  - (1, 1, 1) for The number of threadgroups to decompress Huffman-compressed literals
-            //  - (1, 1, 1) for The number of threadgroups to decompress FSE-compressed sequences
-            //
-            //  - (0) for the Total HUF Weight Streams (uncompressed)
-            //
-            //  - (0) for the Total Sequence count in FSE-decompressed Seqeunce Streams
-            //  - (0) for the Total Byte Size in HUF-decompressed Literal Streams
-            //
-            //  - (0) for the Total FSE-compressed Sequence Streams Counter
-            //  - (0) for the Total HUF-compressed Literal Streams Counter
-            //  - (0) for the Total RAW Streams Counter
-            //  - (0) for the Total RLE Streams Counter
-            //
-            //  - (0) for the Total RAW Blocks Counter
-            //  - (0) for the Total RLE Blocks Counter
-            //  - (0) for the Total Compressed Blocks Counter
-            //  - (0) for the Total Frames Counter
-            //  - (0) for the Total Frames Uncompressed Size Counter
-            // The reason we initialize the 1-st dimension of the last three "Indirect Dispatch" arguments to "1" is
-            // because we always decode "Default" tables that get index "0", so at least 3 tables are always decoded.
-
-            const bool needsZero = i == 0
-                                || i == kzstdgpu_CounterIndex_DecompressHuffmanWeightsGroups
-                                || i == kzstdgpu_CounterIndex_DecodeHuffmanWeightsGroups
-                                || i == kzstdgpu_CounterIndex_GroupCompressedLiteralsGroups
-                                || i == kzstdgpu_CounterIndex_DecompressLiteralsGroups
-                                || i == kzstdgpu_CounterIndex_DecompressSequencesGroups
-                                || i == kzstdgpu_CounterIndex_HUF_WgtStreams
-                                || i >= kzstdgpu_CounterIndex_Seq_Streams_DecodedItems;
-
-            if (needsZero)
-                srt.inoutCounters[i] = 0;
-            else
-                srt.inoutCounters[i] = 1;
-
+            srt.inoutCounters[0].FseHufW                                     = 0;
+            srt.inoutCounters[0].FseHufW_TGroupCount_Y                       = 1;
+            srt.inoutCounters[0].FseHufW_TGroupCount_Z                       = 1;
+            srt.inoutCounters[0].FseLLen                                     = 1;
+            srt.inoutCounters[0].FseLLen_TGroupCount_Y                       = 1;
+            srt.inoutCounters[0].FseLLen_TGroupCount_Z                       = 1;
+            srt.inoutCounters[0].FseOffs                                     = 1;
+            srt.inoutCounters[0].FseOffs_TGroupCount_Y                       = 1;
+            srt.inoutCounters[0].FseOffs_TGroupCount_Z                       = 1;
+            srt.inoutCounters[0].FseMLen                                     = 1;
+            srt.inoutCounters[0].FseMLen_TGroupCount_Y                       = 1;
+            srt.inoutCounters[0].FseMLen_TGroupCount_Z                       = 1;
+            srt.inoutCounters[0].DecompressHuffmanWeightsGroups              = 0;
+            srt.inoutCounters[0].DecompressHuffmanWeightsGroups_TGroupCount_Y = 1;
+            srt.inoutCounters[0].DecompressHuffmanWeightsGroups_TGroupCount_Z = 1;
+            srt.inoutCounters[0].DecodeHuffmanWeightsGroups                  = 0;
+            srt.inoutCounters[0].DecodeHuffmanWeightsGroups_TGroupCount_Y    = 1;
+            srt.inoutCounters[0].DecodeHuffmanWeightsGroups_TGroupCount_Z    = 1;
+            srt.inoutCounters[0].GroupCompressedLiteralsGroups               = 0;
+            srt.inoutCounters[0].GroupCompressedLiteralsGroups_TGroupCount_Y = 1;
+            srt.inoutCounters[0].GroupCompressedLiteralsGroups_TGroupCount_Z = 1;
+            srt.inoutCounters[0].DecompressLiteralsGroups                    = 0;
+            srt.inoutCounters[0].DecompressLiteralsGroups_TGroupCount_Y      = 1;
+            srt.inoutCounters[0].DecompressLiteralsGroups_TGroupCount_Z      = 1;
+            srt.inoutCounters[0].DecompressSequencesGroups                   = 0;
+            srt.inoutCounters[0].DecompressSequencesGroups_TGroupCount_Y     = 1;
+            srt.inoutCounters[0].DecompressSequencesGroups_TGroupCount_Z     = 1;
+            srt.inoutCounters[0].HUF_WgtStreams                              = 0;
+            srt.inoutCounters[0].HUF_WgtStreams_TGroupCount_Y                = 1;
+            srt.inoutCounters[0].HUF_WgtStreams_TGroupCount_Z                = 1;
+            srt.inoutCounters[0].Seq_Streams_DecodedItems                    = 0;
+            srt.inoutCounters[0].HUF_Streams_DecodedBytes                    = 0;
+            srt.inoutCounters[0].Seq_Streams                                 = 0;
+            srt.inoutCounters[0].HUF_Streams                                 = 0;
+            srt.inoutCounters[0].RAW_Streams                                 = 0;
+            srt.inoutCounters[0].RLE_Streams                                 = 0;
+            srt.inoutCounters[0].Blocks_RAW                                  = 0;
+            srt.inoutCounters[0].Blocks_RLE                                  = 0;
+            srt.inoutCounters[0].Blocks_CMP                                  = 0;
+            srt.inoutCounters[0].BlocksBytes_RAW                             = 0;
+            srt.inoutCounters[0].BlocksBytes_RLE                             = 0;
+            srt.inoutCounters[0].Frames                                      = 0;
+            srt.inoutCounters[0].Frames_UncompressedByteSize                 = 0;
+            srt.inoutCounters[0].Frames_ExecuteSequences                     = 0;
         }
 
         // NOTE(pamartis): here we initialize "lookback" regions in buffers containing prefix region + lookback region
@@ -896,8 +900,8 @@ static void zstdgpu_ShaderEntry_ParseCompressedBlocks(ZSTDGPU_PARAM_INOUT(zstdgp
         const uint32_t rleStreamCountPerWave = WaveActiveCountBits(literalBlockType == 1);
         if (WaveIsFirstLane())
         {
-            InterlockedAdd(srt.inoutCounters[kzstdgpu_CounterIndex_RAW_Streams], rawStreamCountPerWave);
-            InterlockedAdd(srt.inoutCounters[kzstdgpu_CounterIndex_RLE_Streams], rleStreamCountPerWave);
+            InterlockedAdd(srt.inoutCounters[0].RAW_Streams, rawStreamCountPerWave);
+            InterlockedAdd(srt.inoutCounters[0].RLE_Streams, rleStreamCountPerWave);
         }
     }
     // ...
@@ -952,8 +956,8 @@ static void zstdgpu_ShaderEntry_ParseCompressedBlocks(ZSTDGPU_PARAM_INOUT(zstdgp
         uint32_t regeneratedOffsetPerWave = 0;
         if (WaveIsFirstLane())
         {
-            InterlockedAdd(srt.inoutCounters[kzstdgpu_CounterIndex_HUF_Streams], streamCountPerWave, streamOffsetPerWave);
-            InterlockedAdd(srt.inoutCounters[kzstdgpu_CounterIndex_HUF_Streams_DecodedBytes], regeneratedSizePerWave, regeneratedOffsetPerWave);
+            InterlockedAdd(srt.inoutCounters[0].HUF_Streams, streamCountPerWave, streamOffsetPerWave);
+            InterlockedAdd(srt.inoutCounters[0].HUF_Streams_DecodedBytes, regeneratedSizePerWave, regeneratedOffsetPerWave);
         }
         const uint32_t streamOffset = WaveReadLaneFirst(streamOffsetPerWave) + WavePrefixSum(streamCount);
         const uint32_t regeneratedOffset = WaveReadLaneFirst(regeneratedOffsetPerWave) + WavePrefixSum(regeneratedSize);
@@ -1003,7 +1007,7 @@ static void zstdgpu_ShaderEntry_ParseCompressedBlocks(ZSTDGPU_PARAM_INOUT(zstdgp
                     if (WaveIsFirstLane())                                                  \
                     {                                                                       \
                         InterlockedAdd(                                                     \
-                            srt.inoutCounters[kzstdgpu_CounterIndex_Fse##name],             \
+                            srt.inoutCounters[0].Fse##name,                                 \
                             fseWaveTableCount##name,                                        \
                             fseWaveTableStart##name                                         \
                         );                                                                  \
@@ -1050,7 +1054,7 @@ static void zstdgpu_ShaderEntry_ParseCompressedBlocks(ZSTDGPU_PARAM_INOUT(zstdgp
                 uint32_t uncompressedHuffmanWeightsStartPerWave = 0;
                 if (WaveIsFirstLane())
                 {
-                    InterlockedAdd(srt.inoutCounters[kzstdgpu_CounterIndex_HUF_WgtStreams], uncompressedHuffmanWeightsCountPerWave, uncompressedHuffmanWeightsStartPerWave);
+                    InterlockedAdd(srt.inoutCounters[0].HUF_WgtStreams, uncompressedHuffmanWeightsCountPerWave, uncompressedHuffmanWeightsStartPerWave);
                 }
                 outBlockData.fseTableIndexHufW = WaveReadLaneFirst(uncompressedHuffmanWeightsStartPerWave) + WavePrefixCountBits(true);
 
@@ -1179,14 +1183,14 @@ static void zstdgpu_ShaderEntry_ParseCompressedBlocks(ZSTDGPU_PARAM_INOUT(zstdgp
     const uint32_t waveSeqCount = WaveActiveSum(seqCount);
 
     #ifndef __hlsl_dx_compiler
-        const uint32_t seqStreamIndex = srt.inoutCounters[kzstdgpu_CounterIndex_Seq_Streams];
-        const uint32_t seqIndex = srt.inoutCounters[kzstdgpu_CounterIndex_Seq_Streams_DecodedItems];
+        const uint32_t seqStreamIndex = srt.inoutCounters[0].Seq_Streams;
+        const uint32_t seqIndex = srt.inoutCounters[0].Seq_Streams_DecodedItems;
     #endif
 
     if (WaveIsFirstLane())
     {
-        InterlockedAdd(srt.inoutCounters[kzstdgpu_CounterIndex_Seq_Streams], waveSeqStreamCount);
-        InterlockedAdd(srt.inoutCounters[kzstdgpu_CounterIndex_Seq_Streams_DecodedItems], waveSeqCount);
+        InterlockedAdd(srt.inoutCounters[0].Seq_Streams, waveSeqStreamCount);
+        InterlockedAdd(srt.inoutCounters[0].Seq_Streams_DecodedItems, waveSeqCount);
     }
 
     #ifdef __hlsl_dx_compiler
@@ -2368,9 +2372,9 @@ static void zstdgpu_ShaderEntry_InitFseTable(ZSTDGPU_PARAM_INOUT(zstdgpu_InitFse
 
 static void zstdgpu_ShaderEntry_DecompressHuffmanWeights(ZSTDGPU_PARAM_INOUT(zstdgpu_DecompressHuffmanWeights_SRT) srt, uint32_t threadId)
 {
-    const uint32_t cmpBlockCnt = srt.inCounters[kzstdgpu_CounterIndex_Blocks_CMP];
+    const uint32_t cmpBlockCnt = srt.inCounters[0].Blocks_CMP;
     // NOTE(pamartis): We check the number of FSE tables for Huffman Weights, which gives us the number of FSE-compressed Huffman Weight streams
-    if (threadId >= srt.inCounters[kzstdgpu_CounterIndex_FseHufW])
+    if (threadId >= srt.inCounters[0].FseHufW)
         return;
 
     zstdgpu_Backward_BitBuffer_V0 buffer;
@@ -2479,7 +2483,7 @@ static void zstdgpu_ShaderEntry_DecompressHuffmanWeights(ZSTDGPU_PARAM_INOUT(zst
 
 static void zstdgpu_ShaderEntry_DecodeHuffmanWeights(ZSTDGPU_PARAM_INOUT(zstdgpu_DecodeHuffmanWeights_SRT) srt, uint32_t threadId)
 {
-    const uint32_t huffmanWeightsTableCount = srt.inCounters[kzstdgpu_CounterIndex_HUF_WgtStreams];
+    const uint32_t huffmanWeightsTableCount = srt.inCounters[0].HUF_WgtStreams;
     if (threadId >= huffmanWeightsTableCount)
         return;
 
@@ -3449,7 +3453,7 @@ static zstdgpu_OffsetAndSize zstdgpu_GetSequenceStartAndCount(ZSTDGPU_PARAM_INOU
 
     ZSTDGPU_BRANCH if (seqStreamIdx + 1u == seqStreamCnt)
     {
-        ref.size = srt.inCounters[kzstdgpu_CounterIndex_Seq_Streams_DecodedItems];
+        ref.size = srt.inCounters[0].Seq_Streams_DecodedItems;
     }
     else
     {
@@ -3546,8 +3550,8 @@ static void zstdgpu_ReadExtraBitsAndUpdateState(ZSTDGPU_PARAM_INOUT(zstdgpu_Back
 static void zstdgpu_ShaderEntry_DecompressSequences_MultiStream(ZSTDGPU_PARAM_INOUT(zstdgpu_DecompressSequences_SRT) srt, uint32_t groupId, uint32_t threadId, uint32_t streamsPerGroup)
 {
     const uint32_t seqStreamIdx = groupId * streamsPerGroup + threadId;
-    const uint32_t seqStreamCnt = srt.inCounters[kzstdgpu_CounterIndex_Seq_Streams];
-    const uint32_t cmpBlockCnt = srt.inCounters[kzstdgpu_CounterIndex_Blocks_CMP];
+    const uint32_t seqStreamCnt = srt.inCounters[0].Seq_Streams;
+    const uint32_t cmpBlockCnt = srt.inCounters[0].Blocks_CMP;
 
     if (seqStreamIdx >= seqStreamCnt)
         return;
@@ -3666,8 +3670,8 @@ static void zstdgpu_ShaderEntry_DecompressSequences_SingleStream(ZSTDGPU_PARAM_I
 #endif
 
     const uint32_t seqStreamIdx = groupId;
-    const uint32_t seqStreamCnt = srt.inCounters[kzstdgpu_CounterIndex_Seq_Streams];
-    const uint32_t cmpBlockCnt = srt.inCounters[kzstdgpu_CounterIndex_Blocks_CMP];
+    const uint32_t seqStreamCnt = srt.inCounters[0].Seq_Streams;
+    const uint32_t cmpBlockCnt = srt.inCounters[0].Blocks_CMP;
 
     if (seqStreamIdx >= seqStreamCnt)
         return;
@@ -3820,14 +3824,14 @@ static void zstdgpu_ShaderEntry_DecompressSequences_MultiStream_LdsOutCache(ZSTD
                                                                 uint32_t streamsPerGroup,
                                                                 uint32_t cacheDwordsPerStream)
 {
-    const uint32_t seqStreamCnt = srt.inCounters[kzstdgpu_CounterIndex_Seq_Streams];
+    const uint32_t seqStreamCnt = srt.inCounters[0].Seq_Streams;
     const uint32_t seqStreamBeg = groupId * streamsPerGroup;
 
     const uint32_t seqStreamCntInGroup = zstdgpu_MinU32(seqStreamCnt - seqStreamBeg, streamsPerGroup);
     const uint32_t seqStreamIdxInGroup = zstdgpu_MinU32(threadId, seqStreamCntInGroup - 1u);
     const uint32_t seqStreamIdx = seqStreamBeg + seqStreamIdxInGroup;
 
-    const uint32_t cmpBlockCnt = srt.inCounters[kzstdgpu_CounterIndex_Blocks_CMP];
+    const uint32_t cmpBlockCnt = srt.inCounters[0].Blocks_CMP;
 
     const zstdgpu_OffsetAndSize seqRefDst = zstdgpu_GetSequenceStartAndCount(srt, seqStreamIdx, seqStreamCnt);
 
@@ -3980,8 +3984,8 @@ static void zstdgpu_ShaderEntry_DecompressSequences_MultiStream_LdsOutCache(ZSTD
 static void zstdgpu_ShaderEntry_FinaliseSequenceOffsets(ZSTDGPU_PARAM_INOUT(zstdgpu_FinaliseSequenceOffsets_SRT) srt, uint32_t threadId)
 {
     const uint32_t seqIdx = threadId;
-    const uint32_t seqCnt = srt.inCounters[kzstdgpu_CounterIndex_Seq_Streams_DecodedItems];
-    const uint32_t frameCnt = srt.inCounters[kzstdgpu_CounterIndex_Frames];
+    const uint32_t seqCnt = srt.inCounters[0].Seq_Streams_DecodedItems;
+    const uint32_t frameCnt = srt.inCounters[0].Frames;
     if (seqIdx >= seqCnt)
         return;
 
@@ -3994,7 +3998,7 @@ static void zstdgpu_ShaderEntry_FinaliseSequenceOffsets(ZSTDGPU_PARAM_INOUT(zstd
     // so here we check if they are actually "repeat" offsets relative to previous block's last sequence
     if (zstdgpu_DecodeSeqRepeatOffsetEncoded(offset) > 0)
     {
-        const uint32_t seqStreamCnt = srt.inCounters[kzstdgpu_CounterIndex_Seq_Streams];
+        const uint32_t seqStreamCnt = srt.inCounters[0].Seq_Streams;
         const uint32_t seqStreamIdx = zstdgpu_BinarySearch(srt.inPerSeqStreamSeqStart, 0, seqStreamCnt, seqIdx);
         const uint32_t blockIdx     = srt.inSeqRefs[seqStreamIdx].blockId;
         const uint32_t frameIdx     = zstdgpu_BinarySearch(srt.inPerFrameBlockCountAll, 0, frameCnt, blockIdx);
@@ -4180,14 +4184,14 @@ static void zstdgpu_ExecuteSequences_Lit(ZSTDGPU_PARAM_INOUT(zstdgpu_ExecuteSequ
 
 static void zstdgpu_ShaderEntry_ExecuteSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_ExecuteSequences_SRT) srt)
 {
-    const uint32_t seqStreamCnt = srt.inoutCounters[kzstdgpu_CounterIndex_Seq_Streams];
+    const uint32_t seqStreamCnt = srt.inoutCounters[0].Seq_Streams;
 
-    const uint32_t frameCnt = srt.inoutCounters[kzstdgpu_CounterIndex_Frames];
+    const uint32_t frameCnt = srt.inoutCounters[0].Frames;
 
     uint32_t frameIdx = 0;
     if (WaveIsFirstLane())
     {
-        InterlockedAdd(srt.inoutCounters[kzstdgpu_CounterIndex_Frames_ExecuteSequences], 1, frameIdx);
+        InterlockedAdd(srt.inoutCounters[0].Frames_ExecuteSequences, 1, frameIdx);
     }
     frameIdx = WaveReadLaneFirst(frameIdx);
 
@@ -4197,7 +4201,7 @@ static void zstdgpu_ShaderEntry_ExecuteSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_Exe
     const uint32_t cmpBlockBeg = srt.inPerFrameBlockCountCMP[frameIdx];
     const uint32_t cmpBlockEnd = (frameIdx + 1u < frameCnt)
                                ? srt.inPerFrameBlockCountCMP[frameIdx + 1u]
-                               : srt.inoutCounters[kzstdgpu_CounterIndex_Blocks_CMP];
+                               : srt.inoutCounters[0].Blocks_CMP;
 
     const uint32_t firstFrameBlockIdx = srt.inPerFrameBlockCountAll[frameIdx];
 
@@ -4249,7 +4253,7 @@ static void zstdgpu_ShaderEntry_ExecuteSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_Exe
 
             ZSTDGPU_BRANCH if (seqStreamIdx + 1u == seqStreamCnt)
             {
-                seqEnd = srt.inoutCounters[kzstdgpu_CounterIndex_Seq_Streams_DecodedItems];
+                seqEnd = srt.inoutCounters[0].Seq_Streams_DecodedItems;
             }
             else
             {

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -620,25 +620,7 @@ static void zstdgpu_ShaderEntry_InitResources(ZSTDGPU_PARAM_INOUT(zstdgpu_InitRe
             srt.inoutCounters[0].Frames_UncompressedByteSize                 = 0;
             srt.inoutCounters[0].Frames_ExecuteSequences                     = 0;
         }
-
-        // NOTE(pamartis): here we initialize "lookback" regions in buffers containing prefix region + lookback region
-        ZSTDGPU_FOR_WORK_ITEMS(i, zstdgpu_GetLookbackBlockCount(srt.frameCount), threadId, kzstdgpu_TgSizeX_InitCounters)
-        {
-            srt.inoutPerFrameBlockCountRAW[srt.frameCount + i] = 0;
-            srt.inoutPerFrameBlockCountRLE[srt.frameCount + i] = 0;
-            srt.inoutPerFrameBlockCountCMP[srt.frameCount + i] = 0;
-            srt.inoutPerFrameBlockCountAll[srt.frameCount + i] = 0;
-            srt.inoutPerFrameBlockSizesRAW[srt.frameCount + i] = 0;
-            srt.inoutPerFrameBlockSizesRLE[srt.frameCount + i] = 0;
-        }
         return;
-    }
-
-    const uint32_t lookbackUInt32Count = zstdgpu_GetHufFseTableIndexLookbackUInt32Count(srt.cmpBlockCount);
-
-    ZSTDGPU_FOR_WORK_ITEMS(i, lookbackUInt32Count, threadId, kzstdgpu_TgSizeX_InitCounters)
-    {
-        srt.inoutTableIndexLookback[i] = 0;
     }
 
     ZSTDGPU_FOR_WORK_ITEMS(i, 1, threadId, kzstdgpu_TgSizeX_InitCounters)
@@ -658,16 +640,6 @@ static void zstdgpu_ShaderEntry_InitResources(ZSTDGPU_PARAM_INOUT(zstdgpu_InitRe
         zstdgpu_FseInfo rleInfo;
         rleInfo.fseProbCountAndAccuracyLog2 = 0;
         srt.inoutFseInfos[i] = rleInfo;
-    }
-
-    // NOTE(pamartis): We initialize the buffer which is going to store (per frame) an index of the first compressed block
-    // with non-zero sequence count, to initialize default offsets to 1, 4, 8
-    //
-    // The actual index of the compressed block is going to be determined during compressed block parsing where each
-    // compressed block (thread) will store its index via atomic "min".
-    ZSTDGPU_FOR_WORK_ITEMS(i, srt.frameCount, threadId, kzstdgpu_TgSizeX_InitCounters)
-    {
-        srt.inoutPerFrameSeqStreamMinIdx[i] = ~0u;
     }
 
     // NOTE(pamartis): We start from `srt.cmpBlockCount * kzstdgpu_MaxCount_FseProbs` because
@@ -698,55 +670,6 @@ static void zstdgpu_ShaderEntry_InitResources(ZSTDGPU_PARAM_INOUT(zstdgpu_InitRe
     ZSTDGPU_FOR_WORK_ITEMS(i, kzstdgpu_FseDefaultProbCount_MLen, threadId, kzstdgpu_TgSizeX_InitCounters)
     {
         srt.inoutFseProbs[dstStart + i] = srt.inFseProbsDefault[srcStart + i];
-    }
-
-    ZSTDGPU_FOR_WORK_ITEMS(i, srt.cmpBlockCount + zstdgpu_GetLookbackBlockCount(srt.cmpBlockCount), threadId, kzstdgpu_TgSizeX_InitCounters)
-    {
-        srt.inoutLitStreamEndPerHuffmanTable[i] = 0;
-    }
-
-#if 0 // NOTE: disabled because "zeros" are written by all compressed blocks without sequences in Compressed Block Parsing.
-
-    ZSTDGPU_FOR_WORK_ITEMS(i, srt.cmpBlockCount, threadId, kzstdgpu_TgSizeX_InitCounters)
-    {
-        // NOTE(pamartis): The motivation why we initialize the entire buffer with per-block "final" offsets to zero is somewhat non-trivial:
-        //
-        //  - The buffer contains two sub-buffers:
-        //      1. the sub-buffer where the actual per block "final" offsets are stored
-        //      2. the sub-buffer with the lookback information to propagate "final" offset between blocks
-        //  - So, the lookback obviously need initialisation to zero because
-        //      1. it doesn't store any data in lower 30 bits
-        //      2. its upper 2-bit "flags" field of 32-bit integer have to store "0" meaning -- it's cleared
-        //
-        //  - The actual "repeat" offsets are initialized to "0" because it's invalid "offset value" which can't be written
-        //    by sequence decompression pass which also outputs re-encoded "offset values", so writing "0" in this initialization pass,
-        //    allows us to write default "repeat" offsets (1, 4, 8) for every first compressed block with non-zero sequence count in every frame,
-        //    and also allows us to populate per-block final re-encoded "repeat" offsets from sequence decompression pass.
-        //    So as a result, all zero offsets give us information during "repeat" offset propagation that they can't be used as "propagation source"
-        //    and only can be used as "propagation destination" because corresponding blocks don't contain any sequences.
-        srt.inoutPerSeqStreamFinalOffset1[i] = 3 + 1;
-        srt.inoutPerSeqStreamFinalOffset2[i] = 3 + 4;
-        srt.inoutPerSeqStreamFinalOffset3[i] = 3 + 8;
-    }
-#endif
-
-    // NOTE(pamartis): initialize all "lookback" sub-buffers that depend on `srt.cmpBlockCount`
-    ZSTDGPU_FOR_WORK_ITEMS(i, zstdgpu_GetLookbackBlockCount(srt.cmpBlockCount), threadId, kzstdgpu_TgSizeX_InitCounters)
-    {
-        #ifdef __hlsl_dx_compiler
-        srt.inoutLitGroupEndPerHuffmanTable[srt.cmpBlockCount + i] = 0;
-        #endif
-        srt.inoutPerSeqStreamFinalOffset1[srt.cmpBlockCount + i] = 0;
-        srt.inoutPerSeqStreamFinalOffset2[srt.cmpBlockCount + i] = 0;
-        srt.inoutPerSeqStreamFinalOffset3[srt.cmpBlockCount + i] = 0;
-        srt.inoutSeqCountPrefixLookback[i] = 0;
-        srt.inoutBlockSeqCountPrefixLookback[i] = 0;
-    }
-
-    // NOTE(pamartis): initialize "lookback" sub-buffer that depend on `srt.allBlockCount`
-    ZSTDGPU_FOR_WORK_ITEMS(i, zstdgpu_GetLookbackBlockCount(srt.allBlockCount), threadId, kzstdgpu_TgSizeX_InitCounters)
-    {
-        srt.inoutBlockSizePrefix[srt.allBlockCount + i] = 0;
     }
 }
 

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -46,12 +46,51 @@ static void zstdgpu_TypedStoreU16(ZSTDGPU_RW_TYPED_BUFFER(uint32_t, uint16_t) in
 #endif
 }
 
-static void zstdgpu_EmitDispatch(ZSTDGPU_RW_BUFFER(uint32_t) dispatchArgs, uint32_t slot, uint32_t elemCount, uint32_t elemsPerTGroup)
+static void zstdgpu_EmitDispatch(ZSTDGPU_RW_BUFFER(uint32_t) dispatchArgs, ZSTDGPU_RW_BUFFER(uint32_t) dispatchCnts, uint32_t slot, uint32_t elemCount, uint32_t elemsPerTGroup)
 {
+    const uint32_t tgCount = ZSTDGPU_TG_COUNT(elemCount, elemsPerTGroup);
     const uint32_t baseIdx = slot * kzstdgpu_DispatchSlot_StrideInUInt32;
-    dispatchArgs[baseIdx + 0] = ZSTDGPU_TG_COUNT(elemCount, elemsPerTGroup);
-    dispatchArgs[baseIdx + 1] = 1;
+#if defined(_GAMING_XBOX) || defined(__XBOX_SCARLETT) || defined(__XBOX_ONE)
+    // dispatch 0: no problems with # of threadgroup per dimension, support 32-bit
+    dispatchArgs[baseIdx + 0] = 0;  // tgOffset
+    dispatchArgs[baseIdx + 1] = tgCount;
     dispatchArgs[baseIdx + 2] = 1;
+    dispatchArgs[baseIdx + 3] = 1;
+    dispatchCnts[slot] = 1;
+#else
+    const uint32_t tgCountY = tgCount >> kzstdgpu_MaxCount_ThreadGroupsPerDimensionLog2;
+    const uint32_t tgCountX = tgCount & ((1u << kzstdgpu_MaxCount_ThreadGroupsPerDimensionLog2) - 1u);
+
+    if (tgCountY > 0)
+    {
+        // dispatch 0: most of threadgroups are launched via 2d dispatch with the maximal possible number of threadgroups per dimension
+        dispatchArgs[baseIdx + 0] = 0;  // tgOffset
+        dispatchArgs[baseIdx + 1] = 1u << kzstdgpu_MaxCount_ThreadGroupsPerDimensionLog2;
+        dispatchArgs[baseIdx + 2] = tgCountY;
+        dispatchArgs[baseIdx + 3] = 1;
+
+        // dispatch 1: the remaining threadgroups are launched via 1d dispatch
+        dispatchArgs[baseIdx + 4] = tgCountY << kzstdgpu_MaxCount_ThreadGroupsPerDimensionLog2;  // tgOffset
+        dispatchArgs[baseIdx + 5] = tgCountX;
+        dispatchArgs[baseIdx + 6] = 1;
+        dispatchArgs[baseIdx + 7] = 1;
+        dispatchCnts[slot] = 2;
+    }
+    else
+    {
+        // dispatch 0: all threadgroups fit into the limit of single dimension
+        dispatchArgs[baseIdx + 0] = 0;  // tgOffset
+        dispatchArgs[baseIdx + 1] = tgCount;
+        dispatchArgs[baseIdx + 2] = 1;
+        dispatchArgs[baseIdx + 3] = 1;
+        // dispatch 1: zeroed (unused but written)
+        dispatchArgs[baseIdx + 4] = 0;
+        dispatchArgs[baseIdx + 5] = 0;
+        dispatchArgs[baseIdx + 6] = 1;
+        dispatchArgs[baseIdx + 7] = 1;
+        dispatchCnts[slot] = 1;
+    }
+#endif
 }
 
 static uint32_t zstdgpu_GlobalExclusivePrefixSum(ZSTDGPU_RW_BUFFER_GLC(uint32_t) lookback,

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -340,7 +340,11 @@ static const uint32_t kzstdgpu_DispatchSlot_PrefixBlockSizes             = 13;
 static const uint32_t kzstdgpu_DispatchSlot_MemcpyRAW                    = 14;
 static const uint32_t kzstdgpu_DispatchSlot_MemsetRLE                    = 15;
 static const uint32_t kzstdgpu_DispatchSlot_ParseCompressedBlocks        = 16;
-static const uint32_t kzstdgpu_DispatchSlot_Count                        = 17;
+static const uint32_t kzstdgpu_DispatchSlot_Memset_CmpBlockLookback      = 17;
+static const uint32_t kzstdgpu_DispatchSlot_Memset_TableIndexLookback    = 18;
+static const uint32_t kzstdgpu_DispatchSlot_Memset_LitStreamEnd          = 19;
+static const uint32_t kzstdgpu_DispatchSlot_Memset_AllBlockLookback      = 20;
+static const uint32_t kzstdgpu_DispatchSlot_Count                        = 21;
 
 #if defined(_GAMING_XBOX) || defined(__XBOX_SCARLETT) || defined(__XBOX_ONE)
 static const uint32_t kzstdgpu_DispatchSlot_CmdsPerSlot                  = 1;
@@ -377,6 +381,7 @@ static const uint32_t kzstdgpu_TgSizeX_PrefixSum = 32;
 #endif
 
 static const uint32_t kzstdgpu_TgSizeX_ParseCompressedBlocks = 32;
+static const uint32_t kzstdgpu_TgSizeX_Memset = 64;
 
 // NOTE(pamartis): The rationale behind the below choice of TG sizes is the following
 //      On Xbox, we aim widest available wave size to help with cross-lane operations
@@ -1517,25 +1522,12 @@ static inline uint32_t zstdgpu_GetHufFseTableIndexLookbackUInt32Count(uint32_t c
     return zstdgpu_GetLookbackBlockCount(compressedBlockCount) * (sizeof(zstdgpu_TableIndexLookback) / sizeof(uint32_t));
 }
 
-static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockCount, uint32_t compressedBlockCount, uint32_t frameCount, uint32_t initResourceStage)
+static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t initResourceStage)
 {
-    const uint32_t lookbackUIntCount = zstdgpu_GetHufFseTableIndexLookbackUInt32Count(compressedBlockCount);
-
     uint32_t maxThreads = 1; // Counter init is single-threaded (struct assignment)
-
-    if (initResourceStage == 0)
-    {
-        // should be sufficient to initialize PerFrameBlockCount{RAW, RLE, CMP}
-        if (maxThreads < frameCount)
-            maxThreads = frameCount;
-    }
 
     if (initResourceStage == 1)
     {
-        // should be sufficient for Lookback
-        if (maxThreads < lookbackUIntCount)
-            maxThreads = lookbackUIntCount;
-
         // should be sufficient for default LLen Prob table
         if (maxThreads < kzstdgpu_FseDefaultProbCount_LLen)
             maxThreads = kzstdgpu_FseDefaultProbCount_LLen;
@@ -1551,17 +1543,6 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
         // should be sufficient for RLE FSE table entries
         if (maxThreads < kzstdgpu_FseRleTableCount)
             maxThreads = kzstdgpu_FseRleTableCount;
-
-        // should be sufficient to initialize PerFrameSeqStreamMinIdx
-        if (maxThreads < frameCount)
-            maxThreads = frameCount;
-
-        // should be sufficient for Histogram of Literals per Huffman Table and its Lookback (appended at the end)
-        if (maxThreads < compressedBlockCount + zstdgpu_GetLookbackBlockCount(compressedBlockCount))
-            maxThreads = compressedBlockCount + zstdgpu_GetLookbackBlockCount(compressedBlockCount);
-
-        if (maxThreads < zstdgpu_GetLookbackBlockCount(allBlockCount))
-            maxThreads = allBlockCount;
     }
     return (maxThreads + kzstdgpu_TgSizeX_InitCounters - 1) / kzstdgpu_TgSizeX_InitCounters;
 }
@@ -1596,24 +1577,8 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
     \
     ZSTDGPU_RW_BUFFER_DECL(zstdgpu_FseInfo                      , FseInfos                      , 1)    \
     ZSTDGPU_RW_BUFFER_DECL(zstdgpu_Counters                     , Counters                      , 2)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , TableIndexLookback            , 3)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , LitStreamEndPerHuffmanTable   , 4)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , LitGroupEndPerHuffmanTable    , 5)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , BlockSizePrefix               , 6)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerSeqStreamFinalOffset1      , 7)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerSeqStreamFinalOffset2      , 8)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerSeqStreamFinalOffset3      , 9)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameBlockCountRAW         , 10)   \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameBlockCountRLE         , 11)   \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameBlockCountCMP         , 12)   \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameBlockCountAll         , 13)   \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameBlockSizesRAW         , 14)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameBlockSizesRLE         , 15)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameSeqStreamMinIdx       , 16)   \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , SeqCountPrefixLookback        , 17)   \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , BlockSeqCountPrefixLookback   , 18)   \
     \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , FseElems                      , 19)
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , FseElems                      , 3)
 
 #define ZSTDGPU_PARSE_COMPRESSED_BLOCKS_SRT()                                                           \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , CompressedData                , 0)    \

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -334,7 +334,8 @@ static const uint32_t kzstdgpu_DispatchSlot_HUF_WgtStreams               = 7;
 static const uint32_t kzstdgpu_DispatchSlot_DecompressLiterals           = 8;
 static const uint32_t kzstdgpu_DispatchSlot_DecompressSequences          = 9;
 static const uint32_t kzstdgpu_DispatchSlot_FinaliseSequenceOffsets      = 10;
-static const uint32_t kzstdgpu_DispatchSlot_Count                        = 11;
+static const uint32_t kzstdgpu_DispatchSlot_PrefixSequenceOffsets        = 11;
+static const uint32_t kzstdgpu_DispatchSlot_Count                        = 12;
 
 #if defined(_GAMING_XBOX) || defined(__XBOX_SCARLETT) || defined(__XBOX_ONE)
 static const uint32_t kzstdgpu_DispatchSlot_CmdsPerSlot                  = 1;

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -339,7 +339,8 @@ static const uint32_t kzstdgpu_DispatchSlot_ComputePrefixSum             = 12;
 static const uint32_t kzstdgpu_DispatchSlot_PrefixBlockSizes             = 13;
 static const uint32_t kzstdgpu_DispatchSlot_MemcpyRAW                    = 14;
 static const uint32_t kzstdgpu_DispatchSlot_MemsetRLE                    = 15;
-static const uint32_t kzstdgpu_DispatchSlot_Count                        = 16;
+static const uint32_t kzstdgpu_DispatchSlot_ParseCompressedBlocks        = 16;
+static const uint32_t kzstdgpu_DispatchSlot_Count                        = 17;
 
 #if defined(_GAMING_XBOX) || defined(__XBOX_SCARLETT) || defined(__XBOX_ONE)
 static const uint32_t kzstdgpu_DispatchSlot_CmdsPerSlot                  = 1;

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -295,36 +295,56 @@ static inline uint32_t zstdgpu_FseElem_NState(uint32_t packed) { return packed >
 static const uint32_t kzstdgpu_FseProbTableIndex_Unused = 0x3fffffff;
 static const uint32_t kzstdgpu_FseProbTableIndex_Repeat = kzstdgpu_FseProbTableIndex_Unused - 1;
 
-static const uint32_t kzstdgpu_CounterIndex_FseHufW = 0;
-static const uint32_t kzstdgpu_CounterIndex_FseLLen = 3;
-static const uint32_t kzstdgpu_CounterIndex_FseOffs = 6;
-static const uint32_t kzstdgpu_CounterIndex_FseMLen = 9;
-static const uint32_t kzstdgpu_CounterIndex_DecompressHuffmanWeightsGroups = 12;
-static const uint32_t kzstdgpu_CounterIndex_DecodeHuffmanWeightsGroups = 15;
-static const uint32_t kzstdgpu_CounterIndex_GroupCompressedLiteralsGroups = 18;
-static const uint32_t kzstdgpu_CounterIndex_DecompressLiteralsGroups = 21;
-static const uint32_t kzstdgpu_CounterIndex_DecompressSequencesGroups = 24;
+typedef struct zstdgpu_Counters
+{
+    // Dispatch slots: each group of 3 = (X, TGroupCount_Y=1, TGroupCount_Z=1) for ExecuteIndirect
+    uint32_t FseHufW;
+    uint32_t FseHufW_TGroupCount_Y;
+    uint32_t FseHufW_TGroupCount_Z;
+    uint32_t FseLLen;
+    uint32_t FseLLen_TGroupCount_Y;
+    uint32_t FseLLen_TGroupCount_Z;
+    uint32_t FseOffs;
+    uint32_t FseOffs_TGroupCount_Y;
+    uint32_t FseOffs_TGroupCount_Z;
+    uint32_t FseMLen;
+    uint32_t FseMLen_TGroupCount_Y;
+    uint32_t FseMLen_TGroupCount_Z;
+    uint32_t DecompressHuffmanWeightsGroups;
+    uint32_t DecompressHuffmanWeightsGroups_TGroupCount_Y;
+    uint32_t DecompressHuffmanWeightsGroups_TGroupCount_Z;
+    uint32_t DecodeHuffmanWeightsGroups;
+    uint32_t DecodeHuffmanWeightsGroups_TGroupCount_Y;
+    uint32_t DecodeHuffmanWeightsGroups_TGroupCount_Z;
+    uint32_t GroupCompressedLiteralsGroups;
+    uint32_t GroupCompressedLiteralsGroups_TGroupCount_Y;
+    uint32_t GroupCompressedLiteralsGroups_TGroupCount_Z;
+    uint32_t DecompressLiteralsGroups;
+    uint32_t DecompressLiteralsGroups_TGroupCount_Y;
+    uint32_t DecompressLiteralsGroups_TGroupCount_Z;
+    uint32_t DecompressSequencesGroups;
+    uint32_t DecompressSequencesGroups_TGroupCount_Y;
+    uint32_t DecompressSequencesGroups_TGroupCount_Z;
+    uint32_t HUF_WgtStreams;
+    uint32_t HUF_WgtStreams_TGroupCount_Y;
+    uint32_t HUF_WgtStreams_TGroupCount_Z;
 
-static const uint32_t kzstdgpu_CounterIndex_HUF_WgtStreams = 27;
-
-static const uint32_t kzstdgpu_CounterIndex_Seq_Streams_DecodedItems = 30;
-static const uint32_t kzstdgpu_CounterIndex_HUF_Streams_DecodedBytes = 31;
-static const uint32_t kzstdgpu_CounterIndex_Seq_Streams = 32;
-static const uint32_t kzstdgpu_CounterIndex_HUF_Streams = 33;
-static const uint32_t kzstdgpu_CounterIndex_RAW_Streams = 34;
-static const uint32_t kzstdgpu_CounterIndex_RLE_Streams = 35;
-
-static const uint32_t kzstdgpu_CounterIndex_Blocks_RAW = 36;
-static const uint32_t kzstdgpu_CounterIndex_Blocks_RLE = 37;
-static const uint32_t kzstdgpu_CounterIndex_Blocks_CMP = 38;
-
-static const uint32_t kzstdgpu_CounterIndex_BlocksBytes_RAW = 39;
-static const uint32_t kzstdgpu_CounterIndex_BlocksBytes_RLE = 40;
-
-static const uint32_t kzstdgpu_CounterIndex_Frames = 41;
-static const uint32_t kzstdgpu_CounterIndex_Frames_UncompressedByteSize = 42;
-static const uint32_t kzstdgpu_CounterIndex_Frames_ExecuteSequences = 43;
-static const uint32_t kzstdgpu_CounterIndex_Count = 44;
+    // Plain counters (no dispatch padding)
+    uint32_t Seq_Streams_DecodedItems;
+    uint32_t HUF_Streams_DecodedBytes;
+    uint32_t Seq_Streams;
+    uint32_t HUF_Streams;
+    uint32_t RAW_Streams;
+    uint32_t RLE_Streams;
+    uint32_t Blocks_RAW;
+    uint32_t Blocks_RLE;
+    uint32_t Blocks_CMP;
+    uint32_t BlocksBytes_RAW;
+    uint32_t BlocksBytes_RLE;
+    uint32_t Frames;
+    uint32_t Frames_UncompressedByteSize;
+    uint32_t Frames_ExecuteSequences;
+} zstdgpu_Counters;
 
 // NOTE(pamartis):
 //      We use macro here to make sure we can use them to compile-out
@@ -1496,7 +1516,7 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
 {
     const uint32_t lookbackUIntCount = zstdgpu_GetHufFseTableIndexLookbackUInt32Count(compressedBlockCount);
 
-    uint32_t maxThreads = kzstdgpu_CounterIndex_Count;
+    uint32_t maxThreads = 1; // Counter init is single-threaded (struct assignment)
 
     if (initResourceStage == 0)
     {
@@ -1545,7 +1565,7 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , CompressedData                , 0)    \
     ZSTDGPU_RO_BUFFER_DECL(zstdgpu_OffsetAndSize                , FramesRefs                    , 1)    \
     \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , Counters                      , 0)    \
+    ZSTDGPU_RW_BUFFER_DECL(zstdgpu_Counters                     , Counters                      , 0)    \
     ZSTDGPU_RW_BUFFER_DECL(zstdgpu_FrameInfo                    , Frames                        , 1)    \
     ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameBlockCountRAW         , 2)    \
     ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameBlockCountRLE         , 3)    \
@@ -1570,7 +1590,7 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
     ZSTDGPU_RW_TYPED_BUFFER_DECL(int32_t, int16_t               , FseProbs                      , 0)    \
     \
     ZSTDGPU_RW_BUFFER_DECL(zstdgpu_FseInfo                      , FseInfos                      , 1)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , Counters                      , 2)    \
+    ZSTDGPU_RW_BUFFER_DECL(zstdgpu_Counters                     , Counters                      , 2)    \
     ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , TableIndexLookback            , 3)    \
     ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , LitStreamEndPerHuffmanTable   , 4)    \
     ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , LitGroupEndPerHuffmanTable    , 5)    \
@@ -1596,7 +1616,7 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , PerFrameBlockCountCMP         , 2)    \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , GlobalBlockIndexPerCmpBlock   , 3)    \
     \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , Counters                      , 0)    \
+    ZSTDGPU_RW_BUFFER_DECL(zstdgpu_Counters                     , Counters                      , 0)    \
     ZSTDGPU_RW_BUFFER_DECL(zstdgpu_FseInfo                      , FseInfos                      , 1)    \
     ZSTDGPU_RW_BUFFER_DECL(zstdgpu_CompressedBlockData          , CompressedBlocks              , 2)    \
     ZSTDGPU_RW_BUFFER_DECL(zstdgpu_OffsetAndSize                , HufRefs                       , 3)    \
@@ -1623,7 +1643,7 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
     ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , FseElems                      , 0)
 
 #define ZSTDGPU_DECOMPRESS_HUFFMAN_WEIGHTS_SRT()                                                        \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , Counters                      , 0)    \
+    ZSTDGPU_RO_BUFFER_DECL(zstdgpu_Counters                     , Counters                      , 0)    \
     ZSTDGPU_RO_RAW_BUFFER_DECL(uint32_t                         , CompressedData                , 1)    \
     ZSTDGPU_RO_BUFFER_DECL(zstdgpu_OffsetAndSize                , HufRefs                       , 2)    \
     ZSTDGPU_RO_BUFFER_DECL(zstdgpu_FseInfo                      , FseInfos                      , 3)    \
@@ -1634,7 +1654,7 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
     ZSTDGPU_RW_TYPED_BUFFER_DECL(uint32_t, uint8_t              , DecompressedHuffmanWeightCount, 1)
 
 #define ZSTDGPU_DECODE_HUFFMAN_WEIGHTS_SRT()                                                            \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , Counters                      , 0)    \
+    ZSTDGPU_RO_BUFFER_DECL(zstdgpu_Counters                     , Counters                      , 0)    \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , CompressedData                , 1)    \
     ZSTDGPU_RO_BUFFER_DECL(zstdgpu_OffsetAndSize                , HufRefs                       , 2)    \
     \
@@ -1652,7 +1672,7 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
 #define ZSTDGPU_INIT_HUFFMAN_TABLE_AND_DECOMPRESS_LITERALS_SRT()                                        \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , LitStreamEndPerHuffmanTable   , 0)    \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , LitGroupEndPerHuffmanTable    , 1)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , Counters                      , 2)    \
+    ZSTDGPU_RO_BUFFER_DECL(zstdgpu_Counters                     , Counters                      , 2)    \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , LitStreamRemap                , 3)    \
     ZSTDGPU_RO_BUFFER_DECL(zstdgpu_LitStreamInfo                , LitRefs                       , 4)    \
     ZSTDGPU_RO_RAW_BUFFER_DECL(uint32_t                         , CompressedData                , 5)    \
@@ -1665,7 +1685,7 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
 #define ZSTDGPU_DECOMPRESS_LITERALS_SRT()                                                               \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , LitStreamEndPerHuffmanTable   , 0)    \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , LitGroupEndPerHuffmanTable    , 1)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , Counters                      , 2)    \
+    ZSTDGPU_RO_BUFFER_DECL(zstdgpu_Counters                     , Counters                      , 2)    \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , LitStreamRemap                , 3)    \
     ZSTDGPU_RO_BUFFER_DECL(zstdgpu_LitStreamInfo                , LitRefs                       , 4)    \
     ZSTDGPU_RO_RAW_BUFFER_DECL(uint32_t                         , CompressedData                , 5)    \
@@ -1679,7 +1699,7 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
     ZSTDGPU_RW_BUFFER_ALIAS_DECL(uint32_t                       , DecompressedLiterals, Dwords  , 1)
 
 #define ZSTDGPU_DECOMPRESS_SEQUENCES_SRT()                                                              \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , Counters                      , 0)    \
+    ZSTDGPU_RO_BUFFER_DECL(zstdgpu_Counters                     , Counters                      , 0)    \
     ZSTDGPU_RO_RAW_BUFFER_DECL(uint32_t                         , CompressedData                , 1)    \
     ZSTDGPU_RO_BUFFER_DECL(zstdgpu_SeqStreamInfo                , SeqRefs                       , 2)    \
     ZSTDGPU_RO_BUFFER_DECL(zstdgpu_FseInfo                      , FseInfos                      , 3)    \
@@ -1696,7 +1716,7 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
     ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerSeqStreamFinalOffset3      , 6)
 
 #define ZSTDGPU_FINALISE_SEQUENCE_OFFSETS_SRT()                                                         \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , Counters                      , 0)    \
+    ZSTDGPU_RO_BUFFER_DECL(zstdgpu_Counters                     , Counters                      , 0)    \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , PerSeqStreamFinalOffset1      , 1)    \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , PerSeqStreamFinalOffset2      , 2)    \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , PerSeqStreamFinalOffset3      , 3)    \
@@ -1724,10 +1744,10 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t allBlockC
     ZSTDGPU_RO_TYPED_BUFFER_DECL(uint32_t, uint8_t              , DecompressedLiterals          ,11)    \
     \
     ZSTDGPU_RW_TYPED_BUFFER_DECL(uint32_t, uint8_t              , UnCompressedFramesData        , 0)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , Counters                      , 1)
+    ZSTDGPU_RW_BUFFER_DECL(zstdgpu_Counters                     , Counters                      , 1)
 
 #define ZSTDGPU_COMPUTE_DEST_SEQUENCE_OFFSETS_SRT()                                                     \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , Counters                      , 0)    \
+    ZSTDGPU_RO_BUFFER_DECL(zstdgpu_Counters                     , Counters                      , 0)    \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , PerFrameBlockCountAll         , 1)    \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , BlockSizePrefix               , 2)    \
     ZSTDGPU_RO_BUFFER_DECL(zstdgpu_OffsetAndSize                , UnCompressedFramesRefs        , 3)    \

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -297,39 +297,14 @@ static const uint32_t kzstdgpu_FseProbTableIndex_Repeat = kzstdgpu_FseProbTableI
 
 typedef struct zstdgpu_Counters
 {
-    // Dispatch slots: each group of 3 = (X, TGroupCount_Y=1, TGroupCount_Z=1) for ExecuteIndirect
     uint32_t FseHufW;
-    uint32_t FseHufW_TGroupCount_Y;
-    uint32_t FseHufW_TGroupCount_Z;
     uint32_t FseLLen;
-    uint32_t FseLLen_TGroupCount_Y;
-    uint32_t FseLLen_TGroupCount_Z;
     uint32_t FseOffs;
-    uint32_t FseOffs_TGroupCount_Y;
-    uint32_t FseOffs_TGroupCount_Z;
     uint32_t FseMLen;
-    uint32_t FseMLen_TGroupCount_Y;
-    uint32_t FseMLen_TGroupCount_Z;
-    uint32_t DecompressHuffmanWeightsGroups;
-    uint32_t DecompressHuffmanWeightsGroups_TGroupCount_Y;
-    uint32_t DecompressHuffmanWeightsGroups_TGroupCount_Z;
-    uint32_t DecodeHuffmanWeightsGroups;
-    uint32_t DecodeHuffmanWeightsGroups_TGroupCount_Y;
-    uint32_t DecodeHuffmanWeightsGroups_TGroupCount_Z;
-    uint32_t GroupCompressedLiteralsGroups;
-    uint32_t GroupCompressedLiteralsGroups_TGroupCount_Y;
-    uint32_t GroupCompressedLiteralsGroups_TGroupCount_Z;
     uint32_t DecompressLiteralsGroups;
-    uint32_t DecompressLiteralsGroups_TGroupCount_Y;
-    uint32_t DecompressLiteralsGroups_TGroupCount_Z;
     uint32_t DecompressSequencesGroups;
-    uint32_t DecompressSequencesGroups_TGroupCount_Y;
-    uint32_t DecompressSequencesGroups_TGroupCount_Z;
-    uint32_t HUF_WgtStreams;
-    uint32_t HUF_WgtStreams_TGroupCount_Y;
-    uint32_t HUF_WgtStreams_TGroupCount_Z;
 
-    // Plain counters (no dispatch padding)
+    uint32_t HUF_WgtStreams;
     uint32_t Seq_Streams_DecodedItems;
     uint32_t HUF_Streams_DecodedBytes;
     uint32_t Seq_Streams;
@@ -345,6 +320,19 @@ typedef struct zstdgpu_Counters
     uint32_t Frames_UncompressedByteSize;
     uint32_t Frames_ExecuteSequences;
 } zstdgpu_Counters;
+
+static const uint32_t kzstdgpu_DispatchSlot_FseHufW                      = 0;
+static const uint32_t kzstdgpu_DispatchSlot_FseLLen                      = 1;
+static const uint32_t kzstdgpu_DispatchSlot_FseOffs                      = 2;
+static const uint32_t kzstdgpu_DispatchSlot_FseMLen                      = 3;
+static const uint32_t kzstdgpu_DispatchSlot_DecompressHuffmanWeights     = 4;
+static const uint32_t kzstdgpu_DispatchSlot_DecodeHuffmanWeights         = 5;
+static const uint32_t kzstdgpu_DispatchSlot_GroupCompressedLiterals      = 6;
+static const uint32_t kzstdgpu_DispatchSlot_HUF_WgtStreams               = 7;
+static const uint32_t kzstdgpu_DispatchSlot_DecompressLiterals           = 8;
+static const uint32_t kzstdgpu_DispatchSlot_DecompressSequences          = 9;
+static const uint32_t kzstdgpu_DispatchSlot_Count                        = 10;
+static const uint32_t kzstdgpu_DispatchSlot_StrideInUInt32               = 3;
 
 // NOTE(pamartis):
 //      We use macro here to make sure we can use them to compile-out

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -348,8 +348,8 @@ static const uint32_t kzstdgpu_DispatchSlot_CmdsPerSlot                  = 1;
 static const uint32_t kzstdgpu_DispatchSlot_CmdsPerSlot                  = 2;
 #endif
 
-static const uint32_t kzstdgpu_DispatchSlot_CmdStrideInUInt32            = 4;  // tgOffset, X, Y, Z
-static const uint32_t kzstdgpu_DispatchSlot_StrideInUInt32               = kzstdgpu_DispatchSlot_CmdsPerSlot * kzstdgpu_DispatchSlot_CmdStrideInUInt32;  // 8
+static const uint32_t kzstdgpu_DispatchSlot_CmdStrideInUInt32            = 5;  // tgOffset, workItemCount, X, Y, Z
+static const uint32_t kzstdgpu_DispatchSlot_StrideInUInt32               = kzstdgpu_DispatchSlot_CmdsPerSlot * kzstdgpu_DispatchSlot_CmdStrideInUInt32;  // 10 (PC), 5 (Xbox)
 
 // NOTE(pamartis):
 //      We use macro here to make sure we can use them to compile-out

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -236,6 +236,8 @@
 #   endif
 #endif
 
+static const uint32_t kzstdgpu_MaxCount_ThreadGroupsPerDimensionLog2 = 15;
+
 static const uint32_t kzstdgpu_MaxCount_BlockSizeBits   = 17u;
 
 static const uint32_t kzstdgpu_MaxCount_LiteralBytes    = 1u << kzstdgpu_MaxCount_BlockSizeBits;
@@ -332,7 +334,15 @@ static const uint32_t kzstdgpu_DispatchSlot_HUF_WgtStreams               = 7;
 static const uint32_t kzstdgpu_DispatchSlot_DecompressLiterals           = 8;
 static const uint32_t kzstdgpu_DispatchSlot_DecompressSequences          = 9;
 static const uint32_t kzstdgpu_DispatchSlot_Count                        = 10;
-static const uint32_t kzstdgpu_DispatchSlot_StrideInUInt32               = 3;
+
+#if defined(_GAMING_XBOX) || defined(__XBOX_SCARLETT) || defined(__XBOX_ONE)
+static const uint32_t kzstdgpu_DispatchSlot_CmdsPerSlot                  = 1;
+#else
+static const uint32_t kzstdgpu_DispatchSlot_CmdsPerSlot                  = 2;
+#endif
+
+static const uint32_t kzstdgpu_DispatchSlot_CmdStrideInUInt32            = 4;  // tgOffset, X, Y, Z
+static const uint32_t kzstdgpu_DispatchSlot_StrideInUInt32               = kzstdgpu_DispatchSlot_CmdsPerSlot * kzstdgpu_DispatchSlot_CmdStrideInUInt32;  // 8
 
 // NOTE(pamartis):
 //      We use macro here to make sure we can use them to compile-out

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -333,7 +333,8 @@ static const uint32_t kzstdgpu_DispatchSlot_GroupCompressedLiterals      = 6;
 static const uint32_t kzstdgpu_DispatchSlot_HUF_WgtStreams               = 7;
 static const uint32_t kzstdgpu_DispatchSlot_DecompressLiterals           = 8;
 static const uint32_t kzstdgpu_DispatchSlot_DecompressSequences          = 9;
-static const uint32_t kzstdgpu_DispatchSlot_Count                        = 10;
+static const uint32_t kzstdgpu_DispatchSlot_FinaliseSequenceOffsets      = 10;
+static const uint32_t kzstdgpu_DispatchSlot_Count                        = 11;
 
 #if defined(_GAMING_XBOX) || defined(__XBOX_SCARLETT) || defined(__XBOX_ONE)
 static const uint32_t kzstdgpu_DispatchSlot_CmdsPerSlot                  = 1;

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -335,7 +335,11 @@ static const uint32_t kzstdgpu_DispatchSlot_DecompressLiterals           = 8;
 static const uint32_t kzstdgpu_DispatchSlot_DecompressSequences          = 9;
 static const uint32_t kzstdgpu_DispatchSlot_FinaliseSequenceOffsets      = 10;
 static const uint32_t kzstdgpu_DispatchSlot_PrefixSequenceOffsets        = 11;
-static const uint32_t kzstdgpu_DispatchSlot_Count                        = 12;
+static const uint32_t kzstdgpu_DispatchSlot_ComputePrefixSum             = 12;
+static const uint32_t kzstdgpu_DispatchSlot_PrefixBlockSizes             = 13;
+static const uint32_t kzstdgpu_DispatchSlot_MemcpyRAW                    = 14;
+static const uint32_t kzstdgpu_DispatchSlot_MemsetRLE                    = 15;
+static const uint32_t kzstdgpu_DispatchSlot_Count                        = 16;
 
 #if defined(_GAMING_XBOX) || defined(__XBOX_SCARLETT) || defined(__XBOX_ONE)
 static const uint32_t kzstdgpu_DispatchSlot_CmdsPerSlot                  = 1;

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -271,7 +271,7 @@ static void zstdgpu_Test_DecompressHuffmanWeights(zstdgpu_ResourceDataCpu & cpuR
         srt.inCompressedData                    = cpuRes.CompressedData;
         srt.inoutDecompressedHuffmanWeights     = cpuRes.DecompressedHuffmanWeights;
         srt.inoutDecompressedHuffmanWeightCount = cpuRes.DecompressedHuffmanWeightCount;
-        for (uint32_t i = 0; i < gpuReadbackRes.Counters[kzstdgpu_CounterIndex_FseHufW]; ++i)
+        for (uint32_t i = 0; i < gpuReadbackRes.Counters->FseHufW; ++i)
         {
             zstdgpu_ShaderEntry_DecompressHuffmanWeights(srt, i);
         }
@@ -303,9 +303,9 @@ static void zstdgpu_Test_DecompressHuffmanWeights(zstdgpu_ResourceDataCpu & cpuR
         // NOTE(pamartis): We don't need to set CPU-side Huffman Weight Counts because they're not computed within kernel
         // like in the "Decompress" case, and only read instead. And therefore we want to use GPU data
         //srt.inoutDecompressedHuffmanWeightCount = cpuRes.DecompressedHuffmanWeightCount;
-        srt.compressedBlockCount                = gpuReadbackRes.Counters[kzstdgpu_CounterIndex_Blocks_CMP];
+        srt.compressedBlockCount                = gpuReadbackRes.Counters->Blocks_CMP;
         srt.compressedBufferSizeInBytes         = zstdDataBufferSize;
-        for (uint32_t i = 0; i < gpuReadbackRes.Counters[kzstdgpu_CounterIndex_HUF_WgtStreams]; ++i)
+        for (uint32_t i = 0; i < gpuReadbackRes.Counters->HUF_WgtStreams; ++i)
         {
             zstdgpu_ShaderEntry_DecodeHuffmanWeights(srt, i);
         }
@@ -348,9 +348,9 @@ static void zstdgpu_Test_DecompressLiterals(zstdgpu_ResourceDataCpu & cpuRes, zs
         zstdgpu_Init_InitHuffmanTable_And_DecompressLiterals_SRT(srt, gpuReadbackRes);
         srt.inCompressedData            = cpuRes.CompressedData;
         srt.inoutDecompressedLiterals   = cpuRes.DecompressedLiterals;
-        srt.huffmanTableSlotCount       = gpuReadbackRes.Counters[kzstdgpu_CounterIndex_Blocks_CMP];
+        srt.huffmanTableSlotCount       = gpuReadbackRes.Counters->Blocks_CMP;
 
-        for (uint32_t groupId = 0; groupId < gpuReadbackRes.Counters[kzstdgpu_CounterIndex_DecompressLiteralsGroups]; ++groupId)
+        for (uint32_t groupId = 0; groupId < gpuReadbackRes.Counters->DecompressLiteralsGroups; ++groupId)
         {
             zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(srt, groupId, 0);
         }
@@ -404,31 +404,31 @@ static void zstdgpu_Test_DecompressSequences(zstdgpu_ResourceDataCpu & cpuRes, z
 
             // FIXUP(pamartis): because DecompreSequences requres 'BlockSizePrefix' to contain literal size (on GPU actual prefix is computed later)
             // we need to setup it properly
-            for (uint32_t i = 0; i < cpuRes.Counters[kzstdgpu_CounterIndex_Blocks_CMP]; ++i)
+            for (uint32_t i = 0; i < cpuRes.Counters->Blocks_CMP; ++i)
             {
                 const uint32_t literalSize = cpuRes.CompressedBlocks[i].literal.size;
                 const uint32_t dstBlockIndex = cpuRes.GlobalBlockIndexPerCmpBlock[i];
                 cpuRes.BlockSizePrefix[dstBlockIndex] = literalSize;
             }
-            for (uint32_t i = 0; i < cpuRes.Counters[kzstdgpu_CounterIndex_Blocks_RAW]; ++i)
+            for (uint32_t i = 0; i < cpuRes.Counters->Blocks_RAW; ++i)
             {
                 const uint32_t dstBlockIndex = cpuRes.GlobalBlockIndexPerRawBlock[i];
                 cpuRes.BlockSizePrefix[dstBlockIndex] = cpuRes.BlocksRAWRefs[i].size;;
             }
-            for (uint32_t i = 0; i < cpuRes.Counters[kzstdgpu_CounterIndex_Blocks_RLE]; ++i)
+            for (uint32_t i = 0; i < cpuRes.Counters->Blocks_RLE; ++i)
             {
                 const uint32_t dstBlockIndex = cpuRes.GlobalBlockIndexPerRleBlock[i];
                 cpuRes.BlockSizePrefix[dstBlockIndex] = cpuRes.BlocksRLERefs[i].size;;
             }
 
-            for (uint32_t i = 0; i < gpuReadbackRes.Counters[kzstdgpu_CounterIndex_Seq_Streams]; ++i)
+            for (uint32_t i = 0; i < gpuReadbackRes.Counters->Seq_Streams; ++i)
             {
                 zstdgpu_ShaderEntry_DecompressSequences_MultiStream(srt, /* groupId */ i, /* threadId */ 0, /* streamsPerGroup */ 1);
             }
             // Compute prefix sum of block sizes
-            const uint32_t allBlockCount = cpuRes.Counters[kzstdgpu_CounterIndex_Blocks_CMP]
-                                         + cpuRes.Counters[kzstdgpu_CounterIndex_Blocks_RAW]
-                                         + cpuRes.Counters[kzstdgpu_CounterIndex_Blocks_RLE];
+            const uint32_t allBlockCount = cpuRes.Counters->Blocks_CMP
+                                         + cpuRes.Counters->Blocks_RAW
+                                         + cpuRes.Counters->Blocks_RLE;
 
             // FIXUP(pamartis): because after `DecompreSequences` execution 'BlockSizePrefix' contain actual size of the block,
             // not the prefix (it's computed after `DecompreSequences`  on GPU) we update the prefix manually
@@ -447,7 +447,7 @@ static void zstdgpu_Test_DecompressSequences(zstdgpu_ResourceDataCpu & cpuRes, z
             zstdgpu_FinaliseSequenceOffsets_SRT srt;
             zstdgpu_Init_FinaliseSequenceOffsets_SRT(srt, gpuReadbackRes);
             srt.inoutDecompressedSequenceOffs = cpuRes.DecompressedSequenceOffs;
-            for (uint32_t i = 0; i < gpuReadbackRes.Counters[kzstdgpu_CounterIndex_Seq_Streams_DecodedItems]; ++i)
+            for (uint32_t i = 0; i < gpuReadbackRes.Counters->Seq_Streams_DecodedItems; ++i)
             {
                 zstdgpu_ShaderEntry_FinaliseSequenceOffsets(srt, i);
             }
@@ -481,16 +481,16 @@ static void zstdgpu_Test_DecompressSequences(zstdgpu_ResourceDataCpu & cpuRes, z
 static void zstdgpu_Test_BlockPrefix(zstdgpu_ResourceDataCpu & cpuRes, zstdgpu_ResourceDataCpu & gpuReadbackRes)
 {
     /** these buffers could be zero if some block types don't exist */
-    const uint32_t refRleBlockCount = cpuRes.Counters[kzstdgpu_CounterIndex_Blocks_RLE];
-    const uint32_t refRawBlockCount = cpuRes.Counters[kzstdgpu_CounterIndex_Blocks_RAW];
-    const uint32_t refCmpBlockCount = cpuRes.Counters[kzstdgpu_CounterIndex_Blocks_CMP];
+    const uint32_t refRleBlockCount = cpuRes.Counters->Blocks_RLE;
+    const uint32_t refRawBlockCount = cpuRes.Counters->Blocks_RAW;
+    const uint32_t refCmpBlockCount = cpuRes.Counters->Blocks_CMP;
     const uint32_t refAllBlockCount = refRleBlockCount
                                     + refRawBlockCount
                                     + refCmpBlockCount;
 
-    VALIDATE_CND(refRleBlockCount == gpuReadbackRes.Counters[kzstdgpu_CounterIndex_Blocks_RLE]);
-    VALIDATE_CND(refRawBlockCount == gpuReadbackRes.Counters[kzstdgpu_CounterIndex_Blocks_RAW]);
-    VALIDATE_CND(refCmpBlockCount == gpuReadbackRes.Counters[kzstdgpu_CounterIndex_Blocks_CMP]);
+    VALIDATE_CND(refRleBlockCount == gpuReadbackRes.Counters->Blocks_RLE);
+    VALIDATE_CND(refRawBlockCount == gpuReadbackRes.Counters->Blocks_RAW);
+    VALIDATE_CND(refCmpBlockCount == gpuReadbackRes.Counters->Blocks_CMP);
 
     if (NULL != cpuRes.GlobalBlockIndexPerCmpBlock)
         VALIDATE_CND(0 == memcmp(cpuRes.GlobalBlockIndexPerCmpBlock, gpuReadbackRes.GlobalBlockIndexPerCmpBlock, sizeof(cpuRes.GlobalBlockIndexPerCmpBlock[0]) * refCmpBlockCount));
@@ -569,7 +569,7 @@ static void zstdgpu_Validate_GpuDecompressOnCpu(zstdgpu_ResourceDataCpu & zstdCp
     memcpy(zstdCpu.FramesRefs, zstdFrameRefs, sizeof(zstdgpu_OffsetAndSize) * zstdFrameCount);
     memcpy(zstdCpu.FseProbsDefault, kzstdgpuFseProbsDefault, sizeof(kzstdgpuFseProbsDefault));
 
-    #define CNTRS(name) zstdCpu.Counters[kzstdgpu_CounterIndex_##name]
+    #define CNTRS(name) zstdCpu.Counters->name
     {
         zstdgpu_InitResources_SRT srt = {};
         zstdgpu_Init_InitResources_SRT(srt, zstdCpu);


### PR DESCRIPTION
This PR tries to reduce reliance on various zstd parameters discovered during decompression and read back to CPU after each submission stage by converting multiple dispatches into indirect dispatches. Indirect dispatches also account for D3D12 limitation of `2^16-1` threadgroups per dispatch dimension to support larger workloads. This is done by introducing two dispatch arguments and dynamic selection of the number of arguments used on GPU timeline.