### PR TITLE
zstdgpu/guarded-no-readback-support: adds support for predication/skipping the rest of submission of GPU decompression pipeline in case if allocated buffers aren't sufficient in single submission mode

### DIFF
--- a/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
@@ -21,24 +21,36 @@
 RWStructuredBuffer<zstdgpu_Counters>  ZstdCounters     : register(u0);
 RWStructuredBuffer<uint32_t>          ZstdDispatchArgs : register(u1);
 RWStructuredBuffer<uint32_t>          ZstdDispatchCnts : register(u2);
+RWStructuredBuffer<uint32_t>          ZstdPredicate    : register(u3);
 
 struct UpdateDispatchArgsConsts
 {
     uint32_t decompressSequences_StreamsPerTG;
     uint32_t stage;
+
+    uint32_t cmpBlockCountMax;
+    uint32_t rawBlockCountMax;
+    uint32_t rleBlockCountMax;
+    uint32_t litByteCountMax;
+    uint32_t seqElemCountMax;
 };
 
 ConstantBuffer<UpdateDispatchArgsConsts> Consts : register(b0);
 
-[RootSignature("UAV(u0), UAV(u1), UAV(u2), RootConstants(b0, num32BitConstants=2)")]
+[RootSignature("UAV(u0), UAV(u1), UAV(u2), UAV(u3), RootConstants(b0, num32BitConstants=7)")]
 [numthreads(1, 1, 1)]
 void main()
 {
     if (Consts.stage == 0)
     {
         // Block-count dependent slots (valid after Stage 0 ParseFrames :: Count Blocks)
-        const uint32_t allBlockCount = ZstdCounters[0].Blocks_RAW + ZstdCounters[0].Blocks_RLE + ZstdCounters[0].Blocks_CMP;
         const uint32_t cmpBlockCount = ZstdCounters[0].Blocks_CMP;
+        const uint32_t rawBlockCount = ZstdCounters[0].Blocks_RAW;
+        const uint32_t rleBlockCount = ZstdCounters[0].Blocks_RLE;
+        const uint32_t allBlockCount = rawBlockCount
+                                     + rleBlockCount
+                                     + cmpBlockCount;
+
 
         // the arguments dependent on block counts/sizes -- these could be computed after ParseFrames
         zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_ComputePrefixSum,         cmpBlockCount,                            kzstdgpu_TgSizeX_PrefixSum_LiteralCount);
@@ -52,9 +64,20 @@ void main()
         zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_Memset_TableIndexLookback,  zstdgpu_GetHufFseTableIndexLookbackUInt32Count(cmpBlockCount),   kzstdgpu_TgSizeX_Memset);
         zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_Memset_LitStreamEnd,        cmpBlockCount + zstdgpu_GetLookbackBlockCount(cmpBlockCount),    kzstdgpu_TgSizeX_Memset);
         zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_Memset_AllBlockLookback,    zstdgpu_GetLookbackBlockCount(allBlockCount),                    kzstdgpu_TgSizeX_Memset);
+
+        const uint32_t predicateMask = 0
+                                     | (cmpBlockCount > Consts.cmpBlockCountMax ? (1u << 0u) : 0u)
+                                     | (rawBlockCount > Consts.rawBlockCountMax ? (1u << 1u) : 0u)
+                                     | (rleBlockCount > Consts.rleBlockCountMax ? (1u << 2u) : 0u);
+
+        ZstdPredicate[0] = predicateMask; // lower 32-bits of Stage 1 predicate
+        ZstdPredicate[2] = predicateMask; // lower 32-bits of Stage 2 predicate
     }
     else if (Consts.stage == 1)
     {
+        const uint32_t litByteCount = ZstdCounters[0].HUF_Streams_DecodedBytes;
+        const uint32_t seqElemCount = ZstdCounters[0].Seq_Streams_DecodedItems;
+
         // the arguments dependent on various streams counts that are part of compressed blocks -- these could be computed after ParseCompressedBlocks
         zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_FseHufW,                  ZstdCounters[0].FseHufW,                  1);
         zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_FseLLen,                  ZstdCounters[0].FseLLen,                  1);
@@ -76,6 +99,12 @@ void main()
 
         // Update derived counter field in Counters (kept for shader bounds checks)
         ZstdCounters[0].DecompressSequencesGroups = ZSTDGPU_TG_COUNT(ZstdCounters[0].Seq_Streams, Consts.decompressSequences_StreamsPerTG);
+
+        const uint32_t predicateMask = 0
+                                     | (litByteCount > Consts.litByteCountMax ? (1u << 3u) : 0u)
+                                     | (seqElemCount > Consts.seqElemCountMax ? (1u << 4u) : 0u);
+
+        ZstdPredicate[2] = ZstdPredicate[2] | predicateMask; // lower 32-bits of Stage 2 predicate
     }
     else
     {

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -1918,7 +1918,7 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         D3D12_RESOURCE_BARRIER barriers[8];
         uint32_t bc = 0;
 
-        // last written by [Init Resources :: Stage 0] and [InitResources :: Memset :: Stage 0]
+        // last written by [Init Resources :: Stage 0]
         // next written/atomically updated by [Parse Frames :: Count Blocks]
         setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.Counters);
         // last written by [InitResources :: Memset :: Stage 0]
@@ -2027,25 +2027,28 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [Readback Counters :: After Block Count] and [Parse Compressed Blocks]");
         D3D12_RESOURCE_BARRIER barriers[5];
+        uint32_t bc = 0;
         // last read by [Update Dispatch Args :: Stage 0]
         // next read by [Readback Counters :: After Block Count] or [Init Resources :: Stage 1]
         if (zstdgpu_IsReadbackRequired(req, 0))
         {
-            setResourceState(barriers, 0, req->resData.gpuOnly.Counters, UNORDERED_ACCESS, COPY_SOURCE);
+            setResourceState(barriers, bc ++, req->resData.gpuOnly.Counters, UNORDERED_ACCESS, COPY_SOURCE);
         }
         else
         {
-            setResourceUavSync(barriers, 0, req->resData.gpuOnly.Counters);
+            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.Counters);
         }
         // last written by [PrefixSum :: Block Counts]
         // next bound to [Parse Compressed Blocks] as UAV
-        setResourceUavSync(barriers, 1, req->resData.gpuOnly.PerFrameBlockCountCMP);
-        setResourceUavSync(barriers, 2, req->resData.gpuOnly.PerFrameBlockCountAll);
+        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountCMP);
+        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountAll);
         // last written by [Update Dispatch Args :: Stage 0]
         // next read by ExecuteIndirect calls as argument/count buffers
-        setResourceState(barriers, 3, req->resData.gpuOnly.DispatchArgs, UNORDERED_ACCESS, INDIRECT_ARGUMENT);
-        setResourceState(barriers, 4, req->resData.gpuOnly.DispatchCnts, UNORDERED_ACCESS, INDIRECT_ARGUMENT);
-        cmdList->ResourceBarrier(_countof(barriers), barriers);
+        setResourceState(barriers, bc ++, req->resData.gpuOnly.DispatchArgs, UNORDERED_ACCESS, INDIRECT_ARGUMENT);
+        setResourceState(barriers, bc ++, req->resData.gpuOnly.DispatchCnts, UNORDERED_ACCESS, INDIRECT_ARGUMENT);
+
+        ZSTDGPU_ASSERT(bc <= _countof(barriers));
+        cmdList->ResourceBarrier(bc, barriers);
         PIXEndEvent(cmdList);
     }
     if (zstdgpu_IsReadbackRequired(req, 0))
@@ -2226,40 +2229,42 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [Readback Counters :: After Block Parse] and [Update Dispatch Args] and [Compute `Per-Huffman Table` Literal Stream Count Prefix]");
         D3D12_RESOURCE_BARRIER barriers[11];
+        uint32_t bc = 0;
         // last written by [Parse Compressed Blocks]
         // next read by [Readback Counters :: After Block Parse] or [Update Dispatch Args]
         if (zstdgpu_IsReadbackRequired(req, 1))
         {
-            setResourceState(barriers, 0, req->resData.gpuOnly.Counters, UNORDERED_ACCESS, COPY_SOURCE);
+            setResourceState(barriers, bc ++, req->resData.gpuOnly.Counters, UNORDERED_ACCESS, COPY_SOURCE);
         }
         else
         {
-            setResourceUavSync(barriers, 0, req->resData.gpuOnly.Counters);
+            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.Counters);
         }
         // last written by [Parse Compressed Blocks]
         // next written/updated by [Compute `Per-Huffman Table` Literal Stream Count Prefix]
-        setResourceUavSync(barriers, 1, req->resData.gpuOnly.LitStreamEndPerHuffmanTable);
-        setResourceUavSync(barriers, 2, req->resData.gpuOnly.LitGroupEndPerHuffmanTable);
+        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.LitStreamEndPerHuffmanTable);
+        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.LitGroupEndPerHuffmanTable);
         // last written by [Parse Compressed Blocks]
         // next written/updated by [Decompress Sequences]
-        setResourceUavSync(barriers, 3, req->resData.gpuOnly.BlockSizePrefix);
+        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.BlockSizePrefix);
         // last written by [Parse Compressed Blocks]
         // next read by [Prefix Sequence Offsets]
-        setResourceUavToSrvSync(barriers, 4, req->resData.gpuOnly.PerFrameSeqStreamMinIdx);
+        setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.PerFrameSeqStreamMinIdx);
 
         // last written by [Init Resources :: Stage 1] with zero values to lookback data
         // next written by [Decompress Sequences] with encoded "final" offsets per block
-        setResourceUavSync(barriers, 5, req->resData.gpuOnly.PerSeqStreamFinalOffset1);
-        setResourceUavSync(barriers, 6, req->resData.gpuOnly.PerSeqStreamFinalOffset2);
-        setResourceUavSync(barriers, 7, req->resData.gpuOnly.PerSeqStreamFinalOffset3);
+        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerSeqStreamFinalOffset1);
+        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerSeqStreamFinalOffset2);
+        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerSeqStreamFinalOffset3);
         // last written by [Parse Compressed Blocks]
         // next read by [Finalise Sequence Offsets]
-        setResourceUavToSrvSync(barriers, 8, req->resData.gpuOnly.PerSeqStreamSeqStart);
+        setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.PerSeqStreamSeqStart);
         // last read by ExecuteIndirect as INDIRECT_ARGUMENT
         // next written by [Update Dispatch Args :: Stage 2]
-        setResourceState(barriers, 9, req->resData.gpuOnly.DispatchArgs, INDIRECT_ARGUMENT, UNORDERED_ACCESS);
-        setResourceState(barriers, 10, req->resData.gpuOnly.DispatchCnts, INDIRECT_ARGUMENT, UNORDERED_ACCESS);
-        cmdList->ResourceBarrier(_countof(barriers), barriers);
+        setResourceState(barriers, bc ++, req->resData.gpuOnly.DispatchArgs, INDIRECT_ARGUMENT, UNORDERED_ACCESS);
+        setResourceState(barriers, bc ++, req->resData.gpuOnly.DispatchCnts, INDIRECT_ARGUMENT, UNORDERED_ACCESS);
+        ZSTDGPU_ASSERT(bc <= _countof(barriers));
+        cmdList->ResourceBarrier(bc, barriers);
         PIXEndEvent(cmdList);
     }
     if (zstdgpu_IsReadbackRequired(req, 1))
@@ -2290,14 +2295,17 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [Compute `Per-Huffman Table` Literal Stream Count Prefix]");
         D3D12_RESOURCE_BARRIER barriers[3];
+        uint32_t bc = 0;
         // last written by [Update Dispatch Args]
         // next read by [Compute `Per-Huffman Table` Literal Stream Count Prefix] via ExecuteIndirect
-        setResourceState(barriers, 0, req->resData.gpuOnly.DispatchArgs, UNORDERED_ACCESS, INDIRECT_ARGUMENT);
-        setResourceState(barriers, 1, req->resData.gpuOnly.DispatchCnts, UNORDERED_ACCESS, INDIRECT_ARGUMENT);
+        setResourceState(barriers, bc ++, req->resData.gpuOnly.DispatchArgs, UNORDERED_ACCESS, INDIRECT_ARGUMENT);
+        setResourceState(barriers, bc ++, req->resData.gpuOnly.DispatchCnts, UNORDERED_ACCESS, INDIRECT_ARGUMENT);
         // last written by [Update Dispatch Args]
         // next read/written by [Compute `Per-Huffman Table` Literal Stream Count Prefix]
-        setResourceUavSync(barriers, 2, req->resData.gpuOnly.Counters);
-        cmdList->ResourceBarrier(_countof(barriers), barriers);
+        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.Counters);
+
+        ZSTDGPU_ASSERT(bc <= _countof(barriers));
+        cmdList->ResourceBarrier(bc, barriers);
         PIXEndEvent(cmdList);
     }
 

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -2267,15 +2267,7 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->ResourceBarrier(bc, barriers);
         PIXEndEvent(cmdList);
     }
-    if (zstdgpu_IsReadbackRequired(req, 1))
-    {
-        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Readback Counters :: After Block Parse]");
-        zstdgpu_PushReadback(Counters);
-        PIXEndEvent(cmdList);
-    }
-}
-void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandList *cmdList)
-{
+
     if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Update Dispatch Args]");
@@ -2309,6 +2301,16 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXEndEvent(cmdList);
     }
 
+    if (zstdgpu_IsReadbackRequired(req, 1))
+    {
+        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Readback Counters :: After Block Parse]");
+        zstdgpu_PushReadback(Counters);
+        PIXEndEvent(cmdList);
+    }
+}
+
+void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandList *cmdList)
+{
     if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Compute `Per-Huffman Table` Literal Stream Count Prefix]");

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -931,8 +931,8 @@ struct zstdgpu_PerRequestContextImpl
     uint32_t                zstdRleBlockCountMax;
     uint32_t                zstdCmpBlockCountMax;
 
-    uint32_t                zstdUncompressedLiteralsByteCount;
-    uint32_t                zstdUncompressedSequenceCount;
+    uint32_t                zstdUncompressedLitByteCountMax;
+    uint32_t                zstdUncompressedSeqElemCountMax;
 
     uint32_t                setupFlags;
 };
@@ -1175,8 +1175,8 @@ ZSTDGPU_ENUM(Status) zstdgpu_CreatePerRequestContext(zstdgpu_PerRequestContext *
         context->zstdRawBlockCountMax               = 0;
         context->zstdRleBlockCountMax               = 0;
         context->zstdCmpBlockCountMax               = 0;
-        context->zstdUncompressedLiteralsByteCount  = 0;
-        context->zstdUncompressedSequenceCount      = 0;
+        context->zstdUncompressedLitByteCountMax    = 0;
+        context->zstdUncompressedSeqElemCountMax    = 0;
         context->setupFlags = 0;
 
         *outPerRequestContext = context;
@@ -1360,8 +1360,8 @@ ZSTDGPU_ENUM(Status) zstdgpu_SetupBlockInfoConstants(zstdgpu_PerRequestContext i
 
     if (proceed)
     {
-        inPerRequestContext->zstdUncompressedLiteralsByteCount = literalsByteCount;
-        inPerRequestContext->zstdUncompressedSequenceCount     = sequenceCount;
+        inPerRequestContext->zstdUncompressedLitByteCountMax = literalsByteCount;
+        inPerRequestContext->zstdUncompressedSeqElemCountMax = sequenceCount;
         inPerRequestContext->setupFlags |= kzstdgpu_SetupFlags_HasBlockInfoConstants;
         return ZSTDGPU_ENUM_CONST(StatusSuccess);
     }
@@ -1435,15 +1435,15 @@ ZSTDGPU_ENUM(Status) zstdgpu_GetGpuMemoryRequirement(uint32_t *outDefaultHeapByt
             uint32_t cntLit, cntSeq;
             if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasBlockInfoConstants))
             {
-                cntLit = req->zstdUncompressedLiteralsByteCount;
-                cntSeq = req->zstdUncompressedSequenceCount;
+                cntLit = req->zstdUncompressedLitByteCountMax;
+                cntSeq = req->zstdUncompressedSeqElemCountMax;
             }
             else
             {
                 cntLit = CNTRS(HUF_Streams_DecodedBytes);
                 cntSeq = CNTRS(Seq_Streams_DecodedItems);
-                req->zstdUncompressedLiteralsByteCount = cntLit;
-                req->zstdUncompressedSequenceCount     = cntSeq;
+                req->zstdUncompressedLitByteCountMax = cntLit;
+                req->zstdUncompressedSeqElemCountMax = cntSeq;
             }
 
             zstdgpu_ResourceInfo_Stage_2_Init(&req->resInfo, cntLit, cntSeq, req->zstdUncompressedFramesByteCount, req->zstdUncompressedFrameCount);
@@ -1499,7 +1499,7 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithExternalMemory(zstdgpu_PerRequestContext 
     {
         if (stageIndex == 2)
         {
-            ZSTDGPU_ASSERT(req->zstdUncompressedLiteralsByteCount == 0 || req->zstdCmpBlockCountMax > 0);
+            ZSTDGPU_ASSERT(req->zstdUncompressedLitByteCountMax == 0 || req->zstdCmpBlockCountMax > 0);
         }
 
         zstdgpu_ResourceDataGpu_Term(&req->resData, stageIndex);
@@ -1619,15 +1619,15 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithInteralMemory(zstdgpu_PerRequestContext r
             uint32_t cntLit, cntSeq;
             if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasBlockInfoConstants))
             {
-                cntLit = req->zstdUncompressedLiteralsByteCount;
-                cntSeq = req->zstdUncompressedSequenceCount;
+                cntLit = req->zstdUncompressedLitByteCountMax;
+                cntSeq = req->zstdUncompressedSeqElemCountMax;
             }
             else
             {
                 cntLit = CNTRS(HUF_Streams_DecodedBytes);
                 cntSeq = CNTRS(Seq_Streams_DecodedItems);
-                req->zstdUncompressedLiteralsByteCount = cntLit;
-                req->zstdUncompressedSequenceCount     = cntSeq;
+                req->zstdUncompressedLitByteCountMax = cntLit;
+                req->zstdUncompressedSeqElemCountMax = cntSeq;
             }
 
             zstdgpu_ResourceInfo_Stage_2_Init(&req->resInfo, cntLit, cntSeq, req->zstdUncompressedFramesByteCount, req->zstdUncompressedFrameCount);
@@ -2638,7 +2638,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         bc += 7;
         // last written/updated by [Init Huffman Table and Decompress Literals]
         // next read by [Execute Sequences]
-        if (req->zstdUncompressedLiteralsByteCount > 0)
+        if (req->zstdUncompressedLitByteCountMax > 0)
         {
             setResourceUavToSrvSync(barriers, bc + 0, req->resData.gpuOnly.DecompressedLiterals);
             bc += 1;
@@ -2809,7 +2809,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Compute Dest Sequence Offsets]");
         BIND_RS_PS_SRT(ComputeDestSequenceOffsets);
 
-        zstdgpu_Dispatch32Bit(cmdList, ZSTDGPU_TG_COUNT(req->zstdUncompressedSequenceCount, 256), 1, 0);
+        zstdgpu_Dispatch32Bit(cmdList, ZSTDGPU_TG_COUNT(req->zstdUncompressedSeqElemCountMax, 256), 1, 0);
 
         PIXEndEvent(cmdList);
     }

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -2017,8 +2017,15 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.Counters->GetGPUVirtualAddress());
         cmdList->SetComputeRootUnorderedAccessView(1, req->resData.gpuOnly.DispatchArgs->GetGPUVirtualAddress());
         cmdList->SetComputeRootUnorderedAccessView(2, req->resData.gpuOnly.DispatchCnts->GetGPUVirtualAddress());
-        cmdList->SetComputeRoot32BitConstant(3, req->DecompressSequences_StreamsPerGroup, 0);
-        cmdList->SetComputeRoot32BitConstant(3, 0 /* stage */, 1);
+        cmdList->SetComputeRootUnorderedAccessView(3, req->resData.gpuOnly.Predicate->GetGPUVirtualAddress());
+        cmdList->SetComputeRoot32BitConstant(4, req->DecompressSequences_StreamsPerGroup, 0);
+        cmdList->SetComputeRoot32BitConstant(4, 0 /* stage */, 1);
+
+        cmdList->SetComputeRoot32BitConstant(4, req->zstdCmpBlockCountMax, 2);
+        cmdList->SetComputeRoot32BitConstant(4, req->zstdRawBlockCountMax, 3);
+        cmdList->SetComputeRoot32BitConstant(4, req->zstdRleBlockCountMax, 4);
+        cmdList->SetComputeRoot32BitConstant(4, 0 /* unused for stage == 0*/, 5);
+        cmdList->SetComputeRoot32BitConstant(4, 0 /* unused for stage == 0*/, 6);
         ZSTDGPU_KERNEL_SCOPE(UpdateDispatchArgs_Stage0, cmdList,
             cmdList->Dispatch(1, 1, 1);
         );
@@ -2026,7 +2033,7 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     }
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [Readback Counters :: After Block Count] and [Parse Compressed Blocks]");
-        D3D12_RESOURCE_BARRIER barriers[5];
+        D3D12_RESOURCE_BARRIER barriers[6];
         uint32_t bc = 0;
         // last read by [Update Dispatch Args :: Stage 0]
         // next read by [Readback Counters :: After Block Count] or [Init Resources :: Stage 1]
@@ -2047,6 +2054,12 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         setResourceState(barriers, bc ++, req->resData.gpuOnly.DispatchArgs, UNORDERED_ACCESS, INDIRECT_ARGUMENT);
         setResourceState(barriers, bc ++, req->resData.gpuOnly.DispatchCnts, UNORDERED_ACCESS, INDIRECT_ARGUMENT);
 
+        if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasFrameInfoConstants))
+        {
+            // last written by [Update Dispatch Args :: Stage 0]
+            // next read by Stage 1/2 predication
+            setResourceState(barriers, bc ++, req->resData.gpuOnly.Predicate, UNORDERED_ACCESS, PREDICATION);
+        }
         ZSTDGPU_ASSERT(bc <= _countof(barriers));
         cmdList->ResourceBarrier(bc, barriers);
         PIXEndEvent(cmdList);
@@ -2060,6 +2073,22 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 }
 void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandList *cmdList)
 {
+    /**
+     *  NOTE(pamartis): We enable predication only when Frame Info constants if setup
+     *  because in this case the submission can be done in a single command list because
+     *  `zstdgpu_IsReadbackRequired` returns `0`, so the calling code is free to submit every
+     *  stage in a single command list, therefore there's a risk that not sufficiently large
+     *  memory was allocated. We use predication on GPU to guard against it.
+     *
+     *  When Frame Info constants are not set, `zstdgpu_IsReadbackRequired` returns `1`,
+     *  so the calling code must wait for the fence after every stage, so readbacks
+     *  get completed, and correct Frame Info constants are read back from GPU to CPU,
+     *  so the memory allocation is always correct (unless calling forgets to call `zstdgpu_GetGpuMemoryRequirement`)
+     */
+    if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasFrameInfoConstants))
+    {
+        cmdList->SetPredication(req->resData.gpuOnly.Predicate, 0 /* Stage 1 predicate */, D3D12_PREDICATION_OP_NOT_EQUAL_ZERO);
+    }
     {
         const uint32_t initResourcesStage = 1;
         const uint32_t allBlockCount = req->zstdRawBlockCountMax
@@ -2260,33 +2289,44 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         // next read by [Finalise Sequence Offsets]
         setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.PerSeqStreamSeqStart);
         // last read by ExecuteIndirect as INDIRECT_ARGUMENT
-        // next written by [Update Dispatch Args :: Stage 2]
+        // next written by [Update Dispatch Args :: Stage 1]
         setResourceState(barriers, bc ++, req->resData.gpuOnly.DispatchArgs, INDIRECT_ARGUMENT, UNORDERED_ACCESS);
         setResourceState(barriers, bc ++, req->resData.gpuOnly.DispatchCnts, INDIRECT_ARGUMENT, UNORDERED_ACCESS);
+        if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasFrameInfoConstants))
+        {
+            // last read by SetPredication as PREDICATION
+            // next written by [Update Dispatch Args :: Stage 1]
+            setResourceState(barriers, bc ++, req->resData.gpuOnly.Predicate, PREDICATION, UNORDERED_ACCESS);
+        }
         ZSTDGPU_ASSERT(bc <= _countof(barriers));
         cmdList->ResourceBarrier(bc, barriers);
         PIXEndEvent(cmdList);
     }
 
-    if (req->zstdCmpBlockCountMax > 0)
     {
-        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Update Dispatch Args]");
+        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Update Dispatch Args :: Stage 1]");
         d3d12aid_ComputeRsPs_Set(&req->UpdateDispatchArgs, cmdList);
         cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.Counters->GetGPUVirtualAddress());
         cmdList->SetComputeRootUnorderedAccessView(1, req->resData.gpuOnly.DispatchArgs->GetGPUVirtualAddress());
         cmdList->SetComputeRootUnorderedAccessView(2, req->resData.gpuOnly.DispatchCnts->GetGPUVirtualAddress());
-        cmdList->SetComputeRoot32BitConstant(3, req->DecompressSequences_StreamsPerGroup, 0);
-        cmdList->SetComputeRoot32BitConstant(3, 1 /* stage */, 1);
+        cmdList->SetComputeRootUnorderedAccessView(3, req->resData.gpuOnly.Predicate->GetGPUVirtualAddress());
+        cmdList->SetComputeRoot32BitConstant(4, req->DecompressSequences_StreamsPerGroup, 0);
+        cmdList->SetComputeRoot32BitConstant(4, 1 /* stage */, 1);
+
+        cmdList->SetComputeRoot32BitConstant(4, req->zstdCmpBlockCountMax, 2);
+        cmdList->SetComputeRoot32BitConstant(4, req->zstdRawBlockCountMax, 3);
+        cmdList->SetComputeRoot32BitConstant(4, req->zstdRleBlockCountMax, 4);
+        cmdList->SetComputeRoot32BitConstant(4, req->zstdUncompressedLitByteCountMax, 5);
+        cmdList->SetComputeRoot32BitConstant(4, req->zstdUncompressedSeqElemCountMax, 6);
         ZSTDGPU_KERNEL_SCOPE(UpdateDispatchArgs, cmdList,
             cmdList->Dispatch(1, 1, 1);
         );
         PIXEndEvent(cmdList);
     }
 
-    if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [Compute `Per-Huffman Table` Literal Stream Count Prefix]");
-        D3D12_RESOURCE_BARRIER barriers[3];
+        D3D12_RESOURCE_BARRIER barriers[4];
         uint32_t bc = 0;
         // last written by [Update Dispatch Args]
         // next read by [Compute `Per-Huffman Table` Literal Stream Count Prefix] via ExecuteIndirect
@@ -2295,10 +2335,21 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         // last written by [Update Dispatch Args]
         // next read/written by [Compute `Per-Huffman Table` Literal Stream Count Prefix]
         setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.Counters);
+        if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasBlockInfoConstants))
+        {
+            // last written by [Update Dispatch Args :: Stage 1]
+            // next read by SetPredication as PREDICATION
+            setResourceState(barriers, bc ++, req->resData.gpuOnly.Predicate, UNORDERED_ACCESS, PREDICATION);
+        }
 
         ZSTDGPU_ASSERT(bc <= _countof(barriers));
         cmdList->ResourceBarrier(bc, barriers);
         PIXEndEvent(cmdList);
+    }
+
+    if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasFrameInfoConstants))
+    {
+        cmdList->SetPredication(NULL, 0, D3D12_PREDICATION_OP_EQUAL_ZERO);
     }
 
     if (zstdgpu_IsReadbackRequired(req, 1))
@@ -2311,6 +2362,11 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
 void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandList *cmdList)
 {
+    if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasBlockInfoConstants))
+    {
+        cmdList->SetPredication(req->resData.gpuOnly.Predicate, sizeof(uint64_t) /* Stage 2 predicate */, D3D12_PREDICATION_OP_NOT_EQUAL_ZERO);
+    }
+
     if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Compute `Per-Huffman Table` Literal Stream Count Prefix]");
@@ -2359,8 +2415,15 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.Counters->GetGPUVirtualAddress());
         cmdList->SetComputeRootUnorderedAccessView(1, req->resData.gpuOnly.DispatchArgs->GetGPUVirtualAddress());
         cmdList->SetComputeRootUnorderedAccessView(2, req->resData.gpuOnly.DispatchCnts->GetGPUVirtualAddress());
-        cmdList->SetComputeRoot32BitConstant(3, req->DecompressSequences_StreamsPerGroup, 0);
-        cmdList->SetComputeRoot32BitConstant(3, 2 /* stage */, 1);
+        cmdList->SetComputeRootUnorderedAccessView(3, req->resData.gpuOnly.Predicate->GetGPUVirtualAddress() /* unused for stage == 2 */);
+        cmdList->SetComputeRoot32BitConstant(4, req->DecompressSequences_StreamsPerGroup, 0);
+        cmdList->SetComputeRoot32BitConstant(4, 2 /* stage */, 1);
+
+        cmdList->SetComputeRoot32BitConstant(4, req->zstdCmpBlockCountMax, 2);
+        cmdList->SetComputeRoot32BitConstant(4, req->zstdRawBlockCountMax, 3);
+        cmdList->SetComputeRoot32BitConstant(4, req->zstdRleBlockCountMax, 4);
+        cmdList->SetComputeRoot32BitConstant(4, 0 /* unused for stage == 2 */, 5);
+        cmdList->SetComputeRoot32BitConstant(4, 0 /* unused for stage == 2 */, 6);
         ZSTDGPU_KERNEL_SCOPE(UpdateDispatchArgs_DecompressLiterals, cmdList,
             cmdList->Dispatch(1, 1, 1);
         );
@@ -2818,6 +2881,10 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Readback Counters :: After Block Decompression]");
         zstdgpu_PushReadback(Counters);
         PIXEndEvent(cmdList);
+    }
+    if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasBlockInfoConstants))
+    {
+        cmdList->SetPredication(NULL, 0, D3D12_PREDICATION_OP_EQUAL_ZERO);
     }
 }
 

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -912,9 +912,24 @@ struct zstdgpu_PerRequestContextImpl
     uint32_t                zstdUncompressedFrameCount;
     uint32_t                zstdUncompressedFramesByteCount;
 
-    uint32_t                zstdRawBlockCount;
-    uint32_t                zstdRleBlockCount;
-    uint32_t                zstdCmpBlockCount;
+    /**
+     *  These the maximal number of blocks of each kind the context can process
+     *
+     *  Option A:
+     *  If `zstdgpu_SetupFrameInfoConstants` was called on the context and these numbers
+     *  were provided by the calling code, these numbers are used internally to conservatively
+     *  allocate memory (so that specified number of blocks fit) and partition it statically
+     *  into buffers/views.
+     *
+     *  Option B:
+     *  If `zstdgpu_SetupFrameInfoConstants` was NOT called, these numbers are originally
+     *  set to zero in `zstdgpu_CreatePerRequestContext`, meaning they can't be used to allocate
+     *  memory until Zstd frames are parsed and the number of blocks read back to CPU
+     *  either through `zstdgpu_SubmitWithInteralMemory` or `zstdgpu_GetGpuMemoryRequirement`
+     */
+    uint32_t                zstdRawBlockCountMax;
+    uint32_t                zstdRleBlockCountMax;
+    uint32_t                zstdCmpBlockCountMax;
 
     uint32_t                zstdUncompressedLiteralsByteCount;
     uint32_t                zstdUncompressedSequenceCount;
@@ -1157,9 +1172,9 @@ ZSTDGPU_ENUM(Status) zstdgpu_CreatePerRequestContext(zstdgpu_PerRequestContext *
         context->zstdUncompressedFrameCount         = 0;
         context->zstdUncompressedFramesByteCount    = 0;
 
-        context->zstdRawBlockCount                  = 0;
-        context->zstdRleBlockCount                  = 0;
-        context->zstdCmpBlockCount                  = 0;
+        context->zstdRawBlockCountMax               = 0;
+        context->zstdRleBlockCountMax               = 0;
+        context->zstdCmpBlockCountMax               = 0;
         context->zstdUncompressedLiteralsByteCount  = 0;
         context->zstdUncompressedSequenceCount      = 0;
         context->setupFlags = 0;
@@ -1328,9 +1343,9 @@ ZSTDGPU_ENUM(Status) zstdgpu_SetupFrameInfoConstants(zstdgpu_PerRequestContext i
 
     if (proceed)
     {
-        inPerRequestContext->zstdRawBlockCount          = rawBlockCount;
-        inPerRequestContext->zstdRleBlockCount          = rleBlockCount;
-        inPerRequestContext->zstdCmpBlockCount          = cmpBlockCount;
+        inPerRequestContext->zstdRawBlockCountMax = rawBlockCount;
+        inPerRequestContext->zstdRleBlockCountMax = rleBlockCount;
+        inPerRequestContext->zstdCmpBlockCountMax = cmpBlockCount;
         inPerRequestContext->setupFlags |= kzstdgpu_SetupFlags_HasFrameInfoConstants;
         return ZSTDGPU_ENUM_CONST(StatusSuccess);
     }
@@ -1395,9 +1410,9 @@ ZSTDGPU_ENUM(Status) zstdgpu_GetGpuMemoryRequirement(uint32_t *outDefaultHeapByt
             uint32_t cntRaw, cntRle, cntCmp;
             if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasFrameInfoConstants))
             {
-                cntRaw = req->zstdRawBlockCount;
-                cntRle = req->zstdRleBlockCount;
-                cntCmp = req->zstdCmpBlockCount;
+                cntRaw = req->zstdRawBlockCountMax;
+                cntRle = req->zstdRleBlockCountMax;
+                cntCmp = req->zstdCmpBlockCountMax;
             }
             else
             {
@@ -1405,9 +1420,9 @@ ZSTDGPU_ENUM(Status) zstdgpu_GetGpuMemoryRequirement(uint32_t *outDefaultHeapByt
                 cntRle = CNTRS(Blocks_RLE);
                 cntCmp = CNTRS(Blocks_CMP);
 
-                req->zstdRawBlockCount = cntRaw;
-                req->zstdRleBlockCount = cntRle;
-                req->zstdCmpBlockCount = cntCmp;
+                req->zstdRawBlockCountMax = cntRaw;
+                req->zstdRleBlockCountMax = cntRle;
+                req->zstdCmpBlockCountMax = cntCmp;
             }
 
             ZSTDGPU_ASSERT(0 != cntRaw + cntRle + cntCmp);
@@ -1484,7 +1499,7 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithExternalMemory(zstdgpu_PerRequestContext 
     {
         if (stageIndex == 2)
         {
-            ZSTDGPU_ASSERT(req->zstdUncompressedLiteralsByteCount == 0 || req->zstdCmpBlockCount > 0);
+            ZSTDGPU_ASSERT(req->zstdUncompressedLiteralsByteCount == 0 || req->zstdCmpBlockCountMax > 0);
         }
 
         zstdgpu_ResourceDataGpu_Term(&req->resData, stageIndex);
@@ -1580,9 +1595,9 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithInteralMemory(zstdgpu_PerRequestContext r
             uint32_t cntRaw, cntRle, cntCmp;
             if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasFrameInfoConstants))
             {
-                cntRaw = req->zstdRawBlockCount;
-                cntRle = req->zstdRleBlockCount;
-                cntCmp = req->zstdCmpBlockCount;
+                cntRaw = req->zstdRawBlockCountMax;
+                cntRle = req->zstdRleBlockCountMax;
+                cntCmp = req->zstdCmpBlockCountMax;
             }
             else
             {
@@ -1590,9 +1605,9 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithInteralMemory(zstdgpu_PerRequestContext r
                 cntRle = CNTRS(Blocks_RLE);
                 cntCmp = CNTRS(Blocks_CMP);
 
-                req->zstdRawBlockCount = cntRaw;
-                req->zstdRleBlockCount = cntRle;
-                req->zstdCmpBlockCount = cntCmp;
+                req->zstdRawBlockCountMax = cntRaw;
+                req->zstdRleBlockCountMax = cntRle;
+                req->zstdCmpBlockCountMax = cntCmp;
             }
 
             ZSTDGPU_ASSERT(0 != cntRaw + cntRle + cntCmp);
@@ -2044,14 +2059,14 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 {
     {
         const uint32_t initResourcesStage = 1;
-        const uint32_t allBlockCount = req->zstdRawBlockCount
-                                     + req->zstdRleBlockCount
-                                     + req->zstdCmpBlockCount;
+        const uint32_t allBlockCount = req->zstdRawBlockCountMax
+                                     + req->zstdRleBlockCountMax
+                                     + req->zstdCmpBlockCountMax;
 
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Init Resources :: Stage 1]");
         BIND_RS_PS_SRT_EX(InitResources, InitResources_S1);
         cmdList->SetComputeRoot32BitConstant(1, allBlockCount, 0);
-        cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 1);
+        cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCountMax, 1);
         cmdList->SetComputeRoot32BitConstant(1, req->zstdFrameCount, 2);
         cmdList->SetComputeRoot32BitConstant(1, initResourcesStage, 3);
         ZSTDGPU_KERNEL_SCOPE(InitResources, cmdList,
@@ -2060,7 +2075,7 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
         PIXEndEvent(cmdList);
     }
-    if (req->zstdCmpBlockCount > 0)
+    if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[InitResources :: Memset :: Stage 1]");
         d3d12aid_ComputeRsPs_Set(&req->Memset, cmdList);
@@ -2069,13 +2084,13 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRoot32BitConstant(1, 0 /* value */, 2);
 
         // Group 1: CmpBlockLookback-sized regions (6 UAV rebinds, same dispatch slot)
-        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.LitGroupEndPerHuffmanTable->GetGPUVirtualAddress() + req->zstdCmpBlockCount * sizeof(uint32_t));
+        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.LitGroupEndPerHuffmanTable->GetGPUVirtualAddress() + req->zstdCmpBlockCountMax * sizeof(uint32_t));
         zstdgpu_DispatchIndirect(cmdList, Memset, Memset_CmpBlockLookback);
-        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.PerSeqStreamFinalOffset1->GetGPUVirtualAddress() + req->zstdCmpBlockCount * sizeof(uint32_t));
+        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.PerSeqStreamFinalOffset1->GetGPUVirtualAddress() + req->zstdCmpBlockCountMax * sizeof(uint32_t));
         zstdgpu_DispatchIndirect(cmdList, Memset, Memset_CmpBlockLookback);
-        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.PerSeqStreamFinalOffset2->GetGPUVirtualAddress() + req->zstdCmpBlockCount * sizeof(uint32_t));
+        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.PerSeqStreamFinalOffset2->GetGPUVirtualAddress() + req->zstdCmpBlockCountMax * sizeof(uint32_t));
         zstdgpu_DispatchIndirect(cmdList, Memset, Memset_CmpBlockLookback);
-        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.PerSeqStreamFinalOffset3->GetGPUVirtualAddress() + req->zstdCmpBlockCount * sizeof(uint32_t));
+        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.PerSeqStreamFinalOffset3->GetGPUVirtualAddress() + req->zstdCmpBlockCountMax * sizeof(uint32_t));
         zstdgpu_DispatchIndirect(cmdList, Memset, Memset_CmpBlockLookback);
         cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.SeqCountPrefixLookback->GetGPUVirtualAddress());
         zstdgpu_DispatchIndirect(cmdList, Memset, Memset_CmpBlockLookback);
@@ -2092,7 +2107,9 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
         // Group 4: BlockSizePrefix lookback (allBlockCount-sized)
         {
-            const uint32_t allBlockCount = req->zstdRawBlockCount + req->zstdRleBlockCount + req->zstdCmpBlockCount;
+            const uint32_t allBlockCount = req->zstdRawBlockCountMax
+                                         + req->zstdRleBlockCountMax
+                                         + req->zstdCmpBlockCountMax;
             cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.BlockSizePrefix->GetGPUVirtualAddress() + allBlockCount * sizeof(uint32_t));
         }
         zstdgpu_DispatchIndirect(cmdList, Memset, Memset_AllBlockLookback);
@@ -2126,7 +2143,7 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         D3D12_RESOURCE_BARRIER barriers[15];
 
         uint32_t bc = 0;
-        if (req->zstdCmpBlockCount > 0)
+        if (req->zstdCmpBlockCountMax > 0)
         {
             // last written by [Parse Frames :: Collect Blocks]
             // next written/updated by [Parse Compressed Blocks] with non-intersecting memory ranges with [Parse Frames :: Collect Blocks]
@@ -2177,12 +2194,12 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
         // last written by [Parse Frames :: Collect Blocks]
         // next read by [Memcpy RAW blocks, Memset RLE blocks]
-        if (req->zstdRawBlockCount > 0)
+        if (req->zstdRawBlockCountMax > 0)
         {
             setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.BlocksRAWRefs);
         }
 
-        if (req->zstdRleBlockCount > 0)
+        if (req->zstdRleBlockCountMax > 0)
         {
             setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.BlocksRLERefs);
         }
@@ -2191,7 +2208,7 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXEndEvent(cmdList);
     }
 
-    if (req->zstdCmpBlockCount > 0)
+    if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Parse Compressed Blocks]");
         BIND_RS_PS_SRT(ParseCompressedBlocks);
@@ -2205,7 +2222,7 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXEndEvent(cmdList);
     }
 
-    if (req->zstdCmpBlockCount > 0)
+    if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [Readback Counters :: After Block Parse] and [Update Dispatch Args] and [Compute `Per-Huffman Table` Literal Stream Count Prefix]");
         D3D12_RESOURCE_BARRIER barriers[11];
@@ -2254,7 +2271,7 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 }
 void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandList *cmdList)
 {
-    if (req->zstdCmpBlockCount > 0)
+    if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Update Dispatch Args]");
         d3d12aid_ComputeRsPs_Set(&req->UpdateDispatchArgs, cmdList);
@@ -2269,7 +2286,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXEndEvent(cmdList);
     }
 
-    if (req->zstdCmpBlockCount > 0)
+    if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [Compute `Per-Huffman Table` Literal Stream Count Prefix]");
         D3D12_RESOURCE_BARRIER barriers[3];
@@ -2284,15 +2301,15 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXEndEvent(cmdList);
     }
 
-    if (req->zstdCmpBlockCount > 0)
+    if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Compute `Per-Huffman Table` Literal Stream Count Prefix]");
 
         d3d12aid_ComputeRsPs_Set(&req->ComputePrefixSum, cmdList);
         cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.LitStreamEndPerHuffmanTable->GetGPUVirtualAddress());
         cmdList->SetComputeRootUnorderedAccessView(1, req->resData.gpuOnly.LitGroupEndPerHuffmanTable->GetGPUVirtualAddress());
-        cmdList->SetComputeRootUnorderedAccessView(2, req->resData.gpuOnly.LitStreamEndPerHuffmanTable->GetGPUVirtualAddress() + req->zstdCmpBlockCount * sizeof(uint32_t));
-        cmdList->SetComputeRootUnorderedAccessView(3, req->resData.gpuOnly.LitGroupEndPerHuffmanTable->GetGPUVirtualAddress() + req->zstdCmpBlockCount * sizeof(uint32_t));
+        cmdList->SetComputeRootUnorderedAccessView(2, req->resData.gpuOnly.LitStreamEndPerHuffmanTable->GetGPUVirtualAddress() + req->zstdCmpBlockCountMax * sizeof(uint32_t));
+        cmdList->SetComputeRootUnorderedAccessView(3, req->resData.gpuOnly.LitGroupEndPerHuffmanTable->GetGPUVirtualAddress() + req->zstdCmpBlockCountMax * sizeof(uint32_t));
         cmdList->SetComputeRootUnorderedAccessView(4, req->resData.gpuOnly.Counters->GetGPUVirtualAddress());
         // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
 #if 0
@@ -2311,7 +2328,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     // NOTE(pamartis): `ComputePrefixSum` writes `DecompressLiteralsGroups` to `Counters`.
     // A separate `UpdateDispatchArgs` pass populates `DecompressLiterals` dispatch slot
     // because `ComputePrefixSum` can't write DispatchArgs (it's in INDIRECT_ARGUMENT state).
-    if (req->zstdCmpBlockCount > 0)
+    if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [Update Dispatch Args :: DecompressLiterals]");
         D3D12_RESOURCE_BARRIER barriers[3];
@@ -2325,7 +2342,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->ResourceBarrier(_countof(barriers), barriers);
         PIXEndEvent(cmdList);
     }
-    if (req->zstdCmpBlockCount > 0)
+    if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Update Dispatch Args :: DecompressLiterals]");
         d3d12aid_ComputeRsPs_Set(&req->UpdateDispatchArgs, cmdList);
@@ -2340,7 +2357,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXEndEvent(cmdList);
     }
 
-    if (req->zstdCmpBlockCount > 0)
+    if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier with Resources for [Init FSE Table] and [Group Lilteral Streams]");
         D3D12_RESOURCE_BARRIER barriers[14];
@@ -2392,7 +2409,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     }
 
     // Groups Huffman-compressed literal streams by Huffman table index
-    if (req->zstdCmpBlockCount > 0)
+    if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Group Lilteral Streams]");
         d3d12aid_ComputeRsPs_Set(&req->GroupCompressedLiterals, cmdList);
@@ -2409,7 +2426,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXEndEvent(cmdList);
     }
 
-    if (req->zstdCmpBlockCount > 0)
+    if (req->zstdCmpBlockCountMax > 0)
     {
         // Run FSE Table Initialisation
         ZSTDGPU_KERNEL_SCOPE(InitFseTable, cmdList,
@@ -2425,31 +2442,31 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Huffman Weights");
             uint32_t tableStartIndex = 0;
             cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 2);
-            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartHufW(0, req->zstdCmpBlockCount), 3);
+            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartHufW(0, req->zstdCmpBlockCountMax), 3);
             cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_HufW, 4);
             zstdgpu_DispatchIndirect(cmdList, InitFseTable, FseHufW);
             PIXEndEvent(cmdList);
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Literal Lengths");
-            tableStartIndex += req->zstdCmpBlockCount;
+            tableStartIndex += req->zstdCmpBlockCountMax;
             cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 2);
-            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartLLen(0, req->zstdCmpBlockCount), 3);
+            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartLLen(0, req->zstdCmpBlockCountMax), 3);
             cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_LLen, 4);
             zstdgpu_DispatchIndirect(cmdList, InitFseTable, FseLLen);
             PIXEndEvent(cmdList);
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Offsets");
-            tableStartIndex += req->zstdCmpBlockCount + 1;
+            tableStartIndex += req->zstdCmpBlockCountMax + 1;
             cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 2);
-            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartOffs(0, req->zstdCmpBlockCount), 3);
+            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartOffs(0, req->zstdCmpBlockCountMax), 3);
             cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_Offs, 4);
             zstdgpu_DispatchIndirect(cmdList, InitFseTable, FseOffs);
             PIXEndEvent(cmdList);
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Match Lengths");
-            tableStartIndex += req->zstdCmpBlockCount + 1;
+            tableStartIndex += req->zstdCmpBlockCountMax + 1;
             cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 2);
-            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartMLen(0, req->zstdCmpBlockCount), 3);
+            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartMLen(0, req->zstdCmpBlockCountMax), 3);
             cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_MLen, 4);
             zstdgpu_DispatchIndirect(cmdList, InitFseTable, FseMLen);
             PIXEndEvent(cmdList);
@@ -2458,7 +2475,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     }
 
     // Needed by readback
-    if (req->zstdCmpBlockCount > 0)
+    if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier with Resources for [Huffman Weights Decompression] and [Decompress Literals]");
         D3D12_RESOURCE_BARRIER barriers[2];
@@ -2473,7 +2490,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     }
 
     // Run Decompression of FSE-compressed Huffman Weights
-    if (req->zstdCmpBlockCount > 0)
+    if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Decompress Huffman Weights]");
         BIND_RS_PS_SRT(DecompressHuffmanWeights);
@@ -2485,12 +2502,12 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXEndEvent(cmdList);
     }
     // Run Decoding of Uncompressed Huffman Weights (can merge with FSE decompression before barrier)
-    if (req->zstdCmpBlockCount > 0)
+    if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Decode Uncompressed Huffman Weights]");
         BIND_RS_PS_SRT(DecodeHuffmanWeights);
         // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
-        cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 2);
+        cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCountMax, 2);
         cmdList->SetComputeRoot32BitConstant(1, req->resInfo.CompressedData_ByteSize, 3);
 
         ZSTDGPU_KERNEL_SCOPE(DecodeHuffmanWeights, cmdList,
@@ -2500,7 +2517,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     }
 
     // Needed by Initialisation of Huffman Tables
-    if (req->zstdCmpBlockCount > 0)
+    if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier with Resources for [Init Huffman Table]");
         D3D12_RESOURCE_BARRIER barriers[2];
@@ -2514,7 +2531,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXEndEvent(cmdList);
     }
 
-    if (req->zstdCmpBlockCount > 0)
+    if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Pre-Init Huffman Table]");
         BIND_RS_PS_SRT(InitHuffmanTable);
@@ -2531,7 +2548,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Path: Uncompressed Huffman Weights]");
             {
-                cmdList->SetComputeRoot32BitConstant(1, /** HuffmaTableIndexBase = zstdCmpBlockCount meaning indices are reversed */req->zstdCmpBlockCount, 2);
+                cmdList->SetComputeRoot32BitConstant(1, /** HuffmaTableIndexBase = zstdCmpBlockCount meaning indices are reversed */req->zstdCmpBlockCountMax, 2);
                 zstdgpu_DispatchIndirect(cmdList, InitHuffmanTable, HUF_WgtStreams);
             }
             PIXEndEvent(cmdList);
@@ -2540,7 +2557,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXEndEvent(cmdList);
     }
 
-    if (req->zstdCmpBlockCount > 0)
+    if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier with Resources for [Decompress Literals]");
         D3D12_RESOURCE_BARRIER barriers[3];
@@ -2553,12 +2570,12 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXEndEvent(cmdList);
     }
 
-    if (req->zstdCmpBlockCount > 0)
+    if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Decompress Literals]");
         BIND_RS_PS_SRT(DecompressLiterals);
         // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
-        cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCount, 2);
+        cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCountMax, 2);
 
         ZSTDGPU_KERNEL_SCOPE(DecompressLiterals, cmdList,
             zstdgpu_DispatchIndirect(cmdList, DecompressLiterals, DecompressLiterals);
@@ -2577,7 +2594,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 #endif
 
     // NOTE(pamartis): (can run in parallel with FSE-compressed Huffman Weight Decompression, right after FSE table initialisation)
-    if (req->zstdCmpBlockCount > 0)
+    if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Decompress Sequences]");
         BIND_RS_PS_SRT(DecompressSequences);
@@ -2588,7 +2605,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         );
         PIXEndEvent(cmdList);
     }
-    if (req->zstdCmpBlockCount > 0)
+    if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier with Resources for [Prefix Block Sizes] and [Prefix Sequence Offsets] and [Execute Sequences]");
         D3D12_RESOURCE_BARRIER barriers[8];
@@ -2620,9 +2637,9 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXEndEvent(cmdList);
     }
     {
-        const uint32_t allBlockCount = req->zstdRawBlockCount
-                                     + req->zstdRleBlockCount
-                                     + req->zstdCmpBlockCount;
+        const uint32_t allBlockCount = req->zstdRawBlockCountMax
+                                     + req->zstdRleBlockCountMax
+                                     + req->zstdCmpBlockCountMax;
 
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Prefix Block Sizes]");
         d3d12aid_ComputeRsPs_Set(&req->PrefixSum, cmdList);
@@ -2638,7 +2655,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
         PIXEndEvent(cmdList);
     }
-    if (req->zstdCmpBlockCount > 0)
+    if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Prefix Sequence Offsets]");
         d3d12aid_ComputeRsPs_Set(&req->PrefixSequenceOffsets, cmdList);
@@ -2646,9 +2663,9 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.PerSeqStreamFinalOffset1->GetGPUVirtualAddress());
         cmdList->SetComputeRootUnorderedAccessView(1, req->resData.gpuOnly.PerSeqStreamFinalOffset2->GetGPUVirtualAddress());
         cmdList->SetComputeRootUnorderedAccessView(2, req->resData.gpuOnly.PerSeqStreamFinalOffset3->GetGPUVirtualAddress());
-        cmdList->SetComputeRootUnorderedAccessView(3, req->resData.gpuOnly.PerSeqStreamFinalOffset1->GetGPUVirtualAddress() + req->zstdCmpBlockCount * sizeof(uint32_t));
-        cmdList->SetComputeRootUnorderedAccessView(4, req->resData.gpuOnly.PerSeqStreamFinalOffset2->GetGPUVirtualAddress() + req->zstdCmpBlockCount * sizeof(uint32_t));
-        cmdList->SetComputeRootUnorderedAccessView(5, req->resData.gpuOnly.PerSeqStreamFinalOffset3->GetGPUVirtualAddress() + req->zstdCmpBlockCount * sizeof(uint32_t));
+        cmdList->SetComputeRootUnorderedAccessView(3, req->resData.gpuOnly.PerSeqStreamFinalOffset1->GetGPUVirtualAddress() + req->zstdCmpBlockCountMax * sizeof(uint32_t));
+        cmdList->SetComputeRootUnorderedAccessView(4, req->resData.gpuOnly.PerSeqStreamFinalOffset2->GetGPUVirtualAddress() + req->zstdCmpBlockCountMax * sizeof(uint32_t));
+        cmdList->SetComputeRootUnorderedAccessView(5, req->resData.gpuOnly.PerSeqStreamFinalOffset3->GetGPUVirtualAddress() + req->zstdCmpBlockCountMax * sizeof(uint32_t));
         cmdList->SetComputeRootShaderResourceView(6, req->resData.gpuOnly.PerFrameSeqStreamMinIdx->GetGPUVirtualAddress());
         cmdList->SetComputeRootShaderResourceView(7, req->resData.gpuOnly.PerFrameBlockCountAll->GetGPUVirtualAddress());
         cmdList->SetComputeRootShaderResourceView(8, req->resData.gpuOnly.SeqRefs->GetGPUVirtualAddress());
@@ -2666,7 +2683,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier with Resources for [Finalise Sequence Offsets]");
         D3D12_RESOURCE_BARRIER barriers[4];
         uint32_t bc = 0;
-        if (req->zstdCmpBlockCount > 0)
+        if (req->zstdCmpBlockCountMax > 0)
         {
             // last written by [Prefix Sequence Offsets]
             // next read by [Finalise Sequence Offsets]
@@ -2683,7 +2700,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->ResourceBarrier(bc, barriers);
         PIXEndEvent(cmdList);
     }
-    if (req->zstdCmpBlockCount > 0)
+    if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Finalise Sequence Offsets]");
         BIND_RS_PS_SRT(FinaliseSequenceOffsets);
@@ -2695,7 +2712,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
         PIXEndEvent(cmdList);
     }
-    if (req->zstdCmpBlockCount > 0)
+    if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier with Resources for [Memcpy RAW blocks, Memset RLE blocks] and [Execute Sequences]");
         D3D12_RESOURCE_BARRIER barriers[1];
@@ -2705,7 +2722,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->ResourceBarrier(_countof(barriers), barriers);
         PIXEndEvent(cmdList);
     }
-    if (req->zstdRawBlockCount > 0 || req->zstdRleBlockCount > 0)
+    if (req->zstdRawBlockCountMax > 0 || req->zstdRleBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Memcpy RAW blocks, Memset RLE blocks]");
         d3d12aid_ComputeRsPs_Set(&req->MemsetMemcpy, cmdList);
@@ -2713,26 +2730,26 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRootDescriptorTable(0, req->srts.MemsetMemcpyGpuHandle);
         ZSTDGPU_KERNEL_SCOPE(MemcpyRAW_MemsetRLE, cmdList,
         {
-            if (req->zstdRawBlockCount > 0)
+            if (req->zstdRawBlockCountMax > 0)
             {
                 cmdList->SetComputeRootShaderResourceView(1, req->resData.gpuOnly.RawBlockSizePrefix->GetGPUVirtualAddress());
                 cmdList->SetComputeRootShaderResourceView(2, req->resData.gpuOnly.PerFrameBlockSizesRAW->GetGPUVirtualAddress());
                 cmdList->SetComputeRootShaderResourceView(3, req->resData.gpuOnly.BlocksRAWRefs->GetGPUVirtualAddress());
                 cmdList->SetComputeRootShaderResourceView(4, req->resData.gpuOnly.GlobalBlockIndexPerRawBlock->GetGPUVirtualAddress());
                 // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
-                cmdList->SetComputeRoot32BitConstant(5, req->zstdRawBlockCount, 2);
+                cmdList->SetComputeRoot32BitConstant(5, req->zstdRawBlockCountMax, 2);
                 cmdList->SetComputeRoot32BitConstant(5, req->zstdFrameCount, 3);
                 cmdList->SetComputeRoot32BitConstant(5, 1 /* flags */, 4);
                 zstdgpu_DispatchIndirect(cmdList, MemsetMemcpy, MemcpyRAW);
             }
-            if (req->zstdRleBlockCount > 0)
+            if (req->zstdRleBlockCountMax > 0)
             {
                 cmdList->SetComputeRootShaderResourceView(1, req->resData.gpuOnly.RleBlockSizePrefix->GetGPUVirtualAddress());
                 cmdList->SetComputeRootShaderResourceView(2, req->resData.gpuOnly.PerFrameBlockSizesRLE->GetGPUVirtualAddress());
                 cmdList->SetComputeRootShaderResourceView(3, req->resData.gpuOnly.BlocksRLERefs->GetGPUVirtualAddress());
                 cmdList->SetComputeRootShaderResourceView(4, req->resData.gpuOnly.GlobalBlockIndexPerRleBlock->GetGPUVirtualAddress());
                 // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
-                cmdList->SetComputeRoot32BitConstant(5, req->zstdRleBlockCount, 2);
+                cmdList->SetComputeRoot32BitConstant(5, req->zstdRleBlockCountMax, 2);
                 cmdList->SetComputeRoot32BitConstant(5, req->zstdFrameCount, 3);
                 cmdList->SetComputeRoot32BitConstant(5, 0 /* flags */, 4);
                 zstdgpu_DispatchIndirect(cmdList, MemsetMemcpy, MemsetRLE);
@@ -2740,12 +2757,12 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         });
         PIXEndEvent(cmdList);
     }
-    if (req->zstdCmpBlockCount > 0)
+    if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier with Resources for [Execute Sequences]");
         D3D12_RESOURCE_BARRIER barriers[2];
         uint32_t bc = 0;
-        if (req->zstdRawBlockCount > 0 || req->zstdRleBlockCount > 0)
+        if (req->zstdRawBlockCountMax > 0 || req->zstdRleBlockCountMax > 0)
         {
             // in case if the number of RAW+RLE blocks > 0, [Memcpy RAW blocks, Memset RLE blocks] has written to 'UnCompressedFramesData'
             // next read by [Execute Sequences]
@@ -2759,7 +2776,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->ResourceBarrier(bc, barriers);
         PIXEndEvent(cmdList);
     }
-    if (req->zstdCmpBlockCount > 0)
+    if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Execute Sequences]");
         BIND_RS_PS_SRT(ExecuteSequences);
@@ -2769,7 +2786,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         );
         PIXEndEvent(cmdList);
     }
-    if (req->zstdCmpBlockCount > 0)
+    if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier with Resources for [Readback Counters :: After Block Decompression]");
         D3D12_RESOURCE_BARRIER barriers[1];
@@ -2786,7 +2803,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
         PIXEndEvent(cmdList);
     }
-    if (req->zstdCmpBlockCount > 0) /* Readback for Counters is only needed if the number of compressed blocks > 0 because Counters are updated during Seqeunce Execution */
+    if (req->zstdCmpBlockCountMax > 0) /* Readback for Counters is only needed if the number of compressed blocks > 0 because Counters are updated during Seqeunce Execution */
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Readback Counters :: After Block Decompression]");
         zstdgpu_PushReadback(Counters);
@@ -2810,20 +2827,20 @@ ZSTDGPU_API void zstdgpu_ReadbackGpuResults(zstdgpu_PerRequestContext req, ID3D1
         setResourceState(barriers, 3, req->resData.gpuOnly.PerFrameBlockSizesRLE, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
         setResourceState(barriers, 4, req->resData.gpuOnly.PerFrameSeqStreamMinIdx, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
         bc += 5;
-        if (req->zstdCmpBlockCount > 0)
+        if (req->zstdCmpBlockCountMax > 0)
         {
             setResourceState(barriers, bc + 0, req->resData.gpuOnly.GlobalBlockIndexPerCmpBlock, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
             setResourceState(barriers, bc + 1, req->resData.gpuOnly.PerSeqStreamSeqStart, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
             bc += 2;
         }
-        if (req->zstdRawBlockCount > 0)
+        if (req->zstdRawBlockCountMax > 0)
         {
             setResourceState(barriers, bc + 0, req->resData.gpuOnly.GlobalBlockIndexPerRawBlock, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
             setResourceState(barriers, bc + 1, req->resData.gpuOnly.RawBlockSizePrefix, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
             setResourceState(barriers, bc + 2, req->resData.gpuOnly.BlocksRAWRefs, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
             bc += 3;
         }
-        if (req->zstdRleBlockCount > 0)
+        if (req->zstdRleBlockCountMax > 0)
         {
             setResourceState(barriers, bc + 0, req->resData.gpuOnly.GlobalBlockIndexPerRleBlock, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
             setResourceState(barriers, bc + 1, req->resData.gpuOnly.RleBlockSizePrefix, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
@@ -2849,9 +2866,9 @@ ZSTDGPU_API void zstdgpu_RetrieveGpuResults(zstdgpu_ResourceDataCpu *outGpuResou
     zstdgpu_ResourceDataCpu_InitFromResourceDataGpu(outGpuResources, &req->resData);
 
     // HACK (pamartis): we copy block counts for now, because validation needs it, but we never compute block count on GPU
-    outGpuResources->Counters->Blocks_RAW = req->zstdRawBlockCount;
-    outGpuResources->Counters->Blocks_RLE = req->zstdRleBlockCount;
-    outGpuResources->Counters->Blocks_CMP = req->zstdCmpBlockCount;
+    outGpuResources->Counters->Blocks_RAW = req->zstdRawBlockCountMax;
+    outGpuResources->Counters->Blocks_RLE = req->zstdRleBlockCountMax;
+    outGpuResources->Counters->Blocks_CMP = req->zstdCmpBlockCountMax;
 }
 
 ZSTDGPU_API void zstdgpu_ReadbackTimestamps(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandList *cmdList)
@@ -2871,7 +2888,7 @@ ZSTDGPU_API void zstdgpu_RetrieveTimestamps(const wchar_t **outTimestampScopeNam
     else if (stageIndex == 1)
     {
         timestampScopeCountPerStage += 0 ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1_ALL_BLOCKS();
-        if (req->zstdCmpBlockCount > 0)
+        if (req->zstdCmpBlockCountMax > 0)
         {
             timestampScopeCountPerStage += 0 ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1_CMP_BLOCKS();
         }
@@ -2879,11 +2896,11 @@ ZSTDGPU_API void zstdgpu_RetrieveTimestamps(const wchar_t **outTimestampScopeNam
     else if (stageIndex == 2)
     {
         timestampScopeCountPerStage += 0 ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_ALL_BLOCKS();
-        if (req->zstdCmpBlockCount > 0)
+        if (req->zstdCmpBlockCountMax > 0)
         {
             timestampScopeCountPerStage += 0 ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_CMP_BLOCKS();
         }
-        if (req->zstdRawBlockCount > 0 || req->zstdRleBlockCount > 0)
+        if (req->zstdRawBlockCountMax > 0 || req->zstdRleBlockCountMax > 0)
         {
             timestampScopeCountPerStage += 0 ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_RAW_RLE_BLOCKS();
         }
@@ -2904,7 +2921,7 @@ ZSTDGPU_API void zstdgpu_RetrieveTimestamps(const wchar_t **outTimestampScopeNam
         else if (stageIndex == 1)
         {
             ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1_ALL_BLOCKS()
-            if (req->zstdCmpBlockCount > 0)
+            if (req->zstdCmpBlockCountMax > 0)
             {
                 ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1_CMP_BLOCKS();
             }
@@ -2912,11 +2929,11 @@ ZSTDGPU_API void zstdgpu_RetrieveTimestamps(const wchar_t **outTimestampScopeNam
         else if (stageIndex == 2)
         {
             ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_ALL_BLOCKS()
-            if (req->zstdCmpBlockCount > 0)
+            if (req->zstdCmpBlockCountMax > 0)
             {
                 ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_CMP_BLOCKS();
             }
-            if (req->zstdRawBlockCount > 0 || req->zstdRleBlockCount > 0)
+            if (req->zstdRawBlockCountMax > 0 || req->zstdRleBlockCountMax > 0)
             {
                 ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_RAW_RLE_BLOCKS();
             }

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -2257,7 +2257,7 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     if (req->zstdCmpBlockCountMax > 0)
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [Readback Counters :: After Block Parse] and [Update Dispatch Args] and [Compute `Per-Huffman Table` Literal Stream Count Prefix]");
-        D3D12_RESOURCE_BARRIER barriers[11];
+        D3D12_RESOURCE_BARRIER barriers[12];
         uint32_t bc = 0;
         // last written by [Parse Compressed Blocks]
         // next read by [Readback Counters :: After Block Parse] or [Update Dispatch Args]

--- a/zstd/zstdgpu/zstdgpu_resources.h
+++ b/zstd/zstdgpu/zstdgpu_resources.h
@@ -41,7 +41,8 @@
 
 #define ZSTDGPU_BUFFERS_LIST_STAGE_0() \
     ZSTDGPU_BUFFER(uint32_t                                 , DispatchArgs                  )   \
-    ZSTDGPU_BUFFER(uint32_t                                 , DispatchCnts                  )
+    ZSTDGPU_BUFFER(uint32_t                                 , DispatchCnts                  )   \
+    ZSTDGPU_BUFFER(uint64_t                                 , Predicate                     )   \
 
 #define ZSTDGPU_BUFFERS_LIST_UPLOAD_STAGE_2() /* empty so far*/
 
@@ -270,6 +271,7 @@ static void zstdgpu_ResourceInfo_Stage_0_InitSize(zstdgpu_ResourceInfo *outInfo,
     const uint32_t PerFrameSeqStreamMinIdx_Count = frameCount;
     const uint32_t DispatchArgs_Count = kzstdgpu_DispatchSlot_Count * kzstdgpu_DispatchSlot_StrideInUInt32;
     const uint32_t DispatchCnts_Count = kzstdgpu_DispatchSlot_Count;
+    const uint32_t Predicate_Count = 2;
 
     ZSTDGPU_ALL_BUFFERS_LIST_STAGE_0()
 }


### PR DESCRIPTION
This PR builds on #99 and adds support for predicated execution for stage 1/2 if respective constants are specified via `zstdgpu_SetupFrameInfoConstants` and / or `zstdgpu_SetupBlockInfoConstants`. This means the single submission mode (enabled when both `zstdgpu_SetupFrameInfoConstants` and `zstdgpu_SetupBlockInfoConstants` are used) becomes verified on GPU timeline: 
- early passes check whether supplied memory is insufficient to completed decompression based on discovered data
- if any of early passes detect supplied memory is insufficient, the rest of pipeline is skipped, allowing the entire operation to completed correctly without potential GPU hangs