### PR TITLE
ZstdGpuMemsetMemcpy: Increase threadgroup size and binary-search scalarization optimizations.

### DIFF
--- a/zstd/zstdgpu/Shaders/ZstdGpuMemsetMemcpy.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuMemsetMemcpy.hlsl
@@ -39,7 +39,7 @@ StructuredBuffer<zstdgpu_OffsetAndSize> ZstdInBlocksRefsTyped               : re
 
 StructuredBuffer<uint32_t>              ZstdInGlobalBlockIndexTyped         : register(t7);
 
-groupshared uint32_t lds[kzstdgpu_TgSizeX_MemsetMemcpy];
+groupshared uint32_t GS_GroupLeaderBlockIdx;
 
 inline void GetDestinationInfo(uint32_t blockIdx,
                                uint32_t i,
@@ -91,13 +91,21 @@ void main(uint2 groupId : SV_GroupId, uint threadIdInGroup : SV_GroupThreadId)
     if (threadIdInGroup == 0)
     {
         const uint32_t groupLeaderBlockIdx = zstdgpu_BinarySearch(ZstdInBlockSizePrefixTyped, 0, Constants.blockCount, scaledGroupId + 0);
-        lds[0] = groupLeaderBlockIdx;
+        GS_GroupLeaderBlockIdx = groupLeaderBlockIdx;
     }
     GroupMemoryBarrierWithGroupSync();
-    const uint32_t groupLeaderBlockIdx = WaveReadLaneFirst(lds[0]);
+    if (i >= Constants.workItemCount)
+        return;
 
-    uint32_t iEndForGroupLeaderBlock = uint32_t(-1);
-    [branch] if (Constants.blockCount >= 2)
+    const uint32_t groupLeaderBlockIdx = WaveReadLaneFirst(GS_GroupLeaderBlockIdx);
+
+    // We do a linear search within the tail, instead of a binary search.
+    // If we did the latter and we ensured we don't track zero-decompress-size Raw/RLE blocks,
+    // this could be min()'d with numActiveThreads:
+    const uint32_t tailBlockCount = Constants.blockCount - groupLeaderBlockIdx; // includes leader
+
+    uint32_t iEndForGroupLeaderBlock = uint32_t(-1); // "infinity"
+    [branch] if (tailBlockCount >= 2)
     {
         iEndForGroupLeaderBlock = ZstdInBlockSizePrefixTyped[groupLeaderBlockIdx + 1];
     }
@@ -110,37 +118,28 @@ void main(uint2 groupId : SV_GroupId, uint threadIdInGroup : SV_GroupThreadId)
     // The else path can handle any case, but try to pass a uniform blockIdx to GetDestinationInfo.
     if (iEndForGroupLeaderBlock >= scaledGroupId + numActiveThreads)
     {
-        if (i >= Constants.workItemCount)
-            return;
-
         GetDestinationInfo(groupLeaderBlockIdx, i, blockRef, byteIdx, dstFrameOffsetAndSize, dstBlockOffset);
     }
     else
     {
-        // After using SMEM to narrow down the block range, do one VMEM load per-wave into LDS.
-        // One VMEM load should be sufficient since we only tracked nonzero-decompressed-size RLE/Raw blocks in ParseFrame().
-        lds[threadIdInGroup] = ZstdInBlockSizePrefixTyped[zstdgpu_MinU32(groupLeaderBlockIdx + threadIdInGroup, Constants.blockCount - 1)];
-        GroupMemoryBarrierWithGroupSync();
-        if (i >= Constants.workItemCount)
-            return;
-
-        const uint32_t numActiveBlocks = zstdgpu_MinU32(Constants.blockCount - groupLeaderBlockIdx, numActiveThreads);
-        uint32_t blockIdx;
-        // Instead of a binary search, do a linear search under the assumption it should usually have few iterations.
-        // Find leftmost interval such that (i >= lds[r] && i < lds[r + 1]).
-        // We already know i >= lds[0] (since that is true for the i of the group leader).
+        // Instead of a binary search, do a linear search under the assumption it should usually have few iterations
+        // from the start of the tail.
         uint32_t intervalEnd = iEndForGroupLeaderBlock;
-        for (uint32_t r = 0;; ++r)
+        uint32_t r = 1; // index of interval _end_ relative to group leader index
+        for (;;)
         {
-            const uint32_t nextIterEnd = lds[(r + 2u) % kzstdgpu_TgSizeX_MemsetMemcpy];
-            if (r == numActiveBlocks - 1 || i < intervalEnd)
+            if (i < intervalEnd)
             {
-                blockIdx = groupLeaderBlockIdx + r;
                 break;
             }
-            intervalEnd = nextIterEnd;
+            ++r;
+            if (r >= tailBlockCount)
+            {
+                break;
+            }
+            intervalEnd = ZstdInBlockSizePrefixTyped[groupLeaderBlockIdx + r];
         }
-
+        const uint32_t blockIdx = groupLeaderBlockIdx + (r - 1);
         GetDestinationInfo(blockIdx, i, blockRef, byteIdx, dstFrameOffsetAndSize, dstBlockOffset);
     }
 

--- a/zstd/zstdgpu/Shaders/ZstdGpuMemsetMemcpy.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuMemsetMemcpy.hlsl
@@ -62,21 +62,35 @@ void main(uint2 groupId : SV_GroupId, uint i : SV_GroupThreadId)
         globalBlockGlobalOffset = ZstdInBlockSizePrefix[globalBlockIdx - 1];
     }
 
-    const uint32_t frameIdx = zstdgpu_BinarySearch(ZstdInPerFrameBlockCountAll, 0, Constants.frameCount, globalBlockIdx);
+    zstdgpu_OffsetAndSize dstFrameOffsetAndSize;
+    uint32_t dstBlockOffset;
 
-    const uint32_t frameFirstGlobalBlockIdx = ZstdInPerFrameBlockCountAll[frameIdx];
-
-    uint32_t frameFirstBlockGlobalOffset = 0;
-    [branch] if (frameFirstGlobalBlockIdx > 0)
-    {
-        frameFirstBlockGlobalOffset = ZstdInBlockSizePrefix[frameFirstGlobalBlockIdx - 1];
+    #define GET_FRAME_INFO(optGlobalBlockIdx) {                                                                                 \
+        const uint32_t frameIdx = zstdgpu_BinarySearch(ZstdInPerFrameBlockCountAll, 0, Constants.frameCount, optGlobalBlockIdx);\
+        const uint32_t frameFirstGlobalBlockIdx = ZstdInPerFrameBlockCountAll[frameIdx];                    \
+        uint32_t frameFirstBlockGlobalOffset = 0;                                                           \
+        [branch] if (frameFirstGlobalBlockIdx > 0)                                                          \
+        {                                                                                                   \
+            frameFirstBlockGlobalOffset = ZstdInBlockSizePrefix[frameFirstGlobalBlockIdx - 1];              \
+        }                                                                                                   \
+        const uint32_t frameRelativeBlockOffset = globalBlockGlobalOffset - frameFirstBlockGlobalOffset;    \
+        dstFrameOffsetAndSize = ZstdInUnCompressedFramesRefs[frameIdx];                                     \
+        dstBlockOffset = dstFrameOffsetAndSize.offs + frameRelativeBlockOffset;                             \
     }
 
-    const uint32_t frameRelativeBlockOffset = globalBlockGlobalOffset - frameFirstBlockGlobalOffset;
+    // Detect the (likely) case all threads store within the same block, and if so use SMEM to do the frame lookup.
+    // Waterfall loop instead of if/else might be better.
+    if (WaveActiveAllEqual(globalBlockIdx))
+    {
+        const uint32_t uniformGlobalBlockIdx = WaveReadLaneFirst(globalBlockIdx);
+        GET_FRAME_INFO(uniformGlobalBlockIdx);
+    }
+    else
+    {
+        GET_FRAME_INFO(globalBlockIdx);
+    }
 
-    const zstdgpu_OffsetAndSize dstFrameOffsetAndSize = ZstdInUnCompressedFramesRefs[frameIdx];
-
-    const uint32_t dstBlockOffset = dstFrameOffsetAndSize.offs + frameRelativeBlockOffset;
+    #undef GET_FRAME_INFO
 
     if (byteIdx >= dstFrameOffsetAndSize.size)
         return;

--- a/zstd/zstdgpu/Shaders/ZstdGpuMemsetMemcpy.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuMemsetMemcpy.hlsl
@@ -39,20 +39,19 @@ StructuredBuffer<zstdgpu_OffsetAndSize> ZstdInBlocksRefsTyped               : re
 
 StructuredBuffer<uint32_t>              ZstdInGlobalBlockIndexTyped         : register(t7);
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=4), UAV(u0, numDescriptors=1)), SRV(t4), SRV(t5), SRV(t6), SRV(t7), RootConstants(b0, num32BitConstants=5)")]
-[numthreads(kzstdgpu_TgSizeX_MemsetMemcpy, 1, 1)]
-void main(uint2 groupId : SV_GroupId, uint i : SV_GroupThreadId)
+groupshared uint32_t lds[kzstdgpu_TgSizeX_MemsetMemcpy];
+
+inline void GetDestinationInfo(uint32_t blockIdx,
+                               uint32_t i,
+                               // These are really just `out`:
+                               ZSTDGPU_PARAM_INOUT(zstdgpu_OffsetAndSize) blockRef,
+                               ZSTDGPU_PARAM_INOUT(uint32_t) byteIdx,
+                               ZSTDGPU_PARAM_INOUT(zstdgpu_OffsetAndSize) dstFrameOffsetAndSize,
+                               ZSTDGPU_PARAM_INOUT(uint32_t) dstBlockOffset)
 {
-    i += zstdgpu_ConvertTo32BitGroupId(groupId, Constants.tgOffset) * kzstdgpu_TgSizeX_MemsetMemcpy;
+    blockRef = ZstdInBlocksRefsTyped[blockIdx];
 
-    if (i >= Constants.workItemCount)
-        return;
-
-    const uint32_t blockIdx = zstdgpu_BinarySearch(ZstdInBlockSizePrefixTyped, 0, Constants.blockCount, i);
-
-    const zstdgpu_OffsetAndSize blockRef = ZstdInBlocksRefsTyped[blockIdx];
-
-    const uint32_t byteIdx = i - ZstdInBlockSizePrefixTyped[blockIdx];
+    byteIdx = i - ZstdInBlockSizePrefixTyped[blockIdx];
 
     const uint32_t globalBlockIdx = ZstdInGlobalBlockIndexTyped[blockIdx];
 
@@ -62,36 +61,88 @@ void main(uint2 groupId : SV_GroupId, uint i : SV_GroupThreadId)
         globalBlockGlobalOffset = ZstdInBlockSizePrefix[globalBlockIdx - 1];
     }
 
+    const uint32_t frameIdx = zstdgpu_BinarySearch(ZstdInPerFrameBlockCountAll, 0, Constants.frameCount, globalBlockIdx);
+
+    const uint32_t frameFirstGlobalBlockIdx = ZstdInPerFrameBlockCountAll[frameIdx];
+
+    uint32_t frameFirstBlockGlobalOffset = 0;
+    [branch] if (frameFirstGlobalBlockIdx > 0)
+    {
+        frameFirstBlockGlobalOffset = ZstdInBlockSizePrefix[frameFirstGlobalBlockIdx - 1];
+    }
+
+    const uint32_t frameRelativeBlockOffset = globalBlockGlobalOffset - frameFirstBlockGlobalOffset;
+
+    dstFrameOffsetAndSize = ZstdInUnCompressedFramesRefs[frameIdx];
+
+    dstBlockOffset = dstFrameOffsetAndSize.offs + frameRelativeBlockOffset;
+}
+
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=4), UAV(u0, numDescriptors=1)), SRV(t4), SRV(t5), SRV(t6), SRV(t7), RootConstants(b0, num32BitConstants=5)")]
+[numthreads(kzstdgpu_TgSizeX_MemsetMemcpy, 1, 1)]
+void main(uint2 groupId : SV_GroupId, uint threadIdInGroup : SV_GroupThreadId)
+{
+    const uint32_t scaledGroupId = zstdgpu_ConvertTo32BitGroupId(groupId, Constants.tgOffset) * kzstdgpu_TgSizeX_MemsetMemcpy;
+    const uint32_t i = scaledGroupId + threadIdInGroup;
+    const uint32_t numActiveThreads = zstdgpu_MinU32(Constants.workItemCount - scaledGroupId, kzstdgpu_TgSizeX_MemsetMemcpy);
+
+    // There are likely much fewer blocks this threadgroup will write than kzstdgpu_TgSizeX_MemsetMemcpy, and commonly a single block.
+    // Do most of the work via scalar instructions.
+    if (threadIdInGroup == 0)
+    {
+        const uint32_t groupLeaderBlockIdx = zstdgpu_BinarySearch(ZstdInBlockSizePrefixTyped, 0, Constants.blockCount, scaledGroupId + 0);
+        lds[0] = groupLeaderBlockIdx;
+    }
+    GroupMemoryBarrierWithGroupSync();
+    const uint32_t groupLeaderBlockIdx = WaveReadLaneFirst(lds[0]);
+
+    uint32_t iEndForGroupLeaderBlock = uint32_t(-1);
+    [branch] if (Constants.blockCount >= 2)
+    {
+        iEndForGroupLeaderBlock = ZstdInBlockSizePrefixTyped[groupLeaderBlockIdx + 1];
+    }
+
+    zstdgpu_OffsetAndSize blockRef;
+    uint32_t byteIdx;
     zstdgpu_OffsetAndSize dstFrameOffsetAndSize;
     uint32_t dstBlockOffset;
 
-    #define GET_FRAME_INFO(optGlobalBlockIdx) {                                                                                 \
-        const uint32_t frameIdx = zstdgpu_BinarySearch(ZstdInPerFrameBlockCountAll, 0, Constants.frameCount, optGlobalBlockIdx);\
-        const uint32_t frameFirstGlobalBlockIdx = ZstdInPerFrameBlockCountAll[frameIdx];                    \
-        uint32_t frameFirstBlockGlobalOffset = 0;                                                           \
-        [branch] if (frameFirstGlobalBlockIdx > 0)                                                          \
-        {                                                                                                   \
-            frameFirstBlockGlobalOffset = ZstdInBlockSizePrefix[frameFirstGlobalBlockIdx - 1];              \
-        }                                                                                                   \
-        const uint32_t frameRelativeBlockOffset = globalBlockGlobalOffset - frameFirstBlockGlobalOffset;    \
-        dstFrameOffsetAndSize = ZstdInUnCompressedFramesRefs[frameIdx];                                     \
-        dstBlockOffset = dstFrameOffsetAndSize.offs + frameRelativeBlockOffset;                             \
-    }
-
-    // Detect the (likely) case all threads store within the same block, and if so use SMEM to do the frame lookup.
-    // Waterfall loop instead of if/else might be better.
-    if (WaveActiveAllEqual(globalBlockIdx))
+    // The else path can handle any case, but try to pass a uniform blockIdx to GetDestinationInfo.
+    if (iEndForGroupLeaderBlock >= scaledGroupId + numActiveThreads)
     {
-        const uint32_t uniformGlobalBlockIdx = WaveReadLaneFirst(globalBlockIdx);
-        GET_FRAME_INFO(uniformGlobalBlockIdx);
+        if (i >= Constants.workItemCount)
+            return;
+
+        GetDestinationInfo(groupLeaderBlockIdx, i, blockRef, byteIdx, dstFrameOffsetAndSize, dstBlockOffset);
     }
     else
     {
-        GET_FRAME_INFO(globalBlockIdx);
+        // After using SMEM to narrow down the block range, do one VMEM load per-wave into LDS,
+        // which should be sufficient since we only kept nonzero-size RLE/Raw blocks.
+        lds[threadIdInGroup] = ZstdInBlockSizePrefixTyped[zstdgpu_MinU32(groupLeaderBlockIdx + threadIdInGroup, Constants.blockCount - 1)];
+        GroupMemoryBarrierWithGroupSync();
+        if (i >= Constants.workItemCount)
+            return;
+
+        const uint32_t numActiveBlocks = zstdgpu_MinU32(Constants.blockCount - groupLeaderBlockIdx, numActiveThreads);
+        uint32_t blockIdx;
+        // Instead of a binary search or linear search from the end, this does a linear search from the beginning.
+        // This has a more complicated loop exit test then linear search from end, but assuming block sizes are
+        // large compared to kzstdgpu_TgSizeX_MemsetMemcpy, the loop should iterate much less times.
+        for (uint32_t r = 0;; ++r)
+        {
+            if ((r == numActiveBlocks - 1) ||
+                (i >= lds[r] && i < lds[r + 1]))
+            {
+                blockIdx = groupLeaderBlockIdx + r;
+                break;
+            }
+        }
+
+        GetDestinationInfo(blockIdx, i, blockRef, byteIdx, dstFrameOffsetAndSize, dstBlockOffset);
     }
 
-    #undef GET_FRAME_INFO
-
+    // Shouldn't be needed for valid data since already checked Constants.workItemCount?
     if (byteIdx >= dstFrameOffsetAndSize.size)
         return;
 

--- a/zstd/zstdgpu/Shaders/ZstdGpuMemsetMemcpy.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuMemsetMemcpy.hlsl
@@ -117,8 +117,8 @@ void main(uint2 groupId : SV_GroupId, uint threadIdInGroup : SV_GroupThreadId)
     }
     else
     {
-        // After using SMEM to narrow down the block range, do one VMEM load per-wave into LDS,
-        // which should be sufficient since we only kept nonzero-size RLE/Raw blocks.
+        // After using SMEM to narrow down the block range, do one VMEM load per-wave into LDS.
+        // One VMEM load should be sufficient since we only tracked nonzero-decompressed-size RLE/Raw blocks in ParseFrame().
         lds[threadIdInGroup] = ZstdInBlockSizePrefixTyped[zstdgpu_MinU32(groupLeaderBlockIdx + threadIdInGroup, Constants.blockCount - 1)];
         GroupMemoryBarrierWithGroupSync();
         if (i >= Constants.workItemCount)
@@ -126,17 +126,19 @@ void main(uint2 groupId : SV_GroupId, uint threadIdInGroup : SV_GroupThreadId)
 
         const uint32_t numActiveBlocks = zstdgpu_MinU32(Constants.blockCount - groupLeaderBlockIdx, numActiveThreads);
         uint32_t blockIdx;
-        // Instead of a binary search or linear search from the end, this does a linear search from the beginning.
-        // This has a more complicated loop exit test then linear search from end, but assuming block sizes are
-        // large compared to kzstdgpu_TgSizeX_MemsetMemcpy, the loop should iterate much less times.
+        // Instead of a binary search, do a linear search under the assumption it should usually have few iterations.
+        // Find leftmost interval such that (i >= lds[r] && i < lds[r + 1]).
+        // We already know i >= lds[0] (since that is true for the i of the group leader).
+        uint32_t intervalEnd = iEndForGroupLeaderBlock;
         for (uint32_t r = 0;; ++r)
         {
-            if ((r == numActiveBlocks - 1) ||
-                (i >= lds[r] && i < lds[r + 1]))
+            const uint32_t nextIterEnd = lds[(r + 2u) % kzstdgpu_TgSizeX_MemsetMemcpy];
+            if (r == numActiveBlocks - 1 || i < intervalEnd)
             {
                 blockIdx = groupLeaderBlockIdx + r;
                 break;
             }
+            intervalEnd = nextIterEnd;
         }
 
         GetDestinationInfo(blockIdx, i, blockRef, byteIdx, dstFrameOffsetAndSize, dstBlockOffset);

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -1231,15 +1231,6 @@ static void zstdgpu_ShaderEntry_ParseCompressedBlocks(ZSTDGPU_PARAM_INOUT(zstdgp
     }
 
 #ifdef __hlsl_dx_compiler
-
-    // Setup default FSE-indices we are going to propagate
-    uint32_t4 fseTableIndices = uint32_t4(
-        outBlockData.fseTableIndexHufW,
-        outBlockData.fseTableIndexLLen,
-        outBlockData.fseTableIndexOffs,
-        outBlockData.fseTableIndexMLen
-    );
-
     const uint32_t blockSize = min(WaveGetLaneCount(), kzstdgpu_TgSizeX_ParseCompressedBlocks);
 
     const uint32_t thisBlockIndex = WaveReadLaneFirst(threadId / blockSize);
@@ -1489,7 +1480,7 @@ static void zstdgpu_ShaderEntry_ParseCompressedBlocks(ZSTDGPU_PARAM_INOUT(zstdgp
     static uint32_t lastOffsIndex = kzstdgpu_FseProbTableIndex_Unused;
     static uint32_t lastMLenIndex = kzstdgpu_FseProbTableIndex_Unused;
 
-    #define PROPAGATE_FSE_HUF_INDEX(name) \
+    #define CPU_PROPAGATE_FSE_INDEX(name) \
         if (outBlockData.fseTableIndex##name < kzstdgpu_FseProbTableIndex_Repeat)    \
         {                                                                           \
             last##name##Index = outBlockData.fseTableIndex##name;                   \
@@ -1499,12 +1490,12 @@ static void zstdgpu_ShaderEntry_ParseCompressedBlocks(ZSTDGPU_PARAM_INOUT(zstdgp
             outBlockData.fseTableIndex##name = last##name##Index;                   \
         }
 
-    PROPAGATE_FSE_HUF_INDEX(HufW)
-    PROPAGATE_FSE_HUF_INDEX(LLen)
-    PROPAGATE_FSE_HUF_INDEX(Offs)
-    PROPAGATE_FSE_HUF_INDEX(MLen)
+    CPU_PROPAGATE_FSE_INDEX(HufW)
+    CPU_PROPAGATE_FSE_INDEX(LLen)
+    CPU_PROPAGATE_FSE_INDEX(Offs)
+    CPU_PROPAGATE_FSE_INDEX(MLen)
 
-    #undef PROPAGATE_FSE_HUF_INDEX
+    #undef CPU_PROPAGATE_FSE_INDEX
 #endif
 
     if (0 != seqCount)

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -200,7 +200,9 @@ static inline uint32_t zstdgpu_OrderedAppendIndex(ZSTDGPU_RW_BUFFER_GLC(uint32_t
     return zstdgpu_GlobalExclusivePrefixSum(lookback, WavePrefixSum(threadAppendCnt), threadAppendCnt, globalThreadIdx, tgroupThreadCnt);
 }
 
-static inline uint32_t zstdgpu_BinarySearch(ZSTDGPU_RO_BUFFER(uint32_t) sortedSequence, uint32_t start, uint32_t count, uint32_t threadId)
+// Returns leftmost index i such that inserting target _after_ i would keep the array sorted ascending.
+// Assumes such an i in [start, start + count) exists.
+static inline uint32_t zstdgpu_BinarySearch(ZSTDGPU_RO_BUFFER(uint32_t) sortedSequence, uint32_t start, uint32_t count, uint32_t target)
 {
     uint32_t rangeBase = start;
     uint32_t rangeSize = count;
@@ -211,7 +213,7 @@ static inline uint32_t zstdgpu_BinarySearch(ZSTDGPU_RO_BUFFER(uint32_t) sortedSe
         const uint32_t rangeNext = rangeBase + rangeTest;
 
         const uint32_t value = sortedSequence[rangeNext];
-        rangeBase = threadId < value ? rangeBase : rangeNext;
+        rangeBase = target < value ? rangeBase : rangeNext;
         rangeSize -= rangeTest;
     }
 
@@ -418,6 +420,13 @@ static inline void zstdgpu_ShaderEntry_ParseFrame(ZSTDGPU_PARAM_INOUT(zstdgpu_Fr
         lastBlock = zstdgpu_Forward_BitBuffer_GetNoRefill(bits, 1);
         const uint32_t blockType = zstdgpu_Forward_BitBuffer_GetNoRefill(bits, 2);
         const uint32_t blockSize = zstdgpu_Forward_BitBuffer_GetNoRefill(bits, 21);
+
+        // The main zstd decompressor seems to accept 0-size RLE and Raw blocks.
+        // ZstdGpuMemsetMemcpy.hlsl doesn't handle that so don't track them.
+        if (blockSize == 0)
+        {
+            continue;
+        }
 
         const bool isRaw = 0 == blockType;
         const bool isRle = 1 == blockType;

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -436,14 +436,6 @@ static inline void zstdgpu_ShaderEntry_ParseFrame(ZSTDGPU_PARAM_INOUT(zstdgpu_Fr
             zstdgpu_Forward_BitBuffer_Skip(bits, blockSize);
         }
 
-        // The main zstd decompressor seems to accept zero-decompressed-size RLE and Raw blocks.
-        // ZstdGpuMemsetMemcpy.hlsl doesn't handle that so don't track them.
-        // For RLE blocks this needs to be after extracting the value byte from the stream.
-        if (blockSize == 0)
-        {
-            continue;
-        }
-
         if (0 != outputBlockInfo)
         {
             const uint32_t blockIndex = outFrameInfo.rawBlockStart

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -1240,6 +1240,15 @@ static void zstdgpu_ShaderEntry_ParseCompressedBlocks(ZSTDGPU_PARAM_INOUT(zstdgp
     }
 
 #ifdef __hlsl_dx_compiler
+
+    // Setup default FSE-indices we are going to propagate
+    uint32_t4 fseTableIndices = uint32_t4(
+        outBlockData.fseTableIndexHufW,
+        outBlockData.fseTableIndexLLen,
+        outBlockData.fseTableIndexOffs,
+        outBlockData.fseTableIndexMLen
+    );
+
     const uint32_t blockSize = min(WaveGetLaneCount(), kzstdgpu_TgSizeX_ParseCompressedBlocks);
 
     const uint32_t thisBlockIndex = WaveReadLaneFirst(threadId / blockSize);
@@ -1489,7 +1498,7 @@ static void zstdgpu_ShaderEntry_ParseCompressedBlocks(ZSTDGPU_PARAM_INOUT(zstdgp
     static uint32_t lastOffsIndex = kzstdgpu_FseProbTableIndex_Unused;
     static uint32_t lastMLenIndex = kzstdgpu_FseProbTableIndex_Unused;
 
-    #define CPU_PROPAGATE_FSE_INDEX(name) \
+    #define PROPAGATE_FSE_HUF_INDEX(name) \
         if (outBlockData.fseTableIndex##name < kzstdgpu_FseProbTableIndex_Repeat)    \
         {                                                                           \
             last##name##Index = outBlockData.fseTableIndex##name;                   \
@@ -1499,12 +1508,12 @@ static void zstdgpu_ShaderEntry_ParseCompressedBlocks(ZSTDGPU_PARAM_INOUT(zstdgp
             outBlockData.fseTableIndex##name = last##name##Index;                   \
         }
 
-    CPU_PROPAGATE_FSE_INDEX(HufW)
-    CPU_PROPAGATE_FSE_INDEX(LLen)
-    CPU_PROPAGATE_FSE_INDEX(Offs)
-    CPU_PROPAGATE_FSE_INDEX(MLen)
+    PROPAGATE_FSE_HUF_INDEX(HufW)
+    PROPAGATE_FSE_HUF_INDEX(LLen)
+    PROPAGATE_FSE_HUF_INDEX(Offs)
+    PROPAGATE_FSE_HUF_INDEX(MLen)
 
-    #undef CPU_PROPAGATE_FSE_INDEX
+    #undef PROPAGATE_FSE_HUF_INDEX
 #endif
 
     if (0 != seqCount)

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -200,8 +200,8 @@ static inline uint32_t zstdgpu_OrderedAppendIndex(ZSTDGPU_RW_BUFFER_GLC(uint32_t
     return zstdgpu_GlobalExclusivePrefixSum(lookback, WavePrefixSum(threadAppendCnt), threadAppendCnt, globalThreadIdx, tgroupThreadCnt);
 }
 
-// Returns leftmost index i such that inserting target _after_ i would keep the array sorted ascending.
-// Assumes such an i in [start, start + count) exists.
+// Given sorted ascending array A where A[i] is the beginning of an interval that ends (exclusive) at A[i+1] (or at "infinity" for i+1 == N),
+// finds assumed to exist index of interval that contains target.
 static inline uint32_t zstdgpu_BinarySearch(ZSTDGPU_RO_BUFFER(uint32_t) sortedSequence, uint32_t start, uint32_t count, uint32_t target)
 {
     uint32_t rangeBase = start;
@@ -421,13 +421,6 @@ static inline void zstdgpu_ShaderEntry_ParseFrame(ZSTDGPU_PARAM_INOUT(zstdgpu_Fr
         const uint32_t blockType = zstdgpu_Forward_BitBuffer_GetNoRefill(bits, 2);
         const uint32_t blockSize = zstdgpu_Forward_BitBuffer_GetNoRefill(bits, 21);
 
-        // The main zstd decompressor seems to accept 0-size RLE and Raw blocks.
-        // ZstdGpuMemsetMemcpy.hlsl doesn't handle that so don't track them.
-        if (blockSize == 0)
-        {
-            continue;
-        }
-
         const bool isRaw = 0 == blockType;
         const bool isRle = 1 == blockType;
         const bool isCmp = 2 == blockType;
@@ -441,6 +434,14 @@ static inline void zstdgpu_ShaderEntry_ParseFrame(ZSTDGPU_PARAM_INOUT(zstdgpu_Fr
         {
             blockOffs = zstdgpu_Forward_BitBuffer_GetByteOffset(bits);
             zstdgpu_Forward_BitBuffer_Skip(bits, blockSize);
+        }
+
+        // The main zstd decompressor seems to accept zero-decompressed-size RLE and Raw blocks.
+        // ZstdGpuMemsetMemcpy.hlsl doesn't handle that so don't track them.
+        // For RLE blocks this needs to be after extracting the value byte from the stream.
+        if (blockSize == 0)
+        {
+            continue;
         }
 
         if (0 != outputBlockInfo)

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -438,11 +438,7 @@ static const uint32_t kzstdgpu_TgSizeX_FinaliseSequenceOffsets = 64;
 static const uint32_t kzstdgpu_TgSizeX_FinaliseSequenceOffsets = 256;
 #endif
 
-#if defined(_GAMING_XBOX) || defined(__XBOX_SCARLETT) || defined(__XBOX_ONE)
 static const uint32_t kzstdgpu_TgSizeX_MemsetMemcpy = 64;
-#else
-static const uint32_t kzstdgpu_TgSizeX_MemsetMemcpy = 32;
-#endif
 
 #define ZSTDGPU_TG_COUNT(elemCount, tgSize) (((elemCount) + (tgSize) - 1) / (tgSize))
 


### PR DESCRIPTION
Increasing `kzstdgpu_TgSizeX_MemsetMemcpy` from 32 to 64 yields nice performance improvements on both an AMD 7900 XTX and an NV RTX 4080. Reasons for this on AMD may include going from wave32 to wave64, which can help in ways like the `s_clause` instruction can, and all waves (though still just one in this case, but it has more lanes) of a threadgroup are launched on the same compute-unit; each compute-unit has its own L0/K$, and it is likely adjacent threadgroups touch adjacent memory.

In the insects archive, the threadgroup size change alone nets between a 30-40% duration reduction on both GPUs; clocks were fixed at some non-specific frequency in both cases, but timings were fairly consistent.

Increasing the threadgroup size to 128 or 256 could further improve performance, but I decide to stop at 64 now, and that's what xbox seems to do.

---

The insects archive has 233 raw blocks that sum to 18,860,773 bytes. The second optimization ([f570ccb](https://github.com/microsoft/DirectStorage/pull/100/commits/f570ccb7a9147c92e2d6231c67916f234602abff)) in this PR tries to detect the (likely) case all lanes in a wave store within the same block (via `WaveActiveAllEqual(globalBlockIdx)`), and if so, does the frame lookup in a uniform context. This seems pretty neutral on RTX 4080, but on 7900 XTX it further reduces duration by about 38% on top of the threadgroup size change.

The last optimization then also tries to scalarize the first binary search too. This absorbs the previous optimization. This also seems pretty neutral on RTX 4080, but on 7900 XTX it seems about a 23% duration reduction on top of the previous change.

In total, all three changes net about a 70% duration reduction for the insects archive on 7900 XTX (at some low-ish fixed-clock frequency).

There's no rush for changes like these.