### PR TITLE
Fix libdeflate compilation with Clang on Windows

### DIFF
--- a/GDeflate/3rdparty/libdeflate.cmake
+++ b/GDeflate/3rdparty/libdeflate.cmake
@@ -64,15 +64,22 @@ if (WIN32)
 # The follow warnings have been disabled to be able to compile this library without making modifications
 # to the original source.
 #  C4244 'return': conversion from 'uint64_t' to 'unsigned int', possible loss of data - compiler_msc.h 68
-#  C4127 conditional expression is constant - common_defs.h 290 
-#  C4267 'function': conversion from 'size_t' to 'uint32_t', possible loss of data - common_defs.h  291 
-#  C4100 'c': unreferenced formal parameter - deflate_compress.c    2428    
-#  C4245 '=': conversion from 'int' to 'unsigned int', signed/unsigned mismatch  - deflate_decompress.c 752 
-#  C4456 declaration of 'len' hides previous local declaration - deflate_compress.c 1118    
-#  C4018 '>=': signed/unsigned mismatch - decompress_template.h 297 
-#  C4146 unary minus operator applied to unsigned type, result still unsigned - bt_matchfinder.h    219 
-#  C4310 cast truncates constant value - bt_matchfinder.h   219 
-add_compile_options(/wd4244 /wd4127 /wd4267 /wd4100 /wd4245 /wd4456 /wd4018 /wd4146 /wd4310)
+#  C4127 conditional expression is constant - common_defs.h 290
+#  C4267 'function': conversion from 'size_t' to 'uint32_t', possible loss of data - common_defs.h  291
+#  C4100 'c': unreferenced formal parameter - deflate_compress.c    2428
+#  C4245 '=': conversion from 'int' to 'unsigned int', signed/unsigned mismatch  - deflate_decompress.c 752
+#  C4456 declaration of 'len' hides previous local declaration - deflate_compress.c 1118
+#  C4018 '>=': signed/unsigned mismatch - decompress_template.h 297
+#  C4146 unary minus operator applied to unsigned type, result still unsigned - bt_matchfinder.h    219
+#  C4310 cast truncates constant value - bt_matchfinder.h   219
+  if (MSVC)
+    # MSVC is TRUE for clang-cl too (CMAKE_<LANG>_COMPILER_FRONTEND_VARIANT=MSVC),
+    # so this covers both cl.exe and clang-cl.exe, which both accept /wd* flags.
+    add_compile_options(/wd4244 /wd4127 /wd4267 /wd4100 /wd4245 /wd4456 /wd4018 /wd4146 /wd4310)
+  else()
+    # Non-MSVC-frontend compilers (e.g. clang/clang++ with the GNU frontend) use -Wno-* flags.
+    add_compile_options(-Wno-conversion -Wno-unused-parameter -Wno-shadow)
+  endif (MSVC)
 endif (WIN32)
 
 include_directories(${LIBDEFLATE_DIR})


### PR DESCRIPTION
## Problem
Building GDeflate with Clang on Windows (clang-cl) failed for two reasons:

- `common_defs.h` included `compiler_gcc.h` only when `__GNUC__` was defined. clang-cl defines `__clang__` but does not always define `__GNUC__`, so the GCC-compatible intrinsics were never pulled in.
- `compiler_gcc.h` unconditionally defined `_rotr/_rotl` rotation macros, which conflicted with the MSVC-compatible definitions already provided by the Windows SDK when building with clang-cl.

Additionally, `libdeflate.cmake` applied MSVC warning-suppression flags (`/wd*`) unconditionally on Windows, which are not valid Clang flags.

### Changes
__libdeflate submodule:__
Now points at the merged upstream commit on the `gdeflate` branch (NVIDIA/libdeflate#4), which contains:
- `common/common_defs.h`: include `compiler_gcc.h` when `__clang__` is defined, not only `__GNUC__`
- `common/compiler_gcc.h`: guard `_rotr*` macro definitions with `#ifndef _MSC_VER`

__`GDeflate/3rdparty/libdeflate.cmake`:__
- Split warning-suppression flags into an `if (MSVC) / else()` block so MSVC-frontend builds (cl.exe and clang-cl.exe both set `MSVC=TRUE` in CMake) use `/wd*` flags, and GNU-frontend Clang builds use `-Wno-*` equivalents
- Added a comment clarifying that `MSVC` is `TRUE` for clang-cl as well, since this wasn't obvious from the code and came up in review

### Test plan
- Built `libdeflate_static` with `clang-cl` (MSVC frontend) — takes the `if(MSVC)` branch, `/wd*` flags applied, compiles cleanly with no redefinition errors
- Built `libdeflate_static` with `clang` (GNU frontend) — takes the `else()` branch, `-Wno-*` flags applied, compiles cleanly
- Build with MSVC — existing warning suppressions preserved