### PR TITLE
zstdgpu/no-readback-support: enables a possibility to run without a readback

### DIFF
--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -95,33 +95,311 @@ static const int16_t kzstdgpuFseProbsDefault[] =
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, -1, -1, -1, -1, -1, -1, -1
 };
 
+struct zstdgpu_BlockInfo
+{
+    uint32_t litStreamCount;
+    uint32_t seqStreamCount;
+    uint32_t litByteCount;
+    uint32_t seqElemCount;
+};
+
+/**
+ *  This is copy and paste of `zstdgpu_ShaderEntry_ParseFrame` mostly due to a divergency of parameters
+ */
+static inline void zstdgpu_ParseFrame(zstdgpu_FrameInfo *outFrameInfo,
+                                      zstdgpu_BlockInfo *outBlockInfo,
+                                      zstdgpu_OffsetAndSize *outBlocksRAWRefs,
+                                      zstdgpu_OffsetAndSize *outBlocksRLERefs,
+                                      zstdgpu_OffsetAndSize *outBlocksCMPRefs,
+                                      zstdgpu_Forward_BitBuffer & bits)
+{
+    ZSTDGPU_ASSERT(NULL != outFrameInfo);
+
+    // "A content compressed by Zstandard is transformed into a Zstandard frame.
+    // Multiple frames can be appended into a single file or stream. A frame is
+    // totally independent, has a defined beginning and end, and a set of
+    // parameters which tells the decoder how to decompress it."
+
+    const uint32_t descriptor = zstdgpu_Forward_BitBuffer_Get(bits, 8);
+
+    // check "Reserved_bit"
+    // This bit is reserved for some future feature. Its value _must be zero_.
+    // A decoder compliant with this specification version must ensure it is not set.
+    // This bit may be used in a future revision, to signal a feature that must be interpreted to decode the frame correctly.
+    if (0 != zstdgpu_BitFieldExtractU32(descriptor, 3, 1))
+    {
+        ZSTDGPU_BREAK();
+    }
+
+    const uint32_t singleSegmentFlag = zstdgpu_BitFieldExtractU32(descriptor, 5, 1);
+    //
+    if (0 == singleSegmentFlag)
+    {
+        const uint32_t windowDescriptor = zstdgpu_Forward_BitBuffer_Get(bits, 8);
+
+        // "Provides guarantees on maximum back-reference distance that will be
+        // used within compressed data. This information is important for
+        // decoders to allocate enough memory.
+        //
+        // Bit numbers  7-3         2-0
+        // Field name   Exponent    Mantissa"
+        const uint32_t exponent = windowDescriptor >> 3;
+        const uint32_t mantissa = windowDescriptor & 7;
+
+        // Use the algorithm from the specification to compute window size
+        // https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md#window_descriptor
+        const uint64_t windowBase = 1ull << (10 + exponent);
+        const uint64_t windowAdd = (windowBase / 8) * mantissa;
+        outFrameInfo->windowSize = windowBase + windowAdd;
+    }
+
+    const uint32_t dictionaryIdFlag = zstdgpu_BitFieldExtractU32(descriptor, 0, 2);
+    if (0 != dictionaryIdFlag)
+    {
+        // "This is a variable size field, which contains the ID of the
+        // dictionary required to properly decode the frame. Note that this
+        // field is optional. When it's not present, it's up to the caller to
+        // make sure it uses the correct dictionary. Format is little-endian."
+        const uint32_t byteCount[] = { 0u, 1u, 2u, 4u };
+        const uint32_t bitCount = byteCount[dictionaryIdFlag] * 8u;
+
+        outFrameInfo->dictionary = zstdgpu_Forward_BitBuffer_Get(bits, bitCount);
+    }
+
+    const uint32_t frameContentSizeFlag = zstdgpu_BitFieldExtractU32(descriptor, 6, 2);
+
+    if (0 != singleSegmentFlag || 0 != frameContentSizeFlag)
+    {
+        // "This is the original (uncompressed) size. This information is
+        // optional. The Field_Size is provided according to value of
+        // Frame_Content_Size_flag. The Field_Size can be equal to 0 (not
+        // present), 1, 2, 4 or 8 bytes. Format is little-endian."
+        //
+        // if frame_content_size_flag == 0 but single_segment_flag is set, we
+        // still have a 1 byte field
+        const uint32_t byteCount[] = { 1u, 2u, 4u, 8u };
+        const uint32_t bitCount = byteCount[frameContentSizeFlag] * 8u;
+
+        if (bitCount == 64)
+        {
+            outFrameInfo->uncompSize = zstdgpu_Forward_BitBuffer_Get(bits, 32);
+            outFrameInfo->uncompSize |= (uint64_t)zstdgpu_Forward_BitBuffer_Get(bits, 32) << 32;
+        }
+        else
+        {
+            outFrameInfo->uncompSize = zstdgpu_Forward_BitBuffer_Get(bits, bitCount);
+        }
+
+        if (16u == bitCount)
+        {
+            // "When Field_Size is 2, the offset of 256 is added."
+            outFrameInfo->uncompSize += 256;
+        }
+    }
+
+    if (0 != singleSegmentFlag)
+    {
+        // "The Window_Descriptor byte is optional. It is absent when
+        // Single_Segment_flag is set. In this case, the maximum back-reference
+        // distance is the content size itself, which can be any value from 1 to
+        // 2^64-1 bytes (16 EB)."
+        outFrameInfo->windowSize = outFrameInfo->uncompSize;
+    }
+
+    //
+    // "A frame encapsulates one or multiple blocks. Each block can be
+    // compressed or not, and has a guaranteed maximum content size, which
+    // depends on frame parameters. Unlike frames, each block depends on
+    // previous blocks for proper decoding. However, each block can be
+    // decompressed without waiting for its successor, allowing streaming
+    // operations."
+    uint32_t lastBlock = 0;
+    do
+    {
+        // "Last_Block
+        //
+        // The lowest bit signals if this block is the last one. Frame ends
+        // right after this block.
+        //
+        // Block_Type and Block_Size
+        //
+        // The next 2 bits represent the Block_Type, while the remaining 21 bits
+        // represent the Block_Size. Format is little-endian."
+        zstdgpu_Forward_BitBuffer_Refill(bits, 1 + 2 + 21);
+
+        lastBlock = zstdgpu_Forward_BitBuffer_GetNoRefill(bits, 1);
+        const uint32_t blockType = zstdgpu_Forward_BitBuffer_GetNoRefill(bits, 2);
+        const uint32_t blockSize = zstdgpu_Forward_BitBuffer_GetNoRefill(bits, 21);
+        const uint32_t blockBase = zstdgpu_Forward_BitBuffer_GetByteOffset(bits);
+
+        if (/* Compressed block */ 2 == blockType)
+        {
+            if (outBlocksCMPRefs)
+            {
+                outBlocksCMPRefs[outFrameInfo->cmpBlockStart].offs = blockBase;
+                outBlocksCMPRefs[outFrameInfo->cmpBlockStart].size = blockSize;
+            }
+            outFrameInfo->cmpBlockStart += 1;
+
+            if (NULL == outBlockInfo)
+            {
+                zstdgpu_Forward_BitBuffer_Skip(bits, blockSize);
+            }
+            else
+            {
+                // Parse literal section header
+                zstdgpu_Forward_BitBuffer_Refill(bits, 32);
+                const uint32_t litBlockType  = zstdgpu_Forward_BitBuffer_GetNoRefill(bits, 2);
+                const uint32_t litBlockSzFmt = zstdgpu_Forward_BitBuffer_GetNoRefill(bits, 2);
+
+                uint32_t regeneratedSize = 0;
+                uint32_t compressedSize  = 0;
+
+                if (litBlockType <= 1)
+                {
+                    if (0 == zstdgpu_BitFieldExtractU32(litBlockSzFmt, 0, 1))
+                    {
+                        regeneratedSize = (zstdgpu_Forward_BitBuffer_Get(bits, 8 - 4) << 1) | zstdgpu_BitFieldExtractU32(litBlockSzFmt, 1, 1);
+                    }
+                    else if (litBlockSzFmt == 1)
+                    {
+                        regeneratedSize = zstdgpu_Forward_BitBuffer_Get(bits, 16 - 4);
+                    }
+                    else
+                    {
+                        regeneratedSize = zstdgpu_Forward_BitBuffer_Get(bits, 24 - 4);
+                    }
+
+                    compressedSize = (litBlockType == 0) ? regeneratedSize : 1;
+                }
+                else
+                {
+                    if (litBlockSzFmt <= 1)
+                    {
+                        zstdgpu_Forward_BitBuffer_Refill(bits, 10 + 10);
+                        regeneratedSize = zstdgpu_Forward_BitBuffer_GetNoRefill(bits, 10);
+                        compressedSize  = zstdgpu_Forward_BitBuffer_GetNoRefill(bits, 10);
+                    }
+                    else if (litBlockSzFmt == 2)
+                    {
+                        zstdgpu_Forward_BitBuffer_Refill(bits, 14 + 14);
+                        regeneratedSize = zstdgpu_Forward_BitBuffer_GetNoRefill(bits, 14);
+                        compressedSize  = zstdgpu_Forward_BitBuffer_GetNoRefill(bits, 14);
+                    }
+                    else
+                    {
+                        regeneratedSize = zstdgpu_Forward_BitBuffer_Get(bits, 18);
+                        compressedSize  = zstdgpu_Forward_BitBuffer_Get(bits, 18);
+                    }
+
+                    outBlockInfo->litByteCount += regeneratedSize;
+                    outBlockInfo->litStreamCount += 1;
+                }
+
+                // Skip past literal section data to reach sequence section header
+                if (compressedSize > 0)
+                {
+                    zstdgpu_Forward_BitBuffer_Skip(bits, compressedSize);
+                }
+
+                // Parse sequence count
+                const uint32_t seqByte0 = zstdgpu_Forward_BitBuffer_Get(bits, 8);
+                uint32_t seqCount = 0;
+                if (seqByte0 < 128)
+                {
+                    seqCount = seqByte0;
+                }
+                else if (seqByte0 < 255)
+                {
+                    seqCount = ((seqByte0 - 128) << 8) + zstdgpu_Forward_BitBuffer_Get(bits, 8);
+                }
+                else
+                {
+                    seqCount = zstdgpu_Forward_BitBuffer_Get(bits, 16) + 0x7F00;
+                }
+
+                outBlockInfo->seqElemCount += seqCount;
+                outBlockInfo->seqStreamCount += seqCount > 0 ? 1 : 0;
+
+                // Skip to the end of block
+                const uint32_t blockCur = zstdgpu_Forward_BitBuffer_GetByteOffset(bits);
+                const uint32_t blockEnd = blockBase + blockSize;
+                if (blockEnd > blockCur)
+                {
+                    zstdgpu_Forward_BitBuffer_Skip(bits, blockEnd - blockCur);
+                }
+                else
+                {
+                    ZSTDGPU_BREAK();
+                }
+            }
+        }
+        else if (/* RAW */ 0 == blockType)
+        {
+            if (outBlocksRAWRefs)
+            {
+                outBlocksRAWRefs[outFrameInfo->rawBlockStart].offs = blockBase;
+                // `Raw_Block` - this is an uncompressed block. `Block_Content` contains `Block_Size` bytes.
+                outBlocksRAWRefs[outFrameInfo->rawBlockStart].size = blockSize;
+            }
+            outFrameInfo->rawBlockStart += 1;
+            outFrameInfo->rawBlockBytesStart += blockSize;
+
+            zstdgpu_Forward_BitBuffer_Skip(bits, blockSize);
+        }
+        else if (/* RLE */ 1 == blockType)
+        {
+            if (outBlocksRLERefs)
+            {
+                outBlocksRLERefs[outFrameInfo->rleBlockStart].offs = zstdgpu_Forward_BitBuffer_Get(bits, 8);
+                // `RLE_Block` - this is a single byte, repeated `Block_Size` times. `Block_Content` consists of a single byte.
+                // On the decompression side, this byte must be repeated `Block_Size` times.
+                outBlocksRLERefs[outFrameInfo->rleBlockStart].size = blockSize;
+            }
+            outFrameInfo->rleBlockStart += 1;
+            outFrameInfo->rleBlockBytesStart += blockSize;
+
+            zstdgpu_Forward_BitBuffer_Skip(bits, 1);
+        }
+        else
+        {
+            ZSTDGPU_BREAK();
+        }
+    }
+    while (0 == lastBlock);
+
+    const uint32_t contentCheckSumFlag = zstdgpu_BitFieldExtractU32(descriptor, 2, 1);
+    if (0 != contentCheckSumFlag)
+    {
+        zstdgpu_Forward_BitBuffer_Refill(bits, 32);
+        zstdgpu_Forward_BitBuffer_Pop(bits, 32);
+    }
+}
+
 void zstdgpu_CountFramesAndBlocks(zstdgpu_CountFramesAndBlocksInfo *outInfo, const void *memoryBlock, uint32_t memoryBlockSizeInBytes, uint32_t contentSizeInBytes)
 {
     uint32_t byteOfs = 0;
 
     zstdgpu_Forward_BitBuffer bits;
-    zstdgpu_FrameInfo frameInfo;
-    zstdgpu_OffsetAndSize unusedRawBlockSize;
-    zstdgpu_OffsetAndSize unusedRLEBlockSize;
-    zstdgpu_OffsetAndSize unusedCmpBlockSize;
-
-    outInfo->rawBlockCount  = 0;
-    outInfo->rleBlockCount  = 0;
-    outInfo->cmpBlockCount  = 0;
-    outInfo->frameCount     = 0;
-    outInfo->frameByteCount = 0;
-
     zstdgpu_Forward_BitBuffer_Init(bits, (uint32_t *)memoryBlock, contentSizeInBytes, memoryBlockSizeInBytes);
 
     while (byteOfs < bits.datasz)
     {
-        const uint32_t magic = zstdgpu_Forward_BitBuffer_Get(bits, 32);
+        uint32_t magic = zstdgpu_Forward_BitBuffer_Get(bits, 32);
+
+        /** skip over skipable frames */
+        while (magic >= 0x184D2A50 && magic <= 0x184D2A5F)
+        {
+            const uint32_t frameSize = zstdgpu_Forward_BitBuffer_Get(bits, 32);
+            zstdgpu_Forward_BitBuffer_Skip(bits, frameSize);
+            byteOfs = zstdgpu_Forward_BitBuffer_GetByteOffset(bits);
+            magic = zstdgpu_Forward_BitBuffer_Get(bits, 32);
+        }
+
         if (magic == 0xFD2FB528U)
         {
-            frameInfo.rawBlockStart = 0;
-            frameInfo.rleBlockStart = 0;
-            frameInfo.cmpBlockStart = 0;
-            zstdgpu_ShaderEntry_ParseFrame(frameInfo, &unusedRawBlockSize, &unusedRLEBlockSize, &unusedCmpBlockSize, NULL, NULL, NULL, NULL, NULL, NULL, bits, 0);
+            zstdgpu_FrameInfo frameInfo = {};
+            zstdgpu_ParseFrame(&frameInfo, NULL, NULL, NULL, NULL, bits);
 
             byteOfs = zstdgpu_Forward_BitBuffer_GetByteOffset(bits);
 
@@ -143,33 +421,43 @@ void zstdgpu_CollectFrames(zstdgpu_OffsetAndSize *outFrames, zstdgpu_FrameInfo *
     uint32_t byteOfs = 0;
 
     zstdgpu_Forward_BitBuffer bits;
-    zstdgpu_FrameInfo frameInfo;
-    zstdgpu_OffsetAndSize unusedRawBlockSize;
-    zstdgpu_OffsetAndSize unusedRLEBlockSize;
-    zstdgpu_OffsetAndSize unusedCmpBlockSize;
+    zstdgpu_FrameInfo frameInfo = {};
 
     zstdgpu_Forward_BitBuffer_Init(bits, (uint32_t*)memoryBlock, contentSizeInBytes, memoryBlockSizeInBytes);
 
-    frameInfo.rawBlockStart = 0;
-    frameInfo.rleBlockStart = 0;
-    frameInfo.cmpBlockStart = 0;
-
     for (uint32_t frameId = 0; frameId < frameCount; ++frameId)
     {
-        const uint32_t magic = zstdgpu_Forward_BitBuffer_Get(bits, 32);
+        uint32_t magic = zstdgpu_Forward_BitBuffer_Get(bits, 32);
+
+        /** skip over skipable frames */
+        while (magic >= 0x184D2A50 && magic <= 0x184D2A5F)
+        {
+            const uint32_t frameSize = zstdgpu_Forward_BitBuffer_Get(bits, 32);
+            zstdgpu_Forward_BitBuffer_Skip(bits, frameSize);
+            byteOfs = zstdgpu_Forward_BitBuffer_GetByteOffset(bits);
+            magic = zstdgpu_Forward_BitBuffer_Get(bits, 32);
+        }
+
         if (magic == 0xFD2FB528U)
         {
             outFrames[frameId].offs = byteOfs;
 
             // store prefix
-            outFrameInfos[frameId].rawBlockStart = frameInfo.rawBlockStart;
-            outFrameInfos[frameId].rleBlockStart = frameInfo.rleBlockStart;
-            outFrameInfos[frameId].cmpBlockStart = frameInfo.cmpBlockStart;
+            outFrameInfos[frameId].rawBlockStart      = frameInfo.rawBlockStart;
+            outFrameInfos[frameId].rleBlockStart      = frameInfo.rleBlockStart;
+            outFrameInfos[frameId].cmpBlockStart      = frameInfo.cmpBlockStart;
+            outFrameInfos[frameId].rawBlockBytesStart = frameInfo.rawBlockBytesStart;
+            outFrameInfos[frameId].rleBlockBytesStart = frameInfo.rleBlockBytesStart;
 
-            frameInfo.rawBlockStart = 0;
-            frameInfo.rleBlockStart = 0;
-            frameInfo.cmpBlockStart = 0;
-            zstdgpu_ShaderEntry_ParseFrame(frameInfo, &unusedRawBlockSize, &unusedRLEBlockSize, &unusedCmpBlockSize, NULL, NULL, NULL, NULL, NULL, NULL, bits, 0);
+            frameInfo.windowSize         = 0;
+            frameInfo.uncompSize         = 0;
+            frameInfo.dictionary         = 0;
+            frameInfo.rawBlockStart      = 0;
+            frameInfo.rleBlockStart      = 0;
+            frameInfo.cmpBlockStart      = 0;
+            frameInfo.rawBlockBytesStart = 0;
+            frameInfo.rleBlockBytesStart = 0;
+            zstdgpu_ParseFrame(&frameInfo, NULL, NULL, NULL, NULL, bits);
 
             // store just retrieved data
             outFrameInfos[frameId].windowSize = frameInfo.windowSize;
@@ -180,9 +468,11 @@ void zstdgpu_CollectFrames(zstdgpu_OffsetAndSize *outFrames, zstdgpu_FrameInfo *
             outFrames[frameId].size = byteOfs - outFrames[frameId].offs;
 
             // accumulate previous prefix onto current frame's block counts
-            frameInfo.rawBlockStart += outFrameInfos[frameId].rawBlockStart;
-            frameInfo.rleBlockStart += outFrameInfos[frameId].rleBlockStart;
-            frameInfo.cmpBlockStart += outFrameInfos[frameId].cmpBlockStart;
+            frameInfo.rawBlockStart      += outFrameInfos[frameId].rawBlockStart;
+            frameInfo.rleBlockStart      += outFrameInfos[frameId].rleBlockStart;
+            frameInfo.cmpBlockStart      += outFrameInfos[frameId].cmpBlockStart;
+            frameInfo.rawBlockBytesStart += outFrameInfos[frameId].rawBlockBytesStart;
+            frameInfo.rleBlockBytesStart += outFrameInfos[frameId].rleBlockBytesStart;
         }
         else
         {
@@ -196,23 +486,70 @@ void zstdgpu_CollectBlocks(zstdgpu_OffsetAndSize *outBlocksRaw, zstdgpu_OffsetAn
     uint32_t byteOfs = 0;
 
     zstdgpu_Forward_BitBuffer bits;
-    zstdgpu_FrameInfo frameInfo;
-
     zstdgpu_Forward_BitBuffer_InitWithSegment(bits, (uint32_t *)memoryBlock, frames[frameIndex], memoryBlockSizeInBytes);
 
-    frameInfo.rawBlockStart = frameInfos[frameIndex].rawBlockStart;
-    frameInfo.rleBlockStart = frameInfos[frameIndex].rleBlockStart;
-    frameInfo.cmpBlockStart = frameInfos[frameIndex].cmpBlockStart;
+    uint32_t magic = zstdgpu_Forward_BitBuffer_Get(bits, 32);
 
-    const uint32_t magic = zstdgpu_Forward_BitBuffer_Get(bits, 32);
+    /** skip over skipable frames */
+    while (magic >= 0x184D2A50 && magic <= 0x184D2A5F)
+    {
+        const uint32_t frameSize = zstdgpu_Forward_BitBuffer_Get(bits, 32);
+        zstdgpu_Forward_BitBuffer_Skip(bits, frameSize);
+        magic = zstdgpu_Forward_BitBuffer_Get(bits, 32);
+    }
+
     if (magic == 0xFD2FB528U)
     {
+        zstdgpu_FrameInfo frameInfo = {};
+
+        const uint32_t rawBlockStart = frameInfos[frameIndex].rawBlockStart;
+        const uint32_t rleBlockStart = frameInfos[frameIndex].rleBlockStart;
+        const uint32_t cmpBlockStart = frameInfos[frameIndex].cmpBlockStart;
+
         const uint32_t byteEnd = frameIndex < frameCount - 1u ? frames[frameIndex + 1u].offs : contentSizeInBytes;
 
-        zstdgpu_ShaderEntry_ParseFrame(frameInfo, outBlocksRaw, outBlocksRLE, outBlocksCmp, NULL, NULL, NULL, NULL, NULL, NULL, bits, 1u);
+        zstdgpu_ParseFrame(&frameInfo, NULL, &outBlocksRaw[rawBlockStart], &outBlocksRLE[rleBlockStart], &outBlocksCmp[cmpBlockStart], bits);
         byteOfs = zstdgpu_Forward_BitBuffer_GetByteOffset(bits);
 
         ZSTDGPU_ASSERT(byteOfs == byteEnd);
+    }
+}
+
+void zstdgpu_CountCompressedLiteralsAndSequences(zstdgpu_CountLiteralAndSequenceInfo *outInfo, const zstdgpu_OffsetAndSize *frames, uint32_t frameCount, const void *memoryBlock, uint32_t memoryBlockSizeInBytes)
+{
+    outInfo->compressedLiteralsByteCount = 0;
+    outInfo->sequenceCount              = 0;
+
+    uint32_t byteOfs = 0;
+
+    for (uint32_t frameIdx = 0; frameIdx < frameCount; ++frameIdx)
+    {
+        zstdgpu_Forward_BitBuffer bits;
+        zstdgpu_Forward_BitBuffer_InitWithSegment(bits, (uint32_t *)memoryBlock, frames[frameIdx], memoryBlockSizeInBytes);
+
+        uint32_t magic = zstdgpu_Forward_BitBuffer_Get(bits, 32);
+
+        /** skip over skipable frames */
+        while (magic >= 0x184D2A50 && magic <= 0x184D2A5F)
+        {
+            const uint32_t frameSize = zstdgpu_Forward_BitBuffer_Get(bits, 32);
+            zstdgpu_Forward_BitBuffer_Skip(bits, frameSize);
+            magic = zstdgpu_Forward_BitBuffer_Get(bits, 32);
+        }
+
+        if (magic == 0xFD2FB528U)
+        {
+            zstdgpu_FrameInfo frameInfo = {};
+            zstdgpu_BlockInfo blockInfo = {};
+
+            zstdgpu_ParseFrame(&frameInfo, &blockInfo, NULL, NULL, NULL, bits);
+            byteOfs = zstdgpu_Forward_BitBuffer_GetByteOffset(bits);
+
+            ZSTDGPU_ASSERT(byteOfs == frames[frameIdx].offs + frames[frameIdx].size);
+
+            outInfo->compressedLiteralsByteCount += blockInfo.litByteCount;
+            outInfo->sequenceCount               += blockInfo.seqElemCount;
+        }
     }
 }
 

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -565,7 +565,7 @@ typedef struct zstdgpu_SRTs
     #undef  ZSTDGPU_SRT
 } zstdgpu_SRTs;
 
-static uint32_t zstdgpu_Count_SRTs(void)
+static uint32_t zstdgpu_Count_SRTs_Stage(uint32_t stageIndex)
 {
     uint32_t descCount = 0;
 
@@ -587,7 +587,18 @@ static uint32_t zstdgpu_Count_SRTs(void)
     #define ZSTDGPU_RW_TYPED_BUFFER_ALIAS_DECL_GLC(hlsl_type, type, name, alias, index) descCount += 1;
 
     #define ZSTDGPU_SRT(name, SRT) SRT
-        ZSTDGPU_SRT_LIST()
+        if (stageIndex == 0)
+        {
+            ZSTDGPU_SRT_LIST_STAGE0()
+        }
+        else if (stageIndex == 1)
+        {
+            ZSTDGPU_SRT_LIST_STAGE1()
+        }
+        else
+        {
+            ZSTDGPU_SRT_LIST_STAGE2()
+        }
     #undef  ZSTDGPU_SRT
 
     #include "zstdgpu_srt_decl_undef.h"
@@ -608,7 +619,7 @@ static void zstdgpu_CreateByteAddressBufferSrv(D3D12_CPU_DESCRIPTOR_HANDLE cpuDe
     device->CreateShaderResourceView(resource, &desc, cpuDest);
 }
 
-static void zstdgpu_ReCreate_SRTs(zstdgpu_SRTs & srts, ID3D12Device *device, const zstdgpu_ResourceInfo & resInfo, const zstdgpu_ResourceDataGpu & gpuResData)
+static void zstdgpu_ReCreate_SRTs(zstdgpu_SRTs & srts, ID3D12Device *device, const zstdgpu_ResourceInfo & resInfo, const zstdgpu_ResourceDataGpu & gpuResData, uint32_t stageIndex)
 {
     D3D12_GPU_DESCRIPTOR_HANDLE gpuStart = d3d12aid_DescriptorHeap_GetGpuStart(srts.heap);
     D3D12_CPU_DESCRIPTOR_HANDLE cpuStart = d3d12aid_DescriptorHeap_GetCpuStart(srts.heap);
@@ -664,7 +675,18 @@ static void zstdgpu_ReCreate_SRTs(zstdgpu_SRTs & srts, ID3D12Device *device, con
     #define ZSTDGPU_RW_TYPED_BUFFER_ALIAS_DECL_GLC(hlsl_type, type, name, alias, index) ZSTDGPU_PUSH_TYPED_BUFFER(type, name, UAV)
 
     #define ZSTDGPU_SRT(name, SRT) srts.name##GpuHandle = gpuDest; SRT
-        ZSTDGPU_SRT_LIST()
+        if (stageIndex == 0)
+        {
+            ZSTDGPU_SRT_LIST_STAGE0()
+        }
+        else if (stageIndex == 1)
+        {
+            ZSTDGPU_SRT_LIST_STAGE1()
+        }
+        else
+        {
+            ZSTDGPU_SRT_LIST_STAGE2()
+        }
     #undef  ZSTDGPU_SRT
 
     #include "zstdgpu_srt_decl_undef.h"
@@ -835,13 +857,14 @@ struct zstdgpu_PersistentContextImpl
     uint32_t                DecompressSequences_StreamsPerGroup;
 };
 
-enum zstdgpu_SetupInputsType
-{
-    kzstdgpu_SetupInputsType_Frames_CpuMemory   = 0,
-    kzstdgpu_SetupInputsType_Frames_GpuMemory   = 1,
+static const uint32_t kzstdgpu_SetupFlags_InputsCpuMemory       = (1u << 0);
+static const uint32_t kzstdgpu_SetupFlags_InputsGpuMemory       = (1u << 1);
+static const uint32_t kzstdgpu_SetupFlags_HasFrameInfoConstants = (1u << 2);
+static const uint32_t kzstdgpu_SetupFlags_HasBlockInfoConstants = (1u << 3);
 
-    kzstdgpu_SetupInputsType_Frames_Unknown     = 0x7fffffff
-};
+static const uint32_t kzstdgpu_SetupFlags_InputsMask = kzstdgpu_SetupFlags_InputsCpuMemory | kzstdgpu_SetupFlags_InputsGpuMemory;
+
+static uint32_t zstdgpu_HasFlag(uint32_t flags, uint32_t flag) { return (flags & flag) != 0; }
 
 struct zstdgpu_PerRequestContextImpl
 {
@@ -885,21 +908,12 @@ struct zstdgpu_PerRequestContextImpl
     uint32_t                zstdRleBlockCount;
     uint32_t                zstdCmpBlockCount;
 
-    uint32_t                zstdRawByteCount;
-    uint32_t                zstdRleByteCount;
-
     uint32_t                zstdUncompressedLiteralsByteCount;
     uint32_t                zstdUncompressedSequenceCount;
-    uint32_t                zstdSeqStreamCount;
 
-    ZSTDGPU_ENUM(SetupInputsType) setupInputsType;
+    uint32_t                setupFlags;
 };
 
-static uint32_t zstdgpu_GetStageCountFromSetupInputsType(ZSTDGPU_ENUM(SetupInputsType) type)
-{
-    ZSTDGPU_UNUSED(type);
-    return ZSTDGPU_ENUM_CONST(ResourceAllocation_StageCount);
-}
 
 uint32_t zstdgpu_GetPersistentContextRequiredMemorySizeInBytes(void)
 {
@@ -1138,12 +1152,9 @@ ZSTDGPU_ENUM(Status) zstdgpu_CreatePerRequestContext(zstdgpu_PerRequestContext *
         context->zstdRawBlockCount                  = 0;
         context->zstdRleBlockCount                  = 0;
         context->zstdCmpBlockCount                  = 0;
-        context->zstdRawByteCount                   = 0;
-        context->zstdRleByteCount                   = 0;
         context->zstdUncompressedLiteralsByteCount  = 0;
         context->zstdUncompressedSequenceCount      = 0;
-        context->zstdSeqStreamCount                 = 0;
-        context->setupInputsType                    = ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_Unknown);
+        context->setupFlags = 0;
 
         *outPerRequestContext = context;
         return ZSTDGPU_ENUM_CONST(StatusSuccess);
@@ -1160,7 +1171,7 @@ ZSTDGPU_ENUM(Status) zstdgpu_DestroyPerRequestContext(void **outMemoryBlock, uin
     {
         d3d12aid_Timestamps_Release(&inPerRequestContext->timestamps);
 
-        const uint32_t stageCount = zstdgpu_GetStageCountFromSetupInputsType(inPerRequestContext->setupInputsType);
+        const uint32_t stageCount = ZSTDGPU_ENUM_CONST(ResourceAllocation_StageCount);
         for (uint32_t stage = 0; stage < stageCount; ++stage)
         {
             zstdgpu_ResourceDataGpu_Term(&inPerRequestContext->resData, stage);
@@ -1209,7 +1220,7 @@ ZSTDGPU_ENUM(Status) zstdgpu_SetupInputsAsFramesInCpuMemory(uint32_t *outStageCo
 
     if (proceed)
     {
-        if (ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_GpuMemory) == inPerRequestContext->setupInputsType)
+        if (zstdgpu_HasFlag(inPerRequestContext->setupFlags, kzstdgpu_SetupFlags_InputsGpuMemory))
         {
             // NOTE(pamartis): we only release ID3D12Resource with the PerRequest context.
             // ID3D12Resource within zstdgpu_ResourceDataGpu will be released with the zstdgpu_ResourceDataGpu_Term call.
@@ -1224,7 +1235,7 @@ ZSTDGPU_ENUM(Status) zstdgpu_SetupInputsAsFramesInCpuMemory(uint32_t *outStageCo
         inPerRequestContext->compressedFramesRefs           = NULL;
         inPerRequestContext->zstdFrameCount                 = frameCount;
         inPerRequestContext->zstdCompressedFramesByteCount  = framesMemorySizeInBytes;
-        inPerRequestContext->setupInputsType                = ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_CpuMemory);
+        inPerRequestContext->setupFlags = (inPerRequestContext->setupFlags & ~kzstdgpu_SetupFlags_InputsMask) | kzstdgpu_SetupFlags_InputsCpuMemory;
 
         *outStageCount = 3u;
         return ZSTDGPU_ENUM_CONST(StatusSuccess);
@@ -1245,7 +1256,7 @@ ZSTDGPU_ENUM(Status) zstdgpu_SetupInputsAsFramesInGpuMemory(uint32_t *outStageCo
 
     if (proceed)
     {
-        if (ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_GpuMemory) == inPerRequestContext->setupInputsType)
+        if (zstdgpu_HasFlag(inPerRequestContext->setupFlags, kzstdgpu_SetupFlags_InputsGpuMemory))
         {
             // NOTE(pamartis): we only release ID3D12Resource with the PerRequest context.
             // ID3D12Resource within zstdgpu_ResourceDataGpu will be released with the zstdgpu_ResourceDataGpu_Term call.
@@ -1262,7 +1273,7 @@ ZSTDGPU_ENUM(Status) zstdgpu_SetupInputsAsFramesInGpuMemory(uint32_t *outStageCo
         inPerRequestContext->compressedFramesRefs->AddRef();
         inPerRequestContext->zstdFrameCount                 = frameCount;
         inPerRequestContext->zstdCompressedFramesByteCount  = framesMemorySizeInBytes;
-        inPerRequestContext->setupInputsType                = ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_GpuMemory);
+        inPerRequestContext->setupFlags = (inPerRequestContext->setupFlags & ~kzstdgpu_SetupFlags_InputsMask) | kzstdgpu_SetupFlags_InputsGpuMemory;
 
         *outStageCount = 3u;
         return ZSTDGPU_ENUM_CONST(StatusSuccess);
@@ -1300,10 +1311,57 @@ ZSTDGPU_API ZSTDGPU_ENUM(Status) zstdgpu_SetupOutputs(zstdgpu_PerRequestContext 
     return ZSTDGPU_ENUM_CONST(StatusInvalidArgument);
 }
 
+ZSTDGPU_ENUM(Status) zstdgpu_SetupFrameInfoConstants(zstdgpu_PerRequestContext inPerRequestContext, uint32_t rawBlockCount, uint32_t rleBlockCount, uint32_t cmpBlockCount)
+{
+    uint32_t proceed = 1;
+    proceed = proceed && (inPerRequestContext->thisMemoryBlock == (void *)inPerRequestContext);
+    proceed = proceed && (0 != rawBlockCount + rleBlockCount + cmpBlockCount);
+    ZSTDGPU_ASSERT(proceed > 0);
+
+    if (proceed)
+    {
+        inPerRequestContext->zstdRawBlockCount          = rawBlockCount;
+        inPerRequestContext->zstdRleBlockCount          = rleBlockCount;
+        inPerRequestContext->zstdCmpBlockCount          = cmpBlockCount;
+        inPerRequestContext->setupFlags |= kzstdgpu_SetupFlags_HasFrameInfoConstants;
+        return ZSTDGPU_ENUM_CONST(StatusSuccess);
+    }
+    return ZSTDGPU_ENUM_CONST(StatusInvalidArgument);
+}
+
+ZSTDGPU_ENUM(Status) zstdgpu_SetupBlockInfoConstants(zstdgpu_PerRequestContext inPerRequestContext, uint32_t literalsByteCount, uint32_t sequenceCount)
+{
+    uint32_t proceed = 1;
+    proceed = proceed && (inPerRequestContext->thisMemoryBlock == (void *)inPerRequestContext);
+    ZSTDGPU_ASSERT(proceed > 0);
+
+    if (proceed)
+    {
+        inPerRequestContext->zstdUncompressedLiteralsByteCount = literalsByteCount;
+        inPerRequestContext->zstdUncompressedSequenceCount     = sequenceCount;
+        inPerRequestContext->setupFlags |= kzstdgpu_SetupFlags_HasBlockInfoConstants;
+        return ZSTDGPU_ENUM_CONST(StatusSuccess);
+    }
+    return ZSTDGPU_ENUM_CONST(StatusInvalidArgument);
+}
+
+uint32_t zstdgpu_IsReadbackRequired(zstdgpu_PerRequestContext inPerRequestContext, uint32_t stageIndex)
+{
+    if (stageIndex == 0)
+    {
+        return zstdgpu_HasFlag(inPerRequestContext->setupFlags, kzstdgpu_SetupFlags_HasFrameInfoConstants) ? 0 : 1;
+    }
+    if (stageIndex == 1)
+    {
+        return zstdgpu_HasFlag(inPerRequestContext->setupFlags, kzstdgpu_SetupFlags_HasBlockInfoConstants) ? 0 : 1;
+    }
+    return 0;
+}
+
 ZSTDGPU_ENUM(Status) zstdgpu_GetGpuMemoryRequirement(uint32_t *outDefaultHeapByteCount, uint32_t *outUploadHeapByteCount, uint32_t *outReadbackHeapByteCount, uint32_t *outShaderVisibleDescriptorCount, zstdgpu_PerRequestContext req, uint32_t stageIndex)
 {
     uint32_t proceed = 1;
-    uint32_t stageCount = zstdgpu_GetStageCountFromSetupInputsType(req->setupInputsType);
+    uint32_t stageCount = ZSTDGPU_ENUM_CONST(ResourceAllocation_StageCount);
 
     proceed = proceed && (NULL != outDefaultHeapByteCount);
     proceed = proceed && (NULL != outUploadHeapByteCount);
@@ -1322,19 +1380,27 @@ ZSTDGPU_ENUM(Status) zstdgpu_GetGpuMemoryRequirement(uint32_t *outDefaultHeapByt
         #define CNTRS(name) req->resData.gpu2Cpu.CountersCpu->name
         if (stageIndex == 0)
         {
-            zstdgpu_ResourceInfo_Stage_0_Init(&req->resInfo, req->zstdFrameCount, req->zstdCompressedFramesByteCount, ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_GpuMemory) == req->setupInputsType ? 1u : 0u);
+            zstdgpu_ResourceInfo_Stage_0_Init(&req->resInfo, req->zstdFrameCount, req->zstdCompressedFramesByteCount, zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_InputsGpuMemory) ? 1u : 0u);
         }
         else if (stageIndex == 1)
         {
-            const uint32_t cntRaw = CNTRS(Blocks_RAW);
-            const uint32_t cntRle = CNTRS(Blocks_RLE);
-            const uint32_t cntCmp = CNTRS(Blocks_CMP);
+            uint32_t cntRaw, cntRle, cntCmp;
+            if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasFrameInfoConstants))
+            {
+                cntRaw = req->zstdRawBlockCount;
+                cntRle = req->zstdRleBlockCount;
+                cntCmp = req->zstdCmpBlockCount;
+            }
+            else
+            {
+                cntRaw = CNTRS(Blocks_RAW);
+                cntRle = CNTRS(Blocks_RLE);
+                cntCmp = CNTRS(Blocks_CMP);
 
-            req->zstdRawBlockCount = cntRaw;
-            req->zstdRleBlockCount = cntRle;
-            req->zstdCmpBlockCount = cntCmp;
-            req->zstdRawByteCount  = CNTRS(BlocksBytes_RAW);
-            req->zstdRleByteCount  = CNTRS(BlocksBytes_RLE);
+                req->zstdRawBlockCount = cntRaw;
+                req->zstdRleBlockCount = cntRle;
+                req->zstdCmpBlockCount = cntCmp;
+            }
 
             ZSTDGPU_ASSERT(0 != cntRaw + cntRle + cntCmp);
 
@@ -1343,19 +1409,26 @@ ZSTDGPU_ENUM(Status) zstdgpu_GetGpuMemoryRequirement(uint32_t *outDefaultHeapByt
         }
         else if (stageIndex == 2)
         {
-            const uint32_t cntLit = CNTRS(HUF_Streams_DecodedBytes);
-            const uint32_t cntSeq = CNTRS(Seq_Streams_DecodedItems);
-
-            req->zstdUncompressedLiteralsByteCount = cntLit;
-            req->zstdUncompressedSequenceCount     = cntSeq;
-            req->zstdSeqStreamCount                = CNTRS(Seq_Streams);
+            uint32_t cntLit, cntSeq;
+            if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasBlockInfoConstants))
+            {
+                cntLit = req->zstdUncompressedLiteralsByteCount;
+                cntSeq = req->zstdUncompressedSequenceCount;
+            }
+            else
+            {
+                cntLit = CNTRS(HUF_Streams_DecodedBytes);
+                cntSeq = CNTRS(Seq_Streams_DecodedItems);
+                req->zstdUncompressedLiteralsByteCount = cntLit;
+                req->zstdUncompressedSequenceCount     = cntSeq;
+            }
 
             zstdgpu_ResourceInfo_Stage_2_Init(&req->resInfo, cntLit, cntSeq, req->zstdUncompressedFramesByteCount, req->zstdUncompressedFrameCount);
         }
         *outDefaultHeapByteCount            = req->resInfo.gpuOnly_ByteCount[stageIndex];
         *outUploadHeapByteCount             = req->resInfo.cpu2Gpu_ByteCount[stageIndex];
         *outReadbackHeapByteCount           = req->resInfo.gpu2Cpu_ByteCount[stageIndex];
-        *outShaderVisibleDescriptorCount    = zstdgpu_Count_SRTs();
+        *outShaderVisibleDescriptorCount    = zstdgpu_Count_SRTs_Stage(stageIndex);
 
         #undef CNTRS
         return ZSTDGPU_ENUM_CONST(StatusSuccess);
@@ -1380,7 +1453,7 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithExternalMemory(zstdgpu_PerRequestContext 
                                                 uint32_t shaderVisibileHeapOffsetInDescriptors)
 {
     uint32_t proceed = 1;
-    uint32_t stageCount = zstdgpu_GetStageCountFromSetupInputsType(req->setupInputsType);
+    uint32_t stageCount = ZSTDGPU_ENUM_CONST(ResourceAllocation_StageCount);
     uint32_t defaultHeapMemReq = 0;
     uint32_t uploadHeapMemReq = 0;
     uint32_t readbackHeapMemReq = 0;
@@ -1427,7 +1500,7 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithExternalMemory(zstdgpu_PerRequestContext 
         req->resData.gpu2Cpu_HeapOffset[stageIndex] = readbackHeap_OffsetInBytes;
 
         zstdgpu_ResourceDataGpu_Init(&req->resData, &req->resInfo, req->device, stageIndex);
-        if (ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_GpuMemory) == req->setupInputsType && stageIndex == 0u)
+        if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_InputsGpuMemory) && stageIndex == 0u)
         {
             zstdgpu_ResourceDataGpu_ReInitInputExternal(&req->resData, req->compressedFramesData, req->compressedFramesRefs);
         }
@@ -1440,7 +1513,7 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithExternalMemory(zstdgpu_PerRequestContext 
         // NOTE(pamartis): we need to do call upload callback right after initialising resources of stage == 0
         if (stageIndex == 0)
         {
-            if (ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_CpuMemory) == req->setupInputsType)
+            if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_InputsCpuMemory))
             {
                 req->uploadCallback(req->resData.cpu2Gpu.CompressedDataCpu, req->zstdCompressedFramesByteCount, req->resData.cpu2Gpu.FramesRefsCpu, req->zstdFrameCount, req->uploadUserdata);
             }
@@ -1451,7 +1524,7 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithExternalMemory(zstdgpu_PerRequestContext 
         req->srts.heap = shaderVisibleHeap;
         req->srts.heap->AddRef();
         req->srts.heapOffset = shaderVisibileHeapOffsetInDescriptors;
-        zstdgpu_ReCreate_SRTs(req->srts, req->device, req->resInfo, req->resData);
+        zstdgpu_ReCreate_SRTs(req->srts, req->device, req->resInfo, req->resData, stageIndex);
 
         if (stageIndex == 0)
         {
@@ -1474,7 +1547,7 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithExternalMemory(zstdgpu_PerRequestContext 
 ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithInteralMemory(zstdgpu_PerRequestContext req, uint32_t stageIndex, struct ID3D12GraphicsCommandList *cmdList)
 {
     uint32_t proceed = 1;
-    uint32_t stageCount = zstdgpu_GetStageCountFromSetupInputsType(req->setupInputsType);
+    uint32_t stageCount = ZSTDGPU_ENUM_CONST(ResourceAllocation_StageCount);
 
     proceed = proceed && (req->thisMemoryBlock == (void *)req);
     proceed = proceed && (req->zstdFrameCount > 0);
@@ -1492,19 +1565,27 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithInteralMemory(zstdgpu_PerRequestContext r
         // NOTE(pamartis): Recompute memory information for a given stage
         if (stageIndex == 0)
         {
-            zstdgpu_ResourceInfo_Stage_0_Init(&req->resInfo, req->zstdFrameCount, req->zstdCompressedFramesByteCount, ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_GpuMemory) == req->setupInputsType ? 1u : 0u);
+            zstdgpu_ResourceInfo_Stage_0_Init(&req->resInfo, req->zstdFrameCount, req->zstdCompressedFramesByteCount, zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_InputsGpuMemory) ? 1u : 0u);
         }
         else if (stageIndex == 1)
         {
-            const uint32_t cntRaw = CNTRS(Blocks_RAW);
-            const uint32_t cntRle = CNTRS(Blocks_RLE);
-            const uint32_t cntCmp = CNTRS(Blocks_CMP);
+            uint32_t cntRaw, cntRle, cntCmp;
+            if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasFrameInfoConstants))
+            {
+                cntRaw = req->zstdRawBlockCount;
+                cntRle = req->zstdRleBlockCount;
+                cntCmp = req->zstdCmpBlockCount;
+            }
+            else
+            {
+                cntRaw = CNTRS(Blocks_RAW);
+                cntRle = CNTRS(Blocks_RLE);
+                cntCmp = CNTRS(Blocks_CMP);
 
-            req->zstdRawBlockCount = cntRaw;
-            req->zstdRleBlockCount = cntRle;
-            req->zstdCmpBlockCount = cntCmp;
-            req->zstdRawByteCount = CNTRS(BlocksBytes_RAW);
-            req->zstdRleByteCount = CNTRS(BlocksBytes_RLE);
+                req->zstdRawBlockCount = cntRaw;
+                req->zstdRleBlockCount = cntRle;
+                req->zstdCmpBlockCount = cntCmp;
+            }
 
             ZSTDGPU_ASSERT(0 != cntRaw + cntRle + cntCmp);
 
@@ -1512,12 +1593,19 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithInteralMemory(zstdgpu_PerRequestContext r
         }
         else if (stageIndex == 2)
         {
-            const uint32_t cntLit = CNTRS(HUF_Streams_DecodedBytes);
-            const uint32_t cntSeq = CNTRS(Seq_Streams_DecodedItems);
-
-            req->zstdUncompressedLiteralsByteCount = cntLit;
-            req->zstdUncompressedSequenceCount     = cntSeq;
-            req->zstdSeqStreamCount                = CNTRS(Seq_Streams);
+            uint32_t cntLit, cntSeq;
+            if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasBlockInfoConstants))
+            {
+                cntLit = req->zstdUncompressedLiteralsByteCount;
+                cntSeq = req->zstdUncompressedSequenceCount;
+            }
+            else
+            {
+                cntLit = CNTRS(HUF_Streams_DecodedBytes);
+                cntSeq = CNTRS(Seq_Streams_DecodedItems);
+                req->zstdUncompressedLiteralsByteCount = cntLit;
+                req->zstdUncompressedSequenceCount     = cntSeq;
+            }
 
             zstdgpu_ResourceInfo_Stage_2_Init(&req->resInfo, cntLit, cntSeq, req->zstdUncompressedFramesByteCount, req->zstdUncompressedFrameCount);
         }
@@ -1534,7 +1622,7 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithInteralMemory(zstdgpu_PerRequestContext r
         // NOTE(pamartis): try re-creating heap and then resources (will trigger only if they were released or never created)
         zstdgpu_ResourceDataGpu_InitHeap(&req->resData, &req->resInfo, req->device, stageIndex);
         zstdgpu_ResourceDataGpu_Init(&req->resData, &req->resInfo, req->device, stageIndex);
-        if (ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_GpuMemory) == req->setupInputsType && stageIndex == 0u)
+        if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_InputsGpuMemory) && stageIndex == 0u)
         {
             zstdgpu_ResourceDataGpu_ReInitInputExternal(&req->resData, req->compressedFramesData, req->compressedFramesRefs);
         }
@@ -1547,7 +1635,7 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithInteralMemory(zstdgpu_PerRequestContext r
         // NOTE(pamartis): we need to do call upload callback right after initialising resources of stage == 0
         if (stageIndex == 0)
         {
-            if (ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_CpuMemory) == req->setupInputsType)
+            if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_InputsCpuMemory))
             {
                 req->uploadCallback(req->resData.cpu2Gpu.CompressedDataCpu, req->zstdCompressedFramesByteCount, req->resData.cpu2Gpu.FramesRefsCpu, req->zstdFrameCount, req->uploadUserdata);
             }
@@ -1556,11 +1644,20 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithInteralMemory(zstdgpu_PerRequestContext r
 
         if (NULL == req->srts.heap)
         {
-            req->srts.heap = d3d12aid_DescriptorHeap_Create(req->device, zstdgpu_Count_SRTs(), D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE);
+            const uint32_t srtCount = zstdgpu_Count_SRTs_Stage(0) + zstdgpu_Count_SRTs_Stage(1) + zstdgpu_Count_SRTs_Stage(2);
+            req->srts.heap = d3d12aid_DescriptorHeap_Create(req->device, srtCount, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE);
             req->srts.heapOffset = 0;
         }
+        {
+            uint32_t offset = 0;
+            for (uint32_t s = 0; s < stageIndex; ++s)
+            {
+                offset += zstdgpu_Count_SRTs_Stage(s);
+            }
+            req->srts.heapOffset = offset;
+        }
         #undef CNTRS
-        zstdgpu_ReCreate_SRTs(req->srts, req->device, req->resInfo, req->resData);
+        zstdgpu_ReCreate_SRTs(req->srts, req->device, req->resInfo, req->resData, stageIndex);
 
         if (stageIndex == 0)
         {
@@ -1682,6 +1779,15 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithInteralMemory(zstdgpu_PerRequestContext r
     }                                                                           \
     while (0)
 
+#define BIND_RS_PS_SRT_EX(psoName, srtName)                                     \
+    do                                                                          \
+    {                                                                           \
+        d3d12aid_ComputeRsPs_Set(&req->psoName, cmdList);                       \
+        cmdList->SetDescriptorHeaps(1, &req->srts.heap);                        \
+        cmdList->SetComputeRootDescriptorTable(0, req->srts.srtName##GpuHandle);\
+    }                                                                           \
+    while (0)
+
 static void zstdgpu_Dispatch32Bit(ID3D12GraphicsCommandList *cmdList, uint32_t tgCount, uint32_t rootParameterIndex, uint32_t rootParameterOffset)
 {
 #ifdef _GAMING_XBOX
@@ -1715,7 +1821,7 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
         #define zstdgpu_PushUpload(name) cmdList->CopyResource(req->resData.gpuOnly.name, req->resData.cpu2Gpu.name)
 
-        if (ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_CpuMemory) == req->setupInputsType)
+        if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_InputsCpuMemory))
         {
             zstdgpu_PushUpload(CompressedData);
             zstdgpu_PushUpload(FramesRefs);
@@ -1725,7 +1831,7 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
         setResourceState(barriers, 0, req->resData.gpuOnly.FseProbsDefault, COPY_DEST, NON_PIXEL_SHADER_RESOURCE);
         uploadBarrierCount += 1;
-        if (ZSTDGPU_ENUM_CONST(SetupInputsType_Frames_CpuMemory) == req->setupInputsType)
+        if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_InputsCpuMemory))
         {
             setResourceState(barriers, 1, req->resData.gpuOnly.CompressedData, COPY_DEST, NON_PIXEL_SHADER_RESOURCE);
             setResourceState(barriers, 2, req->resData.gpuOnly.FramesRefs, COPY_DEST, NON_PIXEL_SHADER_RESOURCE);
@@ -1739,7 +1845,7 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         const uint32_t cmpBlockCount = 0;
 
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Init Resources :: Stage 0]");
-        BIND_RS_PS_SRT(InitResources);
+        BIND_RS_PS_SRT_EX(InitResources, InitResources_S0);
         cmdList->SetComputeRoot32BitConstant(1, allBlockCount, 0);
         cmdList->SetComputeRoot32BitConstant(1, cmpBlockCount, 1);
         cmdList->SetComputeRoot32BitConstant(1, req->zstdFrameCount, 2);
@@ -1811,7 +1917,7 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     {
         const uint32_t countBlocksOnly = 1;
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Parse Frames :: Count Blocks]");
-        BIND_RS_PS_SRT(ParseFrames);
+        BIND_RS_PS_SRT_EX(ParseFrames, ParseFrames_S0);
         cmdList->SetComputeRoot32BitConstant(1, req->zstdFrameCount, 0);
         cmdList->SetComputeRoot32BitConstant(1, req->resInfo.CompressedData_ByteSize, 1);
         cmdList->SetComputeRoot32BitConstant(1, countBlocksOnly, 2);
@@ -1899,14 +2005,19 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [Readback Counters :: After Block Count] and [Parse Compressed Blocks]");
         D3D12_RESOURCE_BARRIER barriers[5];
         // last read by [Update Dispatch Args :: Stage 0]
-        // next read by [Readback Counters :: After Block Count]
-        setResourceState(barriers, 0, req->resData.gpuOnly.Counters, UNORDERED_ACCESS, COPY_SOURCE);
+        // next read by [Readback Counters :: After Block Count] or [Init Resources :: Stage 1]
+        if (zstdgpu_IsReadbackRequired(req, 0))
+        {
+            setResourceState(barriers, 0, req->resData.gpuOnly.Counters, UNORDERED_ACCESS, COPY_SOURCE);
+        }
+        else
+        {
+            setResourceUavSync(barriers, 0, req->resData.gpuOnly.Counters);
+        }
         // last written by [PrefixSum :: Block Counts]
-        // next read by [Parse Compressed Blocks]
-        setResourceUavToSrvSync(barriers, 1, req->resData.gpuOnly.PerFrameBlockCountCMP);
-        // last written by [PrefixSum :: Block Counts]
-        // next read by [Prefix Sequence Offsets] and [Finalise Sequence Offsets]
-        setResourceUavToSrvSync(barriers, 2, req->resData.gpuOnly.PerFrameBlockCountAll);
+        // next bound to [Parse Compressed Blocks] as UAV
+        setResourceUavSync(barriers, 1, req->resData.gpuOnly.PerFrameBlockCountCMP);
+        setResourceUavSync(barriers, 2, req->resData.gpuOnly.PerFrameBlockCountAll);
         // last written by [Update Dispatch Args :: Stage 0]
         // next read by ExecuteIndirect calls as argument/count buffers
         setResourceState(barriers, 3, req->resData.gpuOnly.DispatchArgs, UNORDERED_ACCESS, INDIRECT_ARGUMENT);
@@ -1914,6 +2025,7 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->ResourceBarrier(_countof(barriers), barriers);
         PIXEndEvent(cmdList);
     }
+    if (zstdgpu_IsReadbackRequired(req, 0))
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Readback Counters :: After Block Count]");
         zstdgpu_PushReadback(Counters);
@@ -1929,7 +2041,7 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
                                      + req->zstdCmpBlockCount;
 
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Init Resources :: Stage 1]");
-        BIND_RS_PS_SRT(InitResources);
+        BIND_RS_PS_SRT_EX(InitResources, InitResources_S1);
         cmdList->SetComputeRoot32BitConstant(1, allBlockCount, 0);
         cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 1);
         cmdList->SetComputeRoot32BitConstant(1, req->zstdFrameCount, 2);
@@ -1992,7 +2104,7 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     {
         const uint32_t countBlocksOnly = 0;
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Parse Frames :: Collect Blocks]");
-        BIND_RS_PS_SRT(ParseFrames);
+        BIND_RS_PS_SRT_EX(ParseFrames, ParseFrames_S1);
         cmdList->SetComputeRoot32BitConstant(1, req->zstdFrameCount, 0);
         cmdList->SetComputeRoot32BitConstant(1, req->resInfo.CompressedData_ByteSize, 1);
         cmdList->SetComputeRoot32BitConstant(1, countBlocksOnly, 2);
@@ -2003,7 +2115,7 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     }
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier with Resources for [Parse Compressed Blocks] and [Memcpy RAW blocks, Memset RLE blocks]");
-        D3D12_RESOURCE_BARRIER barriers[14];
+        D3D12_RESOURCE_BARRIER barriers[15];
 
         uint32_t bc = 0;
         if (req->zstdCmpBlockCount > 0)
@@ -2011,63 +2123,60 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             // last written by [Parse Frames :: Collect Blocks]
             // next written/updated by [Parse Compressed Blocks] with non-intersecting memory ranges with [Parse Frames :: Collect Blocks]
             // so TODO: check if can remove
-            setResourceUavSync(barriers, bc + 0, req->resData.gpuOnly.Counters);
+            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.Counters);
             // last written by [Init Resources :: Stage 1]
             // next written/updated by [Parse Compressed Blocks] with non-intersecting memory range with [Init Resources :: Stage 1]
             // so TODO: check if can remove
-            setResourceUavSync(barriers, bc + 1, req->resData.gpuOnly.FseInfos);
-            setResourceUavSync(barriers, bc + 2, req->resData.gpuOnly.FseProbs);
+            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.FseInfos);
+            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.FseProbs);
             // last written by [InitResources :: Memset :: Stage 1]
             // next written/updated by [Parse Compressed Blocks] -- both "lookback" and "prefix" sub-buffers
-            setResourceUavSync(barriers, bc + 3, req->resData.gpuOnly.TableIndexLookback);
+            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.TableIndexLookback);
             // last written by [InitResources :: Memset :: Stage 1]
             // next written/updated by [Parse Compressed Blocks]
-            setResourceUavSync(barriers, bc + 4, req->resData.gpuOnly.LitStreamEndPerHuffmanTable);
-            setResourceUavSync(barriers, bc + 5, req->resData.gpuOnly.PerFrameSeqStreamMinIdx);
+            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.LitStreamEndPerHuffmanTable);
+            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameSeqStreamMinIdx);
             // last written by [Parse Frames :: Collect Blocks]
             // next read by [Parse Compressed Blocks]
-            setResourceUavToSrvSync(barriers, bc + 6, req->resData.gpuOnly.BlocksCMPRefs);
+            setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.BlocksCMPRefs);
+            // last bound as UAV to [Parse Frames :: Collect Blocks]
+            // next read by [Parse Compressed Blocks]
+            setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountCMP);
+            // last bound as UAV to [Parse Frames :: Collect Blocks]
+            // next read by [Prefix Sequence Offsets] and [Finalise Sequence Offsets]
+            setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountAll);
             // last written by [InitResources :: Memset :: Stage 1]
             // next written/updated by [Parse Compressed Blocks]
-            setResourceUavSync(barriers, bc + 7, req->resData.gpuOnly.SeqCountPrefixLookback);
-            setResourceUavSync(barriers, bc + 8, req->resData.gpuOnly.BlockSeqCountPrefixLookback);
+            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.SeqCountPrefixLookback);
+            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.BlockSeqCountPrefixLookback);
             // last written by [Parse Frames :: Collect Blocks]
             // next read by [Parse Compressed Blocks] -- to be able to get global index to index into BlockSizePrefix
-            setResourceUavToSrvSync(barriers, bc + 9, req->resData.gpuOnly.GlobalBlockIndexPerCmpBlock);
+            setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.GlobalBlockIndexPerCmpBlock);
             // last written by [Parse Frames :: Collect Blocks]
             // next written/updated by [Parse Compressed Blocks] - sets literal size to be uncompressed block size
-            setResourceUavSync(barriers, bc + 10, req->resData.gpuOnly.BlockSizePrefix);
-            //
-            // [NOTE] PerFrameBlockCountCMP is bound as UAV by [InitResources :: Memset :: Stage 1] and [Parse Frames],
-            // and later read by ParseCompressedBlocks as SRV, so we transition to read state
-            setResourceUavToSrvSync(barriers, bc + 11, req->resData.gpuOnly.PerFrameBlockCountCMP);
-            bc += 12;
+            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.BlockSizePrefix);
         }
         else
         {
             // last written by [Parse Frames :: Collect Blocks]
             // next read by [Readback Counters :: After Block Parse] and updated by [Update Dispatch Args]
-            setResourceUavToSrvSync(barriers, bc + 0, req->resData.gpuOnly.Counters);
-            bc += 1;
+            setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.Counters);
 
             // last written by [Parse Frames :: Collect Blocks]
             // next updated by [Prefix Block Sizes]
-            setResourceUavSync(barriers, bc + 0, req->resData.gpuOnly.BlockSizePrefix);
-            bc += 1;
+            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.BlockSizePrefix);
         }
 
         // last written by [Parse Frames :: Collect Blocks]
         // next read by [Memcpy RAW blocks, Memset RLE blocks]
         if (req->zstdRawBlockCount > 0)
         {
-            setResourceUavToSrvSync(barriers, bc + 0, req->resData.gpuOnly.BlocksRAWRefs);
-            bc += 1;
+            setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.BlocksRAWRefs);
         }
 
-        if (req->zstdRleByteCount > 0)
+        if (req->zstdRleBlockCount > 0)
         {
-            setResourceUavToSrvSync(barriers, bc + 0, req->resData.gpuOnly.BlocksRLERefs);
-            bc += 1;
+            setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.BlocksRLERefs);
         }
 
         cmdList->ResourceBarrier(bc, barriers);
@@ -2093,8 +2202,15 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [Readback Counters :: After Block Parse] and [Update Dispatch Args] and [Compute `Per-Huffman Table` Literal Stream Count Prefix]");
         D3D12_RESOURCE_BARRIER barriers[11];
         // last written by [Parse Compressed Blocks]
-        // next read by [Readback Counters :: After Block Parse] and updated by [Update Dispatch Args]
-        setResourceState(barriers, 0, req->resData.gpuOnly.Counters, UNORDERED_ACCESS, COPY_SOURCE);
+        // next read by [Readback Counters :: After Block Parse] or [Update Dispatch Args]
+        if (zstdgpu_IsReadbackRequired(req, 1))
+        {
+            setResourceState(barriers, 0, req->resData.gpuOnly.Counters, UNORDERED_ACCESS, COPY_SOURCE);
+        }
+        else
+        {
+            setResourceUavSync(barriers, 0, req->resData.gpuOnly.Counters);
+        }
         // last written by [Parse Compressed Blocks]
         // next written/updated by [Compute `Per-Huffman Table` Literal Stream Count Prefix]
         setResourceUavSync(barriers, 1, req->resData.gpuOnly.LitStreamEndPerHuffmanTable);
@@ -2121,6 +2237,7 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->ResourceBarrier(_countof(barriers), barriers);
         PIXEndEvent(cmdList);
     }
+    if (zstdgpu_IsReadbackRequired(req, 1))
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Readback Counters :: After Block Parse]");
         zstdgpu_PushReadback(Counters);
@@ -2580,7 +2697,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->ResourceBarrier(_countof(barriers), barriers);
         PIXEndEvent(cmdList);
     }
-    if (req->zstdRawByteCount > 0 || req->zstdRleByteCount > 0)
+    if (req->zstdRawBlockCount > 0 || req->zstdRleBlockCount > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Memcpy RAW blocks, Memset RLE blocks]");
         d3d12aid_ComputeRsPs_Set(&req->MemsetMemcpy, cmdList);
@@ -2588,7 +2705,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRootDescriptorTable(0, req->srts.MemsetMemcpyGpuHandle);
         ZSTDGPU_KERNEL_SCOPE(MemcpyRAW_MemsetRLE, cmdList,
         {
-            if (req->zstdRawByteCount > 0)
+            if (req->zstdRawBlockCount > 0)
             {
                 cmdList->SetComputeRootShaderResourceView(1, req->resData.gpuOnly.RawBlockSizePrefix->GetGPUVirtualAddress());
                 cmdList->SetComputeRootShaderResourceView(2, req->resData.gpuOnly.PerFrameBlockSizesRAW->GetGPUVirtualAddress());
@@ -2600,7 +2717,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
                 cmdList->SetComputeRoot32BitConstant(5, 1 /* flags */, 4);
                 zstdgpu_DispatchIndirect(cmdList, MemsetMemcpy, MemcpyRAW);
             }
-            if (req->zstdRleByteCount > 0)
+            if (req->zstdRleBlockCount > 0)
             {
                 cmdList->SetComputeRootShaderResourceView(1, req->resData.gpuOnly.RleBlockSizePrefix->GetGPUVirtualAddress());
                 cmdList->SetComputeRootShaderResourceView(2, req->resData.gpuOnly.PerFrameBlockSizesRLE->GetGPUVirtualAddress());
@@ -2620,7 +2737,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier with Resources for [Execute Sequences]");
         D3D12_RESOURCE_BARRIER barriers[2];
         uint32_t bc = 0;
-        if (req->zstdRawByteCount > 0 || req->zstdRleByteCount > 0)
+        if (req->zstdRawBlockCount > 0 || req->zstdRleBlockCount > 0)
         {
             // in case if the number of RAW+RLE blocks > 0, [Memcpy RAW blocks, Memset RLE blocks] has written to 'UnCompressedFramesData'
             // next read by [Execute Sequences]
@@ -2672,35 +2789,39 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 ZSTDGPU_API void zstdgpu_ReadbackGpuResults(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandList *cmdList)
 {
     // NOTE(pamartis): these are required to make sure D3D12 validation doesn't complain about state mismatch when
-    // Read-only resource from the last stage get a NON_PS_RESOURCE state as a result of promotion from COMMON state
+    // Read-only resource from the last stage (== 2) get a NON_PS_RESOURCE state as a result of promotion from COMMON state
+    // (which happens in case if the stage prior to it (==1) is submitted in a separate CommandList/ExecuteCommandList)
     // and then used as COPY_SOURCE for debug readback
     D3D12_RESOURCE_BARRIER barriers[13];
     uint32_t bc = 0;
-    setResourceState(barriers, 0, req->resData.gpuOnly.PerFrameBlockCountCMP, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
-    setResourceState(barriers, 1, req->resData.gpuOnly.PerFrameBlockCountAll, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
-    setResourceState(barriers, 2, req->resData.gpuOnly.PerFrameBlockSizesRAW, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
-    setResourceState(barriers, 3, req->resData.gpuOnly.PerFrameBlockSizesRLE, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
-    setResourceState(barriers, 4, req->resData.gpuOnly.PerFrameSeqStreamMinIdx, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
-    bc += 5;
-    if (req->zstdCmpBlockCount > 0)
+    if (zstdgpu_IsReadbackRequired(req, 1))
     {
-        setResourceState(barriers, bc + 0, req->resData.gpuOnly.GlobalBlockIndexPerCmpBlock, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
-        setResourceState(barriers, bc + 1, req->resData.gpuOnly.PerSeqStreamSeqStart, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
-        bc += 2;
-    }
-    if (req->zstdRawBlockCount > 0)
-    {
-        setResourceState(barriers, bc + 0, req->resData.gpuOnly.GlobalBlockIndexPerRawBlock, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
-        setResourceState(barriers, bc + 1, req->resData.gpuOnly.RawBlockSizePrefix, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
-        setResourceState(barriers, bc + 2, req->resData.gpuOnly.BlocksRAWRefs, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
-        bc += 3;
-    }
-    if (req->zstdRleBlockCount > 0)
-    {
-        setResourceState(barriers, bc + 0, req->resData.gpuOnly.GlobalBlockIndexPerRleBlock, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
-        setResourceState(barriers, bc + 1, req->resData.gpuOnly.RleBlockSizePrefix, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
-        setResourceState(barriers, bc + 2, req->resData.gpuOnly.BlocksRLERefs, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
-        bc += 3;
+        setResourceState(barriers, 0, req->resData.gpuOnly.PerFrameBlockCountCMP, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
+        setResourceState(barriers, 1, req->resData.gpuOnly.PerFrameBlockCountAll, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
+        setResourceState(barriers, 2, req->resData.gpuOnly.PerFrameBlockSizesRAW, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
+        setResourceState(barriers, 3, req->resData.gpuOnly.PerFrameBlockSizesRLE, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
+        setResourceState(barriers, 4, req->resData.gpuOnly.PerFrameSeqStreamMinIdx, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
+        bc += 5;
+        if (req->zstdCmpBlockCount > 0)
+        {
+            setResourceState(barriers, bc + 0, req->resData.gpuOnly.GlobalBlockIndexPerCmpBlock, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
+            setResourceState(barriers, bc + 1, req->resData.gpuOnly.PerSeqStreamSeqStart, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
+            bc += 2;
+        }
+        if (req->zstdRawBlockCount > 0)
+        {
+            setResourceState(barriers, bc + 0, req->resData.gpuOnly.GlobalBlockIndexPerRawBlock, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
+            setResourceState(barriers, bc + 1, req->resData.gpuOnly.RawBlockSizePrefix, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
+            setResourceState(barriers, bc + 2, req->resData.gpuOnly.BlocksRAWRefs, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
+            bc += 3;
+        }
+        if (req->zstdRleBlockCount > 0)
+        {
+            setResourceState(barriers, bc + 0, req->resData.gpuOnly.GlobalBlockIndexPerRleBlock, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
+            setResourceState(barriers, bc + 1, req->resData.gpuOnly.RleBlockSizePrefix, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
+            setResourceState(barriers, bc + 2, req->resData.gpuOnly.BlocksRLERefs, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
+            bc += 3;
+        }
     }
 
     if (bc > 0)

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -324,7 +324,7 @@ static inline void zstdgpu_ParseFrame(zstdgpu_FrameInfo *outFrameInfo,
                 // Skip to the end of block
                 const uint32_t blockCur = zstdgpu_Forward_BitBuffer_GetByteOffset(bits);
                 const uint32_t blockEnd = blockBase + blockSize;
-                if (blockEnd > blockCur)
+                if (blockEnd >= blockCur)
                 {
                     zstdgpu_Forward_BitBuffer_Skip(bits, blockEnd - blockCur);
                 }
@@ -356,10 +356,12 @@ static inline void zstdgpu_ParseFrame(zstdgpu_FrameInfo *outFrameInfo,
                 // On the decompression side, this byte must be repeated `Block_Size` times.
                 outBlocksRLERefs[outFrameInfo->rleBlockStart].size = blockSize;
             }
+            else
+            {
+                zstdgpu_Forward_BitBuffer_Skip(bits, 1);
+            }
             outFrameInfo->rleBlockStart += 1;
             outFrameInfo->rleBlockBytesStart += blockSize;
-
-            zstdgpu_Forward_BitBuffer_Skip(bits, 1);
         }
         else
         {
@@ -378,6 +380,12 @@ static inline void zstdgpu_ParseFrame(zstdgpu_FrameInfo *outFrameInfo,
 
 void zstdgpu_CountFramesAndBlocks(zstdgpu_CountFramesAndBlocksInfo *outInfo, const void *memoryBlock, uint32_t memoryBlockSizeInBytes, uint32_t contentSizeInBytes)
 {
+    outInfo->rawBlockCount  = 0;
+    outInfo->rleBlockCount  = 0;
+    outInfo->cmpBlockCount  = 0;
+    outInfo->frameCount     = 0;
+    outInfo->frameByteCount = 0;
+
     uint32_t byteOfs = 0;
 
     zstdgpu_Forward_BitBuffer bits;
@@ -517,7 +525,7 @@ void zstdgpu_CollectBlocks(zstdgpu_OffsetAndSize *outBlocksRaw, zstdgpu_OffsetAn
 
 void zstdgpu_CountCompressedLiteralsAndSequences(zstdgpu_CountLiteralAndSequenceInfo *outInfo, const zstdgpu_OffsetAndSize *frames, uint32_t frameCount, const void *memoryBlock, uint32_t memoryBlockSizeInBytes)
 {
-    outInfo->compressedLiteralsByteCount = 0;
+    outInfo->decodedLiteralsByteCount = 0;
     outInfo->sequenceCount              = 0;
 
     uint32_t byteOfs = 0;
@@ -547,7 +555,7 @@ void zstdgpu_CountCompressedLiteralsAndSequences(zstdgpu_CountLiteralAndSequence
 
             ZSTDGPU_ASSERT(byteOfs == frames[frameIdx].offs + frames[frameIdx].size);
 
-            outInfo->compressedLiteralsByteCount += blockInfo.litByteCount;
+            outInfo->decodedLiteralsByteCount    += blockInfo.litByteCount;
             outInfo->sequenceCount               += blockInfo.seqElemCount;
         }
     }

--- a/zstd/zstdgpu/zstdgpu.h
+++ b/zstd/zstdgpu/zstdgpu.h
@@ -96,7 +96,7 @@ ZSTDGPU_API void zstdgpu_CollectBlocks(zstdgpu_OffsetAndSize *outBlocksRaw, zstd
 
 struct zstdgpu_CountLiteralAndSequenceInfo
 {
-    uint32_t compressedLiteralsByteCount;
+    uint32_t decodedLiteralsByteCount;
     uint32_t sequenceCount;
 };
 

--- a/zstd/zstdgpu/zstdgpu.h
+++ b/zstd/zstdgpu/zstdgpu.h
@@ -56,7 +56,7 @@ ZSTDGPU_API void zstdgpu_CountFramesAndBlocks(zstdgpu_CountFramesAndBlocksInfo *
 
 /**
  *  Traverses a memory block containing zstd frames on CPU and extracts information for every zstd frame.
- *  During traversal, the function jumps over every blocks in every frame to determine the end of the parent zstd frame
+ *  During traversal, the function jumps over every block in every frame to determine the end of the parent zstd frame
  *  because zstd doesn't store the size of compressed frames.
  *
  *  The results of this function are stored in two arrays:
@@ -93,6 +93,26 @@ ZSTDGPU_API void zstdgpu_CollectFrames(zstdgpu_OffsetAndSize *outFrames, zstdgpu
  *       stores the number of times the symbol has to be repeated in the decompressed stream.
  */
 ZSTDGPU_API void zstdgpu_CollectBlocks(zstdgpu_OffsetAndSize *outBlocksRaw, zstdgpu_OffsetAndSize *outBlocksRLE, zstdgpu_OffsetAndSize *outBlocksCmp, const zstdgpu_OffsetAndSize *frames, const zstdgpu_FrameInfo *frameInfos, uint32_t frameIndex, uint32_t frameCount, const void *memoryBlock, uint32_t memoryBlockSizeInBytes, uint32_t contentSizeInBytes);
+
+struct zstdgpu_CountLiteralAndSequenceInfo
+{
+    uint32_t compressedLiteralsByteCount;
+    uint32_t sequenceCount;
+};
+
+/**
+ *  Scans compressed block interiors on CPU and extracts aggregate literal/sequence statistics.
+ *  For each compressed block, parses the literal section header (to get regenerated size for
+ *  compressed/treeless literals) and the sequence section header (to get sequence count).
+ *
+ *  Takes the already-discovered frame offsets from a prior `zstdgpu_CollectFrames` call.
+ *
+ *  Results can be passed to `zstdgpu_SetupBlockInfoConstants` to enable merging all GPU
+ *  stages into a single command list submission without CPU fences.
+ *
+ *  NB: `memoryBlockSize` must be a multiple of 4 bytes.
+ */
+ZSTDGPU_API void zstdgpu_CountCompressedLiteralsAndSequences(zstdgpu_CountLiteralAndSequenceInfo *outInfo, const zstdgpu_OffsetAndSize *frames, uint32_t frameCount, const void *memoryBlock, uint32_t memoryBlockSizeInBytes);
 
 typedef enum zstdgpu_Status
 {

--- a/zstd/zstdgpu/zstdgpu.h
+++ b/zstd/zstdgpu/zstdgpu.h
@@ -188,6 +188,31 @@ ZSTDGPU_API zstdgpu_Status zstdgpu_SetupInputsAsFramesInGpuMemory(uint32_t *outS
 
 ZSTDGPU_API zstdgpu_Status zstdgpu_SetupOutputs(zstdgpu_PerRequestContext inPerRequestContext, struct ID3D12Resource *framesMemory, uint32_t framesMemorySizeInBytes, struct ID3D12Resource *frames, uint32_t frameCount);
 
+/**
+ *  @brief      Specifies the number of blocks of each type from a CPU pre-scan.
+ *              When set, `zstdgpu_GetGpuMemoryRequirement` for stage 1 uses these counts instead of
+ *              reading from GPU counter readback, enabling stages 0 and 1 to be recorded into
+ *              the same command list without a CPU fence.
+ *              Can be called before or after `zstdgpu_SetupInputs*` functions.
+ */
+ZSTDGPU_API zstdgpu_Status zstdgpu_SetupFrameInfoConstants(zstdgpu_PerRequestContext inPerRequestContext, uint32_t rawBlockCount, uint32_t rleBlockCount, uint32_t cmpBlockCount);
+
+/**
+ *  @brief      Specifies the total decoded literal byte count and sequence count.
+ *              When set, `zstdgpu_GetGpuMemoryRequirement` for stage 2 uses these counts instead of
+ *              reading from GPU counter readback, enabling stages 1 and 2 to be recorded into
+ *              the same command list without a CPU fence.
+ *              Can be called before or after `zstdgpu_SetupInputs*` functions.
+ */
+ZSTDGPU_API zstdgpu_Status zstdgpu_SetupBlockInfoConstants(zstdgpu_PerRequestContext inPerRequestContext, uint32_t literalsByteCount, uint32_t sequenceCount);
+
+/**
+ *  @brief      Returns 1 if a CPU readback/fence is required after the given stage before proceeding
+ *              to the next stage, 0 otherwise. Use this to determine whether to submit the command list
+ *              and wait for GPU idle between stages.
+ */
+ZSTDGPU_API uint32_t zstdgpu_IsReadbackRequired(zstdgpu_PerRequestContext inPerRequestContext, uint32_t stageIndex);
+
 ZSTDGPU_API zstdgpu_Status zstdgpu_GetGpuMemoryRequirement(uint32_t *outDefaultHeapByteCount, uint32_t *outUploadHeapByteCount, uint32_t *outReadbackHeapByteCount, uint32_t *outShaderVisibleDescriptorCount, zstdgpu_PerRequestContext inPerRequestContext, uint32_t stageIndex);
 
 ZSTDGPU_API zstdgpu_Status zstdgpu_SubmitWithExternalMemory(zstdgpu_PerRequestContext inPerRequestContext,

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -1736,10 +1736,16 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t initResou
     \
     ZSTDGPU_RW_TYPED_BUFFER_DECL(uint32_t, uint8_t              , UnCompressedFramesData        , 0)
 
-#define ZSTDGPU_SRT_LIST()                                                                                          \
-    ZSTDGPU_SRT(InitResources                           , ZSTDGPU_INIT_RESOURCES_SRT())                             \
-    ZSTDGPU_SRT(ParseFrames                             , ZSTDGPU_PARSE_FRAMES_SRT())                               \
-    ZSTDGPU_SRT(ParseCompressedBlocks                   , ZSTDGPU_PARSE_COMPRESSED_BLOCKS_SRT())                    \
+#define ZSTDGPU_SRT_LIST_STAGE0()                                                                                   \
+    ZSTDGPU_SRT(InitResources_S0                        , ZSTDGPU_INIT_RESOURCES_SRT())                             \
+    ZSTDGPU_SRT(ParseFrames_S0                          , ZSTDGPU_PARSE_FRAMES_SRT())
+
+#define ZSTDGPU_SRT_LIST_STAGE1()                                                                                   \
+    ZSTDGPU_SRT(InitResources_S1                        , ZSTDGPU_INIT_RESOURCES_SRT())                             \
+    ZSTDGPU_SRT(ParseFrames_S1                          , ZSTDGPU_PARSE_FRAMES_SRT())                               \
+    ZSTDGPU_SRT(ParseCompressedBlocks                   , ZSTDGPU_PARSE_COMPRESSED_BLOCKS_SRT())
+
+#define ZSTDGPU_SRT_LIST_STAGE2()                                                                                   \
     ZSTDGPU_SRT(InitFseTable                            , ZSTDGPU_INIT_FSE_TABLE_SRT())                             \
     ZSTDGPU_SRT(DecompressHuffmanWeights                , ZSTDGPU_DECOMPRESS_HUFFMAN_WEIGHTS_SRT())                 \
     ZSTDGPU_SRT(DecodeHuffmanWeights                    , ZSTDGPU_DECODE_HUFFMAN_WEIGHTS_SRT())                     \
@@ -1751,6 +1757,11 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t initResou
     ZSTDGPU_SRT(MemsetMemcpy                            , ZSTDGPU_MEMSET_MEMCPY_SRT())                              \
     ZSTDGPU_SRT(ExecuteSequences                        , ZSTDGPU_EXECUTE_SEQUENCES_SRT())                          \
     ZSTDGPU_SRT(ComputeDestSequenceOffsets              , ZSTDGPU_COMPUTE_DEST_SEQUENCE_OFFSETS_SRT())
+
+#define ZSTDGPU_SRT_LIST()                                                                                          \
+    ZSTDGPU_SRT_LIST_STAGE0()                                                                                       \
+    ZSTDGPU_SRT_LIST_STAGE1()                                                                                       \
+    ZSTDGPU_SRT_LIST_STAGE2()
 
 #define ZSTDGPU_RO_RAW_BUFFER_DECL(type, name, index)                               ZSTDGPU_RO_RAW_BUFFER(type)                     in##name;
 

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -40,7 +40,7 @@
 #include <xmem.h>
 #endif
 
-#define D3D12AID_CMD_QUEUE_LATENCY_FRAME_MAX_COUNT 2
+#define D3D12AID_CMD_QUEUE_LATENCY_FRAME_MAX_COUNT 3
 #define D3D12AID_MAPPED_BUFFER_LATENCY_FRAME_MAX_COUNT 1
 #include <d3d12aid.h>
 
@@ -918,6 +918,8 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
 #endif
 
     bool extMem = false;
+    bool blkCnt = false;
+    bool seqCnt = false;
     bool chkGpu = false;
     bool chkCpu = false;
     bool simGpu = false;
@@ -1030,6 +1032,15 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
                 {
                     extMem = true;
                 }
+                else if (0 == wcscmp(argv[argi], L"--blk-cnt"))
+                {
+                    blkCnt = true;
+                }
+                else if (0 == wcscmp(argv[argi], L"--seq-cnt"))
+                {
+                    seqCnt = true;
+                    blkCnt = true; // --seq-cnt implies --blk-cnt
+                }
                 else if (0 == wcscmp(argv[argi], L"--prf-lvl"))
                 {
                     nextPrfLevel = true;
@@ -1061,6 +1072,8 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
                 debugPrint(L"\t--d3d-gfx                 [Optional] Enables D3D12 Graphics queue (DIRECT), otherwise COMPUTE (by default).\n");
                 debugPrint(L"\t--run-cnt <count>         [Optional] The number of times to repeat the experiment.\n");
                 debugPrint(L"\t--ext-mem                 [Optional] Enables external heaps so the library doesn't create them.\n");
+                debugPrint(L"\t--blk-cnt                 [Optional] Uses SetupFrameInfoConstants path (user-specified block counts from CPU pre-scan).\n");
+                debugPrint(L"\t--seq-cnt                 [Optional] Also uses SetupBlockInfoConstants (implies --blk-cnt). Merges all stages into single submission.\n");
                 debugPrint(L"\t--prf-lvl <0, 1, 2>       [Optional] Chooses the level of profiling: 0 - overall bandwidth in GB/s, 1 - stage cost, 2 - internal pass cost.\n");
                 debugPrint(L"\t--idx-{min,max} <number>  [Optional] Chooses the {minimal, maximal} index of the frame to decompress in multi-frame .zst file. Both values are clamped to the number of available frames.\n");
                 if (badArg)
@@ -1306,6 +1319,16 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
         defaultUploadCallbackUserData[1] = (void *)zstdInFrameRefs;
         zstdgpu_SetupInputsAsFramesInCpuMemory(&stageCount, perRequestContext, fbInfo.frameCount, zstdDataSize, zstdgpu_DefaultUploadCallback, defaultUploadCallbackUserData);
     }
+    if (blkCnt)
+    {
+        zstdgpu_SetupFrameInfoConstants(perRequestContext, fbInfo.rawBlockCount, fbInfo.rleBlockCount, fbInfo.cmpBlockCount);
+        if (seqCnt)
+        {
+            zstdgpu_CountLiteralAndSequenceInfo blkInfo;
+            zstdgpu_CountCompressedLiteralsAndSequences(&blkInfo, zstdInFrameRefs, fbInfo.frameCount, zstdData, zstdCompressedFramesMemorySizeInBytes);
+            zstdgpu_SetupBlockInfoConstants(perRequestContext, blkInfo.compressedLiteralsByteCount, blkInfo.sequenceCount);
+        }
+    }
     zstdgpu_SetupOutputs(perRequestContext, zstdUnCompressedFramesMemory.bufGpu, zstdUnCompressedFramesMemorySizeInBytes, zstdUnCompressedFramesRefs.bufGpu, fbInfo.frameCount);
 
     ID3D12Heap *readbackHeap[3] = { NULL, NULL, NULL };
@@ -1422,7 +1445,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
                             zstdgpu_SubmitWithExternalMemory(perRequestContext, stageIndex, cmdList, defaultHeap[stageIndex], 0, uploadHeap[stageIndex], 0, readbackHeap[stageIndex], 0, descriptorHeap[stageIndex], 0);
                         );
 
-                        if (stageIndex < 2)
+                        if (stageIndex < 2 && zstdgpu_IsReadbackRequired(perRequestContext, stageIndex))
                         {
                             d3d12aid_Timestamp_PushScope(*ReadbackTimestamp[stageIndex], timestamps, cmdList,
                                 d3d12aid_CmdQueue_SubmitCmdList(&cmdQueue, 0);
@@ -1434,29 +1457,23 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
                 }
                 else
                 {
-                    d3d12aid_Timestamp_PushScope(Stage0_Stamp, timestamps, cmdList,
-                        zstdgpu_SubmitWithInteralMemory(perRequestContext, 0, cmdList);
-                    );
+                    uint32_t *const StageTimestampInt[3] = { &Stage0_Stamp, &Stage1_Stamp, &Stage2_Stamp };
+                    uint32_t *const ReadbackTimestampInt[2] = { &Readback0_Stamp, &Readback1_Stamp };
+                    for (uint32_t stageIndex = 0; stageIndex < 3; ++stageIndex)
+                    {
+                        d3d12aid_Timestamp_PushScope(*StageTimestampInt[stageIndex], timestamps, cmdList,
+                            zstdgpu_SubmitWithInteralMemory(perRequestContext, stageIndex, cmdList);
+                        );
 
-                    d3d12aid_Timestamp_PushScope(Readback0_Stamp, timestamps, cmdList,
-                        d3d12aid_CmdQueue_SubmitCmdList(&cmdQueue, 0);
-                        d3d12aid_CmdQueue_CpuWaitForGpuIdle(&cmdQueue);
-                        cmdList = d3d12aid_CmdQueue_StartCmdList(&cmdQueue, 0/** cmdListId */);
-                    );
-
-                    d3d12aid_Timestamp_PushScope(Stage1_Stamp, timestamps, cmdList,
-                        zstdgpu_SubmitWithInteralMemory(perRequestContext, 1, cmdList);
-                    );
-
-                    d3d12aid_Timestamp_PushScope(Readback1_Stamp, timestamps, cmdList,
-                        d3d12aid_CmdQueue_SubmitCmdList(&cmdQueue, 0);
-                        d3d12aid_CmdQueue_CpuWaitForGpuIdle(&cmdQueue);
-                        cmdList = d3d12aid_CmdQueue_StartCmdList(&cmdQueue, 0/** cmdListId */);
-                    );
-
-                    d3d12aid_Timestamp_PushScope(Stage2_Stamp, timestamps, cmdList,
-                        zstdgpu_SubmitWithInteralMemory(perRequestContext, 2, cmdList);
-                    );
+                        if (stageIndex < 2 && zstdgpu_IsReadbackRequired(perRequestContext, stageIndex))
+                        {
+                            d3d12aid_Timestamp_PushScope(*ReadbackTimestampInt[stageIndex], timestamps, cmdList,
+                                d3d12aid_CmdQueue_SubmitCmdList(&cmdQueue, 0);
+                                d3d12aid_CmdQueue_CpuWaitForGpuIdle(&cmdQueue);
+                                cmdList = d3d12aid_CmdQueue_StartCmdList(&cmdQueue, 0/** cmdListId */);
+                            );
+                        }
+                    }
                 }
                 {
                     D3D12_RESOURCE_BARRIER barrier;

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -1091,7 +1091,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
         debugPrint(L"[INFO] Loaded '%s' -- %u bytes.\n", zstFilePath, zstdDataSize);
     }
 
-    zstdgpu_CountFramesAndBlocksInfo fbInfo;
+    zstdgpu_CountFramesAndBlocksInfo fbInfo = {};
     zstdgpu_CountFramesAndBlocks(&fbInfo, zstdData, zstdCompressedFramesMemorySizeInBytes, zstdDataSize);
 
     zstdgpu_FrameInfo *zstdFrameInfo = (zstdgpu_FrameInfo *)malloc(sizeof(zstdgpu_FrameInfo) * fbInfo.frameCount);

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -1104,7 +1104,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
         debugPrint(L"[INFO] Loaded '%s' -- %u bytes.\n", zstFilePath, zstdDataSize);
     }
 
-    zstdgpu_CountFramesAndBlocksInfo fbInfo = {};
+    zstdgpu_CountFramesAndBlocksInfo fbInfo;
     zstdgpu_CountFramesAndBlocks(&fbInfo, zstdData, zstdCompressedFramesMemorySizeInBytes, zstdDataSize);
 
     zstdgpu_FrameInfo *zstdFrameInfo = (zstdgpu_FrameInfo *)malloc(sizeof(zstdgpu_FrameInfo) * fbInfo.frameCount);

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -1326,7 +1326,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
         {
             zstdgpu_CountLiteralAndSequenceInfo blkInfo;
             zstdgpu_CountCompressedLiteralsAndSequences(&blkInfo, zstdInFrameRefs, fbInfo.frameCount, zstdData, zstdCompressedFramesMemorySizeInBytes);
-            zstdgpu_SetupBlockInfoConstants(perRequestContext, blkInfo.compressedLiteralsByteCount, blkInfo.sequenceCount);
+            zstdgpu_SetupBlockInfoConstants(perRequestContext, blkInfo.decodedLiteralsByteCount, blkInfo.sequenceCount);
         }
     }
     zstdgpu_SetupOutputs(perRequestContext, zstdUnCompressedFramesMemory.bufGpu, zstdUnCompressedFramesMemorySizeInBytes, zstdUnCompressedFramesRefs.bufGpu, fbInfo.frameCount);


### PR DESCRIPTION
This PR adds support for additional public APIs `zstdgpu_SetupFrameInfoConstants`, `zstdgpu_SetupBlockInfoConstants` and `zstdgpu_IsReadbackRequired`. The first two allow to setup additional information about compressed data that is required to compute the minimal required temporal memory size. Calling `zstdgpu_SetupFrameInfoConstants` with exact number of number of blocks of different kinds in all *zstd* frames allows to eliminate the readback after `stageIndex == 0`. Calling `zstdgpu_SetupBlockInfoConstants` while supplying 
- the total number of decompressed bytes in all compressed/treeless literals (in all *zstd* frames)
- the total number of sequences (in all *zstd* frames)

allows to eliminate the readback after `stageIndex == 1`. So when both functions are called on `zstdgpu_PerRequestContext` instance, both readbacks could be avoided and all stages could be submitted in a single `ExecuteCommandList`

The caveat so far is that supplied numbers aren't checked on GPU, so they have to be sufficient for all workloads to complete correctly.

This PR also adds new helper public API `zstdgpu_CountCompressedLiteralsAndSequences` that could be used to discover necessary parameters for `zstdgpu_SetupBlockInfoConstants` on CPU (parameters for `zstdgpu_SetupFrameInfoConstants` could be discovered on CPU with already existing `zstdgpu_CountFramesAndBlocks`)

The demo itself exposes new command line parameters:
- `--blk-cnt` to eliminate the first readback (by calling `zstdgpu_CountFramesAndBlocks`)
- `--seq-cnt` to eliminate both readbacks (by calling `zstdgpu_CountCompressedLiteralsAndSequences` and enabling `--blk-cnt`)
