### PR TITLE
zstdgpu/fix: brings fixes for `--chk-cpu` and `--sim-gpu` modes

### DIFF
--- a/zstd/zstdgpu/Shaders/ZstdGpuInitHuffmanTableAndDecompressLiterals.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuInitHuffmanTableAndDecompressLiterals.hlsl
@@ -55,5 +55,5 @@ void main(uint groupId : SV_GroupId, uint i : SV_GroupThreadId)
     if (groupId >= srt.inCounters[0].DecompressLiteralsGroups)
         return;
 
-    zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(srt, groupId, i);
+    zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(srt, groupId, i, kzstdgpu_TgSizeX_DecompressLiterals);
 }

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -454,7 +454,7 @@ static inline void zstdgpu_ShaderEntry_ParseFrame(ZSTDGPU_PARAM_INOUT(zstdgpu_Fr
             ZSTDGPU_BRANCH if (isRle)
             {
                 outBlocksRLERefs[outFrameInfo.rleBlockStart].offs = blockOffs;
-                outBlocksRLERefs[outFrameInfo.rleBlockStart].size = 1u;
+                outBlocksRLERefs[outFrameInfo.rleBlockStart].size = blockSize;
 
                 outRleBlockSizes[outFrameInfo.rleBlockStart] = outFrameInfo.rleBlockBytesStart;
                 outGlobalBlockIndexPerRleBlock[outFrameInfo.rleBlockStart] = blockIndex;

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -2927,7 +2927,7 @@ static void zstdgpu_ShaderEntry_DecompressLiterals(ZSTDGPU_PARAM_INOUT(zstdgpu_D
 ZSTDGPU_INIT_HUFFMAN_TABLE_AND_DECOMPRESS_LITERALS_LDS(0, InitHuffmanTableAndDecompressLiterals);
 #include "zstdgpu_lds_decl_undef.h"
 
-static void zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(ZSTDGPU_PARAM_INOUT(zstdgpu_InitHuffmanTable_And_DecompressLiterals_SRT) srt, uint32_t groupId, uint32_t threadId)
+static void zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(ZSTDGPU_PARAM_INOUT(zstdgpu_InitHuffmanTable_And_DecompressLiterals_SRT) srt, uint32_t groupId, uint32_t threadId, uint32_t tgSize)
 {
     uint32_t htIndex = 0;
     uint32_t htGroupStart = 0;
@@ -2964,7 +2964,7 @@ static void zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(ZSTDGPU_
         srt.inDecompressedHuffmanWeightCount,
         htIndex,
         threadId,
-        kzstdgpu_TgSizeX_DecompressLiterals,
+        tgSize,
         bitsMax,
         codeTableSize,
         GS_PreInit,
@@ -2980,7 +2980,7 @@ static void zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(ZSTDGPU_
     const uint32_t statePairCnt = stateCnt >> 1u;
 
     // Expand Huffman Table
-    ZSTDGPU_FOR_WORK_ITEMS(statePairId, statePairCnt, threadId, kzstdgpu_TgSizeX_DecompressLiterals)
+    ZSTDGPU_FOR_WORK_ITEMS(statePairId, statePairCnt, threadId, tgSize)
     {
         const uint32_t stateId0 = statePairId << 1u;
         const uint32_t stateId1 = stateId0 + 1u;
@@ -3016,7 +3016,7 @@ static void zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(ZSTDGPU_
         htLiteralStart,
         htLiteralCount,
         bitsMax,
-        kzstdgpu_TgSizeX_DecompressLiterals
+        tgSize
     );
 }
 

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -350,9 +350,19 @@ static void zstdgpu_Test_DecompressLiterals(zstdgpu_ResourceDataCpu & cpuRes, zs
         srt.inoutDecompressedLiterals   = cpuRes.DecompressedLiterals;
         srt.huffmanTableSlotCount       = gpuReadbackRes.Counters->Blocks_CMP;
 
-        for (uint32_t groupId = 0; groupId < gpuReadbackRes.Counters->DecompressLiteralsGroups; ++groupId)
+        // NOTE(pamartis): because on CPU we use `TGSize == 1`, the number of threadgroups per Huffman Table
+        // is the same as the number of literal streams
+        srt.inLitGroupEndPerHuffmanTable= srt.inLitStreamEndPerHuffmanTable;
+
+        uint32_t groupCount = 0;
+        if (srt.huffmanTableSlotCount > 0)
         {
-            zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(srt, groupId, 0);
+            groupCount = srt.inLitGroupEndPerHuffmanTable[srt.huffmanTableSlotCount - 1];
+        }
+
+        for (uint32_t groupId = 0; groupId < groupCount; ++groupId)
+        {
+            zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(srt, groupId, 0, 1);
         }
 
         if (chkGpu)
@@ -772,7 +782,7 @@ static void zstdgpu_Validate_GpuDecompressOnCpu(zstdgpu_ResourceDataCpu & zstdCp
             for (uint32_t i = 0; i < zstdCmpBlockCount; ++i)
             {
                 const uint32_t streamCount = zstdCpu.LitStreamEndPerHuffmanTable[i];
-                const uint32_t groupCount = ZSTDGPU_TG_COUNT(streamCount, kzstdgpu_TgSizeX_DecompressLiterals);
+                const uint32_t groupCount = streamCount;
                 streamPrefix += streamCount;
                 groupPrefix += groupCount;
                 zstdCpu.LitStreamEndPerHuffmanTable[i] = streamPrefix;
@@ -800,7 +810,7 @@ static void zstdgpu_Validate_GpuDecompressOnCpu(zstdgpu_ResourceDataCpu & zstdCp
         srt.huffmanTableSlotCount = zstdCmpBlockCount;
         for (uint32_t groupId = 0; groupId < groupPrefix; ++groupId)
         {
-            zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(srt, groupId, 0);
+            zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(srt, groupId, 0, 1);
         }
         VALIDATE(DecompressedLiterals(&zstdCpu));
     }


### PR DESCRIPTION
This PR brings several fixes for the following bugs:

- `--chk-cpu` mode now uses proper RLE block sizes to compute prefix sum of block sizes
- `--sim-gpu` mode now uses threadgroup size `==1` and corresponding group counts to decompress literals instead of group counts read back from GPU because those are computed after dynamic choice of threadgroup size.