### PR TITLE
zstdgpu/imp: adds public api for single submission mode.

### DIFF
--- a/zstd/zstdgpu/Shaders/ZstdGpuDecodeHuffmanWeights.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecodeHuffmanWeights.hlsl
@@ -21,7 +21,6 @@ struct Consts
 {
     uint32_t tgOffset;
     uint32_t workItemCount;
-    uint32_t ZstdCompressedBlockCount;
     uint32_t ZstdCompressedBufferSizeInBytes;
 };
 
@@ -35,7 +34,7 @@ ZSTDGPU_DECODE_HUFFMAN_WEIGHTS_SRT()
 #define __XBOX_ENABLE_WAVE32 1
 #endif
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=3), UAV(u0, numDescriptors=2)), RootConstants(b0, num32BitConstants=4)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=3), UAV(u0, numDescriptors=2)), RootConstants(b0, num32BitConstants=3)")]
 [numthreads(kzstdgpu_TgSizeX_DecodeHuffmanWeights, 1, 1)]
 void main(uint2 groupId2 : SV_GroupID, uint32_t i : SV_GroupThreadId)
 {
@@ -46,7 +45,6 @@ void main(uint2 groupId2 : SV_GroupID, uint32_t i : SV_GroupThreadId)
     ZSTDGPU_DECODE_HUFFMAN_WEIGHTS_SRT()
     #include "../zstdgpu_srt_decl_undef.h"
 
-    srt.compressedBlockCount        = Constants.ZstdCompressedBlockCount;
     srt.compressedBufferSizeInBytes = Constants.ZstdCompressedBufferSizeInBytes;
     zstdgpu_ShaderEntry_DecodeHuffmanWeights(srt, i);
 }

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressLiterals.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressLiterals.hlsl
@@ -20,7 +20,6 @@ struct Consts
 {
     uint32_t tgOffset;
     uint32_t workItemCount;
-    uint32_t huffmanTableSlotCount;
 };
 
 ConstantBuffer<Consts> Constants : register(b0);
@@ -38,7 +37,7 @@ groupshared uint32_t GS_Lds[kzstdgpu_DecompressLiterals_LdsSize];
 #define __XBOX_ENABLE_WAVE32 1
 #endif
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=9), UAV(u0, numDescriptors=1)),RootConstants(b0, num32BitConstants=3)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=9), UAV(u0, numDescriptors=1)),RootConstants(b0, num32BitConstants=2)")]
 [numthreads(kzstdgpu_TgSizeX_DecompressLiterals, 1, 1)]
 void main(uint2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
 {
@@ -48,7 +47,6 @@ void main(uint2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
     #include "../zstdgpu_srt_decl_copy.h"
     ZSTDGPU_DECOMPRESS_LITERALS_SRT()
     #include "../zstdgpu_srt_decl_undef.h"
-    srt.huffmanTableSlotCount   = Constants.huffmanTableSlotCount;
 
     if (groupId >= srt.inCounters[0].DecompressLiteralsGroups)
         return;

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressLiterals_LdsStoreCache.hlsli
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressLiterals_LdsStoreCache.hlsli
@@ -58,7 +58,6 @@ struct Consts
 {
     uint32_t tgOffset;
     uint32_t workItemCount;
-    uint32_t huffmanTableSlotCount;
 };
 
 ConstantBuffer<Consts> Constants : register(b0);
@@ -71,7 +70,7 @@ groupshared uint32_t GS_Lds[kzstdgpu_DecompressLiterals_LdsStoreCache_LdsSize];
 #define ZSTDGPU_LDS GS_Lds
 #include "../zstdgpu_lds_hlsl.h"
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=9), UAV(u0, numDescriptors=2)), RootConstants(b0, num32BitConstants=3)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=9), UAV(u0, numDescriptors=2)), RootConstants(b0, num32BitConstants=2)")]
 [numthreads(kzstdgpu_TgSizeX_DecompressLiterals_LdsStoreCache, 1, 1)]
 void main(uint2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
 {
@@ -82,7 +81,6 @@ void main(uint2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
     #include "../zstdgpu_srt_decl_copy.h"
     ZSTDGPU_DECOMPRESS_LITERALS_SRT()
     #include "../zstdgpu_srt_decl_undef.h"
-    srt.huffmanTableSlotCount   = Constants.huffmanTableSlotCount;
 
     if (groupId >= srt.inCounters[0].DecompressLiteralsGroups)
         return;
@@ -98,7 +96,7 @@ void main(uint2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
         srt.inHufLitIdToLitStreamId,
         srt.inCounters[0].HufLit,
         srt.inCounters[0].HUF_Streams,
-        srt.huffmanTableSlotCount,
+        srt.inCounters[0].Blocks_CMP, // The number of Huffman table slots is the same as the number of Compressed blocks
         groupId,
         htIndex,
         htGroupStart,

--- a/zstd/zstdgpu/Shaders/ZstdGpuInitFseTable.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuInitFseTable.hlsl
@@ -46,9 +46,7 @@ struct Consts
 {
     uint32_t tgOffset;
     uint32_t workItemCount;
-    uint32_t tableStartIndex;
-    uint32_t tableDataStart;
-    uint32_t tableDataCount;
+    uint32_t tableType; // 0=HufW, 1=LLen, 2=Offs, 3=MLen
 };
 
 ConstantBuffer<Consts> Constants : register(b0);
@@ -66,7 +64,7 @@ groupshared uint32_t Lds[kzstdgpu_InitFseTable_Experimental_LdsSize];
 #define ZSTDGPU_LDS Lds
 #include "../zstdgpu_lds_hlsl.h"
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors = 2), UAV(u0, numDescriptors=1)), RootConstants(b0, num32BitConstants=5)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors = 3), UAV(u0, numDescriptors=1)), RootConstants(b0, num32BitConstants=3)")]
 [numthreads(kzstdgpu_TgSizeX_InitFseTable, 1, 1)]
 void main(uint2 groupId2 : SV_GroupId, uint32_t i : SV_GroupThreadId)
 {
@@ -77,8 +75,31 @@ void main(uint2 groupId2 : SV_GroupId, uint32_t i : SV_GroupThreadId)
     #include "../zstdgpu_srt_decl_copy.h"
     ZSTDGPU_INIT_FSE_TABLE_SRT()
     #include "../zstdgpu_srt_decl_undef.h"
-    srt.tableStartIndex = Constants.tableStartIndex;
-    srt.tableDataStart  = Constants.tableDataStart;
-    srt.tableDataCount  = Constants.tableDataCount;
+
+    const uint32_t cmpBlockCount = srt.inCounters[0].Blocks_CMP;
+    if (Constants.tableType == 1u) // LLen
+    {
+        srt.tableStartIndex = cmpBlockCount;
+        srt.tableDataStart  = zstdgpu_ComputeFseDataStartLLen(0, cmpBlockCount);
+        srt.tableDataCount  = kzstdgpu_FseElemMaxCount_LLen;
+    }
+    else if (Constants.tableType == 2u) // Offs
+    {
+        srt.tableStartIndex = 2u * cmpBlockCount + 1u;
+        srt.tableDataStart  = zstdgpu_ComputeFseDataStartOffs(0, cmpBlockCount);
+        srt.tableDataCount  = kzstdgpu_FseElemMaxCount_Offs;
+    }
+    else if (Constants.tableType == 3u) // MLen
+    {
+        srt.tableStartIndex = 3u * cmpBlockCount + 2u;
+        srt.tableDataStart  = zstdgpu_ComputeFseDataStartMLen(0, cmpBlockCount);
+        srt.tableDataCount  = kzstdgpu_FseElemMaxCount_MLen;
+    }
+    else // 0 == HufW
+    {
+        srt.tableStartIndex = 0u;
+        srt.tableDataStart  = zstdgpu_ComputeFseDataStartHufW(0, cmpBlockCount);
+        srt.tableDataCount  = kzstdgpu_FseElemMaxCount_HufW;
+    }
     zstdgpu_ShaderEntry_InitFseTable(srt, groupId, i);
 }

--- a/zstd/zstdgpu/Shaders/ZstdGpuInitHuffmanTable.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuInitHuffmanTable.hlsl
@@ -21,7 +21,8 @@ struct Consts
 {
     uint32_t tgOffset;
     uint32_t workItemCount;
-    uint32_t HuffmanTableBase;
+    uint32_t fseCompressed; // 1 - means FSE-compressed weights (at the start of the buffer),
+                            // 0 - means uncompressed weight (at the end of buffer)
 };
 
 ConstantBuffer<Consts> Constants : register(b0);
@@ -39,7 +40,7 @@ groupshared uint32_t GS_Lds[kzstdgpu_InitHuffmanTable_LdsSize];
 #define __XBOX_ENABLE_WAVE32 1
 #endif
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=2), UAV(u0, numDescriptors=3)), RootConstants(b0, num32BitConstants=3)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=3), UAV(u0, numDescriptors=3)), RootConstants(b0, num32BitConstants=3)")]
 [numthreads(kzstdgpu_TgSizeX_DecompressLiterals, 1, 1)]
 void main(uint2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
 {
@@ -51,7 +52,7 @@ void main(uint2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
 
     uint32_t groupId = zstdgpu_ConvertTo32BitGroupId(groupId2, Constants.tgOffset);
 
-    groupId = (Constants.HuffmanTableBase != 0) ? (Constants.HuffmanTableBase - 1 - groupId) : groupId;
+    groupId = (Constants.fseCompressed == 0u) ? (srt.inCounters[0].Blocks_CMP - 1u - groupId) : groupId;
 
     zstdgpu_ShaderEntry_InitHuffmanTable(srt, groupId, i, kzstdgpu_TgSizeX_DecompressLiterals);
 }

--- a/zstd/zstdgpu/Shaders/ZstdGpuInitHuffmanTableAndDecompressLiterals.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuInitHuffmanTableAndDecompressLiterals.hlsl
@@ -21,13 +21,6 @@
 #pragma dxc diagnostic ignored "-Wfor-redefinition"
 #endif
 
-struct Consts
-{
-    uint32_t huffmanTableSlotCount;
-};
-
-ConstantBuffer<Consts> Constants : register(b0);
-
 #include "../zstdgpu_srt_decl_bind.h"
 ZSTDGPU_INIT_HUFFMAN_TABLE_AND_DECOMPRESS_LITERALS_SRT()
 #include "../zstdgpu_srt_decl_undef.h"
@@ -41,7 +34,7 @@ groupshared uint32_t GS_Lds[kzstdgpu_InitHuffmanTableAndDecompressLiterals_LdsSi
 #define __XBOX_ENABLE_WAVE32 1
 #endif
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=8), UAV(u0, numDescriptors=1)),RootConstants(b0, num32BitConstants=1)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=8), UAV(u0, numDescriptors=1))")]
 [numthreads(kzstdgpu_TgSizeX_DecompressLiterals, 1, 1)]
 void main(uint groupId : SV_GroupId, uint i : SV_GroupThreadId)
 {
@@ -50,7 +43,6 @@ void main(uint groupId : SV_GroupId, uint i : SV_GroupThreadId)
     #include "../zstdgpu_srt_decl_copy.h"
     ZSTDGPU_INIT_HUFFMAN_TABLE_AND_DECOMPRESS_LITERALS_SRT()
     #include "../zstdgpu_srt_decl_undef.h"
-    srt.huffmanTableSlotCount   = Constants.huffmanTableSlotCount;
 
     if (groupId >= srt.inCounters[0].DecompressLiteralsGroups)
         return;

--- a/zstd/zstdgpu/Shaders/ZstdGpuMemsetMemcpy.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuMemsetMemcpy.hlsl
@@ -31,15 +31,15 @@ ConstantBuffer<Consts>                  Constants                           : re
 ZSTDGPU_MEMSET_MEMCPY_SRT()
 #include "../zstdgpu_srt_decl_undef.h"
 
-StructuredBuffer<uint32_t>              ZstdInBlockSizePrefixTyped          : register(t4);
+StructuredBuffer<uint32_t>              ZstdInBlockSizePrefixTyped          : register(t5);
 
-StructuredBuffer<uint32_t>              ZstdInPerFrameBlockSizePrefixTyped  : register(t5);
+StructuredBuffer<uint32_t>              ZstdInPerFrameBlockSizePrefixTyped  : register(t6);
 
-StructuredBuffer<zstdgpu_OffsetAndSize> ZstdInBlocksRefsTyped               : register(t6);
+StructuredBuffer<zstdgpu_OffsetAndSize> ZstdInBlocksRefsTyped               : register(t7);
 
-StructuredBuffer<uint32_t>              ZstdInGlobalBlockIndexTyped         : register(t7);
+StructuredBuffer<uint32_t>              ZstdInGlobalBlockIndexTyped         : register(t8);
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=4), UAV(u0, numDescriptors=1)), SRV(t4), SRV(t5), SRV(t6), SRV(t7), RootConstants(b0, num32BitConstants=5)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=5), UAV(u0, numDescriptors=1)), SRV(t5), SRV(t6), SRV(t7), SRV(t8), RootConstants(b0, num32BitConstants=5)")]
 [numthreads(kzstdgpu_TgSizeX_MemsetMemcpy, 1, 1)]
 void main(uint2 groupId : SV_GroupId, uint i : SV_GroupThreadId)
 {
@@ -48,7 +48,8 @@ void main(uint2 groupId : SV_GroupId, uint i : SV_GroupThreadId)
     if (i >= Constants.workItemCount)
         return;
 
-    const uint32_t blockIdx = zstdgpu_BinarySearch(ZstdInBlockSizePrefixTyped, 0, Constants.blockCount, i);
+    const uint32_t blockCnt = (Constants.flags & 0x1u) ? ZstdInCounters[0].Blocks_RAW : ZstdInCounters[0].Blocks_RLE;
+    const uint32_t blockIdx = zstdgpu_BinarySearch(ZstdInBlockSizePrefixTyped, 0, blockCnt, i);
 
     const zstdgpu_OffsetAndSize blockRef = ZstdInBlocksRefsTyped[blockIdx];
 

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -811,18 +811,18 @@ static const zstdgpu_CompiledShader kzstdgpu_CompiledShaders [] =
 #define ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_0() \
     ZSTDGPU_KERNEL_SCOPE_X(InitResources_CountBlocks            , L"Init Resources"             )   \
     ZSTDGPU_KERNEL_SCOPE_X(ParseFrames_CountBlocks              , L"Parse Frames"               )   \
-    ZSTDGPU_KERNEL_SCOPE_X(PrefixSum                            , L"Prefix Sums"                )
+    ZSTDGPU_KERNEL_SCOPE_X(PrefixSum                            , L"Prefix Sums"                )   \
+    ZSTDGPU_KERNEL_SCOPE_X(UpdateDispatchArgs_Stage0            , L"UpdateDispatchArgs:: Stage0")
 
-#define ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1_ALL_BLOCKS() \
+#define ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1() \
     ZSTDGPU_KERNEL_SCOPE_X(InitResources                        , L"Init Resources"             )   \
-    ZSTDGPU_KERNEL_SCOPE_X(ParseFrames                          , L"Parse Frames"               )
-
-#define ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1_CMP_BLOCKS() \
+    ZSTDGPU_KERNEL_SCOPE_X(ParseFrames                          , L"Parse Frames"               )   \
     ZSTDGPU_KERNEL_SCOPE_X(ParseCompressedBlocks                , L"Parse Compressed Blocks"    )   \
-    ZSTDGPU_KERNEL_SCOPE_X(PropagateFseIndex                    , L"Propagate FSE Index"        )
+    ZSTDGPU_KERNEL_SCOPE_X(PropagateFseIndex                    , L"Propagate FSE Index"        )   \
+    ZSTDGPU_KERNEL_SCOPE_X(UpdateDispatchArgs_Stage1            , L"UpdateDispatchArgs:: Stage1")
 
-#define ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_CMP_BLOCKS() \
-    ZSTDGPU_KERNEL_SCOPE_X(UpdateDispatchArgs                   , L"Update Dispatch Arguments"  )   \
+#define ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2() \
+    ZSTDGPU_KERNEL_SCOPE_X(UpdateDispatchArgs_DecompressLiterals, L"UpdateDispatchArgs:: Stage2")   \
     ZSTDGPU_KERNEL_SCOPE_X(ComputePrefixSum                     , L"Compute Prefix Sums"        )   \
     ZSTDGPU_KERNEL_SCOPE_X(InitFseTable                         , L"Init FSE Tables"            )   \
     ZSTDGPU_KERNEL_SCOPE_X(DecompressHuffmanWeights             , L"Decompress Huffman Weights" )   \
@@ -832,21 +832,50 @@ static const zstdgpu_CompiledShader kzstdgpu_CompiledShaders [] =
     ZSTDGPU_KERNEL_SCOPE_X(DecompressSequences                  , L"Decompress Sequences"       )   \
     ZSTDGPU_KERNEL_SCOPE_X(PrefixSequenceOffsets                , L"Propagate Sequence Offsets" )   \
     ZSTDGPU_KERNEL_SCOPE_X(FinaliseSequenceOffsets              , L"Finalise Sequence Offsets"  )   \
-    ZSTDGPU_KERNEL_SCOPE_X(ExecuteSequences                     , L"ExecuteSequences"           )
-
-#define ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_RAW_RLE_BLOCKS() \
-    ZSTDGPU_KERNEL_SCOPE_X(MemcpyRAW_MemsetRLE                  , L"Memcpy Raw/Memset RLE Blocks")
-
-#define ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_ALL_BLOCKS() \
+    ZSTDGPU_KERNEL_SCOPE_X(ExecuteSequences                     , L"ExecuteSequences"           )   \
+    ZSTDGPU_KERNEL_SCOPE_X(MemcpyRAW_MemsetRLE                  , L"Memcpy Raw/Memset RLE Blocks")  \
     ZSTDGPU_KERNEL_SCOPE_X(PrefixBlockSizes                     , L"Prefix Block Sizes"         )
 
-#define ZSTDGPU_KERNEL_SCOPE_LIST()                     \
-    ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_0()                 \
-    ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1_ALL_BLOCKS()      \
-    ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1_CMP_BLOCKS()      \
-    ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_CMP_BLOCKS()      \
-    ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_RAW_RLE_BLOCKS()  \
-    ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_ALL_BLOCKS()
+#define ZSTDGPU_KERNEL_SCOPE_LIST()     \
+    ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_0() \
+    ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1() \
+    ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2()
+
+enum zstdgpu_KernelScopeId
+{
+    kzstdgpu_KernelScope_Stage0_Start,
+    kzstdgpu_KernelScope_Stage0_End,
+    kzstdgpu_KernelScope_Stage1_Start,
+    kzstdgpu_KernelScope_Stage1_End,
+    kzstdgpu_KernelScope_Stage2_Start,
+    kzstdgpu_KernelScope_Stage2_End,
+
+#define ZSTDGPU_KERNEL_SCOPE_X(name, desc) kzstdgpu_KernelScope_##name,
+    ZSTDGPU_KERNEL_SCOPE_LIST()
+#undef  ZSTDGPU_KERNEL_SCOPE_X
+
+    kzstdgpu_KernelScope_Count,
+
+#define ZSTDGPU_KERNEL_SCOPE_X(name, desc) + 1
+    kzstdgpu_KernelScope_Stage0Count = 0 + (ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_0()),
+    kzstdgpu_KernelScope_Stage1Count = 0 + (ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1()),
+    kzstdgpu_KernelScope_Stage2Count = 0 + (ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2()),
+#undef  ZSTDGPU_KERNEL_SCOPE_X
+
+    kzstdgpu_KernelScope_StageSlotCount = kzstdgpu_KernelScope_Stage2_End + 1,
+    kzstdgpu_KernelScope_Stage0Start = kzstdgpu_KernelScope_StageSlotCount,
+    kzstdgpu_KernelScope_Stage1Start = kzstdgpu_KernelScope_Stage0Start + kzstdgpu_KernelScope_Stage0Count,
+    kzstdgpu_KernelScope_Stage2Start = kzstdgpu_KernelScope_Stage1Start + kzstdgpu_KernelScope_Stage1Count,
+
+    kzstdgpu_KernelScope_ForceInt    = 0x3fffffff
+};
+
+static const wchar_t * kzstdgpu_KernelScopeDesc[] =
+{
+#define ZSTDGPU_KERNEL_SCOPE_X(name, desc) desc,
+    ZSTDGPU_KERNEL_SCOPE_LIST()
+#undef  ZSTDGPU_KERNEL_SCOPE_X
+};
 
 struct zstdgpu_PersistentContextImpl
 {
@@ -904,9 +933,7 @@ struct zstdgpu_PerRequestContextImpl
 
     d3d12aid_Timestamps     timestamps;
 
-    #define ZSTDGPU_KERNEL_SCOPE_X(name, desc) uint32_t name##_TimestampSlot;
-        ZSTDGPU_KERNEL_SCOPE_LIST()
-    #undef  ZSTDGPU_KERNEL_SCOPE_X
+    uint32_t                timestampSlot[kzstdgpu_KernelScope_Count];
 
     uint32_t                zstdFrameCount;
     uint32_t                zstdCompressedFramesByteCount;
@@ -1161,11 +1188,7 @@ ZSTDGPU_ENUM(Status) zstdgpu_CreatePerRequestContext(zstdgpu_PerRequestContext *
         context->uncompressedFramesData             = NULL;
         context->uncompressedFramesRefs             = NULL;
 
-        const uint32_t timestampCount = 0
-        #define ZSTDGPU_KERNEL_SCOPE_X(name, desc) +2
-            ZSTDGPU_KERNEL_SCOPE_LIST();
-        #undef  ZSTDGPU_KERNEL_SCOPE_X
-        d3d12aid_Timestamps_Create(&context->timestamps, context->device, timestampCount, 1);
+        d3d12aid_Timestamps_Create(&context->timestamps, context->device, kzstdgpu_KernelScope_Count * 2, 1);
 
         context->zstdFrameCount                     = 0;
         context->zstdCompressedFramesByteCount      = 0;
@@ -2255,7 +2278,7 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitAllStagesWithInteralMemory(zstdgpu_PerRequest
 #define ZSTDGPU_KERNEL_SCOPE(name, cmdList, statement)                                  \
     do                                                                                  \
     {                                                                                   \
-        req->name##_TimestampSlot = d3d12aid_Timestamps_Push(&req->timestamps, cmdList);\
+        req->timestampSlot[kzstdgpu_KernelScope_##name] = d3d12aid_Timestamps_Push(&req->timestamps, cmdList);\
         statement                                                                       \
         d3d12aid_Timestamps_Push(&req->timestamps, cmdList);                            \
     }                                                                                   \
@@ -2308,6 +2331,12 @@ static void zstdgpu_Dispatch32Bit(ID3D12GraphicsCommandList *cmdList, uint32_t t
 
 void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandList *cmdList)
 {
+#if ZSTDGPU_ENABLE_TIMESTAMPS
+    // NOTE(pamartis): reset the per-scope timestamp slots to ~0u here.
+    // Scopes that are pushed conditionally then remain ~0u and are ignored by zstdgpu_RetrieveTimestamps.
+    for (uint32_t i = 0; i < kzstdgpu_KernelScope_Count; ++i)
+        req->timestampSlot[i] = ~0u;
+#endif
     {
         D3D12_RESOURCE_BARRIER barriers[3];
         uint32_t uploadBarrierCount = 0;
@@ -2332,6 +2361,10 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         }
         cmdList->ResourceBarrier(uploadBarrierCount, barriers);
     }
+#if ZSTDGPU_ENABLE_TIMESTAMPS
+    // NOTE(pamartis): So far we don't include upload into measurement intentionally
+    req->timestampSlot[kzstdgpu_KernelScope_Stage0_Start] = d3d12aid_Timestamps_Push(&req->timestamps, cmdList);
+#endif
     {
         const uint32_t initResourcesStage = 0;
         const uint32_t allBlockCount = 0;
@@ -2540,9 +2573,15 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         zstdgpu_PushReadback(Counters);
         PIXEndEvent(cmdList);
     }
+#if ZSTDGPU_ENABLE_TIMESTAMPS
+    req->timestampSlot[kzstdgpu_KernelScope_Stage0_End] = d3d12aid_Timestamps_Push(&req->timestamps, cmdList);
+#endif
 }
 void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandList *cmdList)
 {
+#if ZSTDGPU_ENABLE_TIMESTAMPS
+    req->timestampSlot[kzstdgpu_KernelScope_Stage1_Start] = d3d12aid_Timestamps_Push(&req->timestamps, cmdList);
+#endif
     /**
      *  NOTE(pamartis): We enable predication only when Frame Info constants if setup
      *  because in this case the submission can be done in a single command list because
@@ -2829,7 +2868,7 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRoot32BitConstant(4, req->zstdRleBlockCountMax, 4);
         cmdList->SetComputeRoot32BitConstant(4, req->zstdUncompressedLitByteCountMax, 5);
         cmdList->SetComputeRoot32BitConstant(4, req->zstdUncompressedSeqElemCountMax, 6);
-        ZSTDGPU_KERNEL_SCOPE(UpdateDispatchArgs, cmdList,
+        ZSTDGPU_KERNEL_SCOPE(UpdateDispatchArgs_Stage1, cmdList,
             cmdList->Dispatch(1, 1, 1);
         );
         PIXEndEvent(cmdList);
@@ -2916,10 +2955,16 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         zstdgpu_PushReadback(Counters);
         PIXEndEvent(cmdList);
     }
+#if ZSTDGPU_ENABLE_TIMESTAMPS
+    req->timestampSlot[kzstdgpu_KernelScope_Stage1_End] = d3d12aid_Timestamps_Push(&req->timestamps, cmdList);
+#endif
 }
 
 void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandList *cmdList)
 {
+#if ZSTDGPU_ENABLE_TIMESTAMPS
+    req->timestampSlot[kzstdgpu_KernelScope_Stage2_Start] = d3d12aid_Timestamps_Push(&req->timestamps, cmdList);
+#endif
     if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasBlockInfoConstants))
     {
         cmdList->SetPredication(req->resData.gpuOnly.Predicate, sizeof(uint64_t) /* Stage 2 predicate */, D3D12_PREDICATION_OP_NOT_EQUAL_ZERO);
@@ -3412,6 +3457,9 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     {
         cmdList->SetPredication(NULL, 0, D3D12_PREDICATION_OP_EQUAL_ZERO);
     }
+#if ZSTDGPU_ENABLE_TIMESTAMPS
+    req->timestampSlot[kzstdgpu_KernelScope_Stage2_End] = d3d12aid_Timestamps_Push(&req->timestamps, cmdList);
+#endif
 }
 
 ZSTDGPU_API void zstdgpu_ReadbackGpuResults(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandList *cmdList)
@@ -3474,74 +3522,37 @@ ZSTDGPU_API void zstdgpu_ReadbackTimestamps(zstdgpu_PerRequestContext req, ID3D1
     d3d12aid_Timestamps_AdvanceFrame(&req->timestamps, cmdList);
 }
 
-ZSTDGPU_API void zstdgpu_RetrieveTimestamps(const wchar_t **outTimestampScopeNames, uint64_t *outTimestampScopeClocks, uint32_t *inoutTimestampScopeCnt, zstdgpu_PerRequestContext req, uint32_t stageIndex)
+ZSTDGPU_API uint64_t zstdgpu_RetrieveTimestamps(const wchar_t **outTimestampScopeNames, uint64_t *outTimestampScopeClocks, uint32_t *inoutTimestampScopeCnt, zstdgpu_PerRequestContext req, uint32_t stageIndex)
 {
 #if ZSTDGPU_ENABLE_TIMESTAMPS
-    uint32_t timestampScopeCountPerStage = 0;
-    #define ZSTDGPU_KERNEL_SCOPE_X(name, desc) +1
-    if (stageIndex == 0)
-    {
-        timestampScopeCountPerStage += 0 ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_0();
-    }
-    else if (stageIndex == 1)
-    {
-        timestampScopeCountPerStage += 0 ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1_ALL_BLOCKS();
-        if (req->zstdCmpBlockCountMax > 0)
-        {
-            timestampScopeCountPerStage += 0 ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1_CMP_BLOCKS();
-        }
-    }
-    else if (stageIndex == 2)
-    {
-        timestampScopeCountPerStage += 0 ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_ALL_BLOCKS();
-        if (req->zstdCmpBlockCountMax > 0)
-        {
-            timestampScopeCountPerStage += 0 ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_CMP_BLOCKS();
-        }
-        if (req->zstdRawBlockCountMax > 0 || req->zstdRleBlockCountMax > 0)
-        {
-            timestampScopeCountPerStage += 0 ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_RAW_RLE_BLOCKS();
-        }
-    }
-    #undef  ZSTDGPU_KERNEL_SCOPE_X
+    const uint32_t start = 0 == stageIndex ? kzstdgpu_KernelScope_Stage0Start : (1 == stageIndex ? kzstdgpu_KernelScope_Stage1Start : kzstdgpu_KernelScope_Stage2Start);
+    const uint32_t count = 0 == stageIndex ? kzstdgpu_KernelScope_Stage0Count : (1 == stageIndex ? kzstdgpu_KernelScope_Stage1Count : kzstdgpu_KernelScope_Stage2Count);
 
-    if (timestampScopeCountPerStage > 0 && *inoutTimestampScopeCnt >= timestampScopeCountPerStage)
+    const uint32_t stageStartSlot = 0 == stageIndex ? kzstdgpu_KernelScope_Stage0_Start : (1 == stageIndex ? kzstdgpu_KernelScope_Stage1_Start : kzstdgpu_KernelScope_Stage2_Start);
+    const uint32_t stageEndSlot   = 0 == stageIndex ? kzstdgpu_KernelScope_Stage0_End   : (1 == stageIndex ? kzstdgpu_KernelScope_Stage1_End   : kzstdgpu_KernelScope_Stage2_End);
+
+    uint32_t outSlotCount = 0;
+    uint32_t reqSlotCount = 0;
+
+    for (uint32_t i = start; i < start + count; ++i)
     {
-        *inoutTimestampScopeCnt = timestampScopeCountPerStage;
-        uint32_t i = 0;
-        #define ZSTDGPU_KERNEL_SCOPE_X(name, desc)  \
-            outTimestampScopeNames[i] = desc;       \
-            outTimestampScopeClocks[i++] = d3d12aid_Timestamps_GetScopeDelta(&req->timestamps, 0, req->name##_TimestampSlot);
-        if (stageIndex == 0)
-        {
-            ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_0()
-        }
-        else if (stageIndex == 1)
-        {
-            ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1_ALL_BLOCKS()
-            if (req->zstdCmpBlockCountMax > 0)
-            {
-                ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_1_CMP_BLOCKS();
-            }
-        }
-        else if (stageIndex == 2)
-        {
-            ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_ALL_BLOCKS()
-            if (req->zstdCmpBlockCountMax > 0)
-            {
-                ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_CMP_BLOCKS();
-            }
-            if (req->zstdRawBlockCountMax > 0 || req->zstdRleBlockCountMax > 0)
-            {
-                ZSTDGPU_KERNEL_SCOPE_LIST_STAGE_2_RAW_RLE_BLOCKS();
-            }
-        }
-        #undef  ZSTDGPU_KERNEL_SCOPE_X
+        reqSlotCount += ~0u != req->timestampSlot[i] ? 1u : 0u;
     }
-    else
+
+    if (reqSlotCount <= *inoutTimestampScopeCnt)
     {
-        *inoutTimestampScopeCnt = 0;
+        for (uint32_t i = start; i < start + count; ++i)
+        {
+            if (~0u != req->timestampSlot[i])
+            {
+                outTimestampScopeNames[outSlotCount] = kzstdgpu_KernelScopeDesc[i - kzstdgpu_KernelScope_StageSlotCount];
+                outTimestampScopeClocks[outSlotCount ++] = d3d12aid_Timestamps_GetScopeDelta(&req->timestamps, 0, req->timestampSlot[i]);
+            }
+        }
     }
+
+    *inoutTimestampScopeCnt = outSlotCount;
+    return d3d12aid_Timestamps_GetDelta(&req->timestamps, 0, req->timestampSlot[stageStartSlot], req->timestampSlot[stageEndSlot]);
 #else
     *inoutTimestampScopeCnt = 0;
 
@@ -3549,5 +3560,6 @@ ZSTDGPU_API void zstdgpu_RetrieveTimestamps(const wchar_t **outTimestampScopeNam
     ZSTDGPU_UNUSED(outTimestampScopeClocks);
     ZSTDGPU_UNUSED(req);
     ZSTDGPU_UNUSED(stageIndex);
+    return 0;
 #endif /* #if ZSTDGPU_ENABLE_TIMESTAMPS */
 }

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -1429,7 +1429,7 @@ static uint32_t zstdgpu_OutputSizeToSequenceCount(uint32_t size)
 {
     // NOTE(pamartis): 8 bytes per sequence is emperical estimation, not something stipulated
     // by ZSTD standard.
-    return size >> 4;
+    return size >> 3;
 }
 
 ZSTDGPU_ENUM(Status) zstdgpu_GetGpuMemoryRequirement(uint32_t *outDefaultHeapByteCount, uint32_t *outUploadHeapByteCount, uint32_t *outReadbackHeapByteCount, uint32_t *outShaderVisibleDescriptorCount, zstdgpu_PerRequestContext req, uint32_t stageIndex)
@@ -1536,16 +1536,18 @@ static void zstdgpu_GetAllStageGpuMemoryRequirementInternal(uint32_t *outDefault
     uint32_t cntRaw, cntRle, cntCmp, cntLit, cntSeq;
     zstdgpu_ResourceInfo_Stage_0_Init(&req->resInfo, req->zstdFrameCount, req->zstdCompressedFramesByteCount, zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_InputsGpuMemory) ? 1u : 0u);
 
-    if (0 == zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasSingleSubmission))
+    // NOTE(pamartis):
+    // If 'frame' constants were setup, we prioritize those assuming they are based on some knowledge about submitted data,
+    // otherwise rely on estimation which may be underestimation
+    if (0 != zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasFrameInfoConstants))
     {
-        ZSTDGPU_ASSERT(0 != zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasFrameInfoConstants));
         cntRaw = req->zstdRawBlockCountMax;
         cntRle = req->zstdRleBlockCountMax;
         cntCmp = req->zstdCmpBlockCountMax;
-
     }
     else
     {
+        ZSTDGPU_ASSERT(0 == zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasSingleSubmission));
         cntRaw = cntRle = cntCmp = zstdgpu_OutputSizeToBlockCount(req->zstdUncompressedFramesByteCount);
 
         req->zstdRawBlockCountMax = cntRaw;
@@ -1554,14 +1556,15 @@ static void zstdgpu_GetAllStageGpuMemoryRequirementInternal(uint32_t *outDefault
     }
     zstdgpu_ResourceInfo_Stage_1_Init(&req->resInfo, cntRaw, cntRle, cntCmp);
 
-    if (0 == zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasSingleSubmission))
+    if (0 != zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasBlockInfoConstants) )
     {
-        ZSTDGPU_ASSERT(0 != zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasBlockInfoConstants));
         cntLit = req->zstdUncompressedLitByteCountMax;
         cntSeq = req->zstdUncompressedSeqElemCountMax;
     }
     else
     {
+        ZSTDGPU_ASSERT(0 == zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasSingleSubmission));
+
         // NOTE(pamartis): it's a huge overestimate, but it's best we can do safely,
         // a single output byte requires 1 byte for literal storage
         cntLit = req->zstdUncompressedFramesByteCount;

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -3370,11 +3370,6 @@ ZSTDGPU_API void zstdgpu_ReadbackGpuResults(zstdgpu_PerRequestContext req, ID3D1
 ZSTDGPU_API void zstdgpu_RetrieveGpuResults(zstdgpu_ResourceDataCpu *outGpuResources, zstdgpu_PerRequestContext req)
 {
     zstdgpu_ResourceDataCpu_InitFromResourceDataGpu(outGpuResources, &req->resData);
-
-    // HACK (pamartis): we copy block counts for now, because validation needs it, but we never compute block count on GPU
-    outGpuResources->Counters->Blocks_RAW = req->zstdRawBlockCountMax;
-    outGpuResources->Counters->Blocks_RLE = req->zstdRleBlockCountMax;
-    outGpuResources->Counters->Blocks_CMP = req->zstdCmpBlockCountMax;
 }
 
 ZSTDGPU_API void zstdgpu_ReadbackTimestamps(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandList *cmdList)

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -869,6 +869,7 @@ static const uint32_t kzstdgpu_SetupFlags_InputsCpuMemory       = (1u << 0);
 static const uint32_t kzstdgpu_SetupFlags_InputsGpuMemory       = (1u << 1);
 static const uint32_t kzstdgpu_SetupFlags_HasFrameInfoConstants = (1u << 2);
 static const uint32_t kzstdgpu_SetupFlags_HasBlockInfoConstants = (1u << 3);
+static const uint32_t kzstdgpu_SetupFlags_HasSingleSubmission   = (1u << 4);
 
 static const uint32_t kzstdgpu_SetupFlags_InputsMask = kzstdgpu_SetupFlags_InputsCpuMemory | kzstdgpu_SetupFlags_InputsGpuMemory;
 
@@ -1334,6 +1335,21 @@ ZSTDGPU_API ZSTDGPU_ENUM(Status) zstdgpu_SetupOutputs(zstdgpu_PerRequestContext 
     return ZSTDGPU_ENUM_CONST(StatusInvalidArgument);
 }
 
+ZSTDGPU_ENUM(Status) zstdgpu_SetupAllStageSubmission(zstdgpu_PerRequestContext req)
+{
+    uint32_t proceed = 1;
+    proceed = proceed && (NULL != req);
+    proceed = proceed && (req->thisMemoryBlock == (void *)req);
+    ZSTDGPU_ASSERT(proceed > 0);
+
+    if (proceed)
+    {
+        req->setupFlags |= kzstdgpu_SetupFlags_HasSingleSubmission;
+        return ZSTDGPU_ENUM_CONST(StatusSuccess);
+    }
+    return ZSTDGPU_ENUM_CONST(StatusInvalidArgument);
+}
+
 ZSTDGPU_ENUM(Status) zstdgpu_SetupFrameInfoConstants(zstdgpu_PerRequestContext inPerRequestContext, uint32_t rawBlockCount, uint32_t rleBlockCount, uint32_t cmpBlockCount)
 {
     uint32_t proceed = 1;
@@ -1368,23 +1384,52 @@ ZSTDGPU_ENUM(Status) zstdgpu_SetupBlockInfoConstants(zstdgpu_PerRequestContext i
     return ZSTDGPU_ENUM_CONST(StatusInvalidArgument);
 }
 
-uint32_t zstdgpu_IsReadbackRequired(zstdgpu_PerRequestContext inPerRequestContext, uint32_t stageIndex)
+uint32_t zstdgpu_IsReadbackRequired(zstdgpu_PerRequestContext req, uint32_t stageIndex)
 {
+    uint32_t reqFlags = 0;
+
     if (stageIndex == 0)
     {
-        return zstdgpu_HasFlag(inPerRequestContext->setupFlags, kzstdgpu_SetupFlags_HasFrameInfoConstants) ? 0 : 1;
+        reqFlags = kzstdgpu_SetupFlags_HasFrameInfoConstants | kzstdgpu_SetupFlags_HasSingleSubmission;
     }
-    if (stageIndex == 1)
+    else if (stageIndex == 1)
     {
-        return zstdgpu_HasFlag(inPerRequestContext->setupFlags, kzstdgpu_SetupFlags_HasBlockInfoConstants) ? 0 : 1;
+        reqFlags = kzstdgpu_SetupFlags_HasBlockInfoConstants | kzstdgpu_SetupFlags_HasSingleSubmission;
+    }
+
+    if (stageIndex <= 1)
+    {
+        return 0 != (req->setupFlags & reqFlags) ? 0 : 1;
     }
     return 0;
 }
 
 uint32_t zstdgpu_IsAnyStageReadbackRequired(zstdgpu_PerRequestContext inPerRequestContext)
 {
-    uint32_t requiredFlags = kzstdgpu_SetupFlags_HasFrameInfoConstants | kzstdgpu_SetupFlags_HasBlockInfoConstants;
-    return (requiredFlags == (inPerRequestContext->setupFlags & requiredFlags)) ? 0 : 1;
+    uint32_t reqFlags = kzstdgpu_SetupFlags_HasFrameInfoConstants | kzstdgpu_SetupFlags_HasBlockInfoConstants;
+    if (inPerRequestContext->setupFlags & kzstdgpu_SetupFlags_HasSingleSubmission)
+    {
+        return 0;
+    }
+    else if (reqFlags == (inPerRequestContext->setupFlags & reqFlags))
+    {
+        return 0;
+    }
+    return 1;
+}
+
+static uint32_t zstdgpu_OutputSizeToBlockCount(uint32_t size)
+{
+    // NOTE(pamartis): We compute the number of 4KiB blocks -- which is the minimal size of the block
+    // standard ZSTD compressor uses.
+    return (size + 4095) >> 12;
+}
+
+static uint32_t zstdgpu_OutputSizeToSequenceCount(uint32_t size)
+{
+    // NOTE(pamartis): 8 bytes per sequence is emperical estimation, not something stipulated
+    // by ZSTD standard.
+    return size >> 4;
 }
 
 ZSTDGPU_ENUM(Status) zstdgpu_GetGpuMemoryRequirement(uint32_t *outDefaultHeapByteCount, uint32_t *outUploadHeapByteCount, uint32_t *outReadbackHeapByteCount, uint32_t *outShaderVisibleDescriptorCount, zstdgpu_PerRequestContext req, uint32_t stageIndex)
@@ -1420,6 +1465,14 @@ ZSTDGPU_ENUM(Status) zstdgpu_GetGpuMemoryRequirement(uint32_t *outDefaultHeapByt
                 cntRle = req->zstdRleBlockCountMax;
                 cntCmp = req->zstdCmpBlockCountMax;
             }
+            else if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasSingleSubmission))
+            {
+                cntRle = cntRaw = cntCmp = zstdgpu_OutputSizeToBlockCount(req->zstdUncompressedFramesByteCount);
+
+                req->zstdRawBlockCountMax = cntRaw;
+                req->zstdRleBlockCountMax = cntRle;
+                req->zstdCmpBlockCountMax = cntCmp;
+            }
             else
             {
                 cntRaw = CNTRS(Blocks_RAW);
@@ -1443,6 +1496,16 @@ ZSTDGPU_ENUM(Status) zstdgpu_GetGpuMemoryRequirement(uint32_t *outDefaultHeapByt
             {
                 cntLit = req->zstdUncompressedLitByteCountMax;
                 cntSeq = req->zstdUncompressedSeqElemCountMax;
+            }
+            else if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasSingleSubmission))
+            {
+                // NOTE(pamartis): it's a huge overestimate, but it's best we can do safely,
+                // a single output byte requires 1 byte for literal storage
+                cntLit = req->zstdUncompressedFramesByteCount;
+                cntSeq = zstdgpu_OutputSizeToSequenceCount(req->zstdUncompressedFramesByteCount);
+
+                req->zstdUncompressedLitByteCountMax = cntLit;
+                req->zstdUncompressedSeqElemCountMax = cntSeq;
             }
             else
             {
@@ -1473,13 +1536,41 @@ static void zstdgpu_GetAllStageGpuMemoryRequirementInternal(uint32_t *outDefault
     uint32_t cntRaw, cntRle, cntCmp, cntLit, cntSeq;
     zstdgpu_ResourceInfo_Stage_0_Init(&req->resInfo, req->zstdFrameCount, req->zstdCompressedFramesByteCount, zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_InputsGpuMemory) ? 1u : 0u);
 
-    cntRaw = req->zstdRawBlockCountMax;
-    cntRle = req->zstdRleBlockCountMax;
-    cntCmp = req->zstdCmpBlockCountMax;
+    if (0 == zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasSingleSubmission))
+    {
+        ZSTDGPU_ASSERT(0 != zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasFrameInfoConstants));
+        cntRaw = req->zstdRawBlockCountMax;
+        cntRle = req->zstdRleBlockCountMax;
+        cntCmp = req->zstdCmpBlockCountMax;
+
+    }
+    else
+    {
+        cntRaw = cntRle = cntCmp = zstdgpu_OutputSizeToBlockCount(req->zstdUncompressedFramesByteCount);
+
+        req->zstdRawBlockCountMax = cntRaw;
+        req->zstdRleBlockCountMax = cntRle;
+        req->zstdCmpBlockCountMax = cntCmp;
+    }
     zstdgpu_ResourceInfo_Stage_1_Init(&req->resInfo, cntRaw, cntRle, cntCmp);
 
-    cntLit = req->zstdUncompressedLitByteCountMax;
-    cntSeq = req->zstdUncompressedSeqElemCountMax;
+    if (0 == zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasSingleSubmission))
+    {
+        ZSTDGPU_ASSERT(0 != zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasBlockInfoConstants));
+        cntLit = req->zstdUncompressedLitByteCountMax;
+        cntSeq = req->zstdUncompressedSeqElemCountMax;
+    }
+    else
+    {
+        // NOTE(pamartis): it's a huge overestimate, but it's best we can do safely,
+        // a single output byte requires 1 byte for literal storage
+        cntLit = req->zstdUncompressedFramesByteCount;
+        cntSeq = zstdgpu_OutputSizeToSequenceCount(req->zstdUncompressedFramesByteCount);
+
+        req->zstdUncompressedLitByteCountMax = cntLit;
+        req->zstdUncompressedSeqElemCountMax = cntSeq;
+
+    }
     zstdgpu_ResourceInfo_Stage_2_Init(&req->resInfo, cntLit, cntSeq, req->zstdUncompressedFramesByteCount, req->zstdUncompressedFrameCount);
 
     *outDefaultHeapByteCount    = req->resInfo.gpuOnly_ByteCount[0]
@@ -1778,6 +1869,14 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithInteralMemory(zstdgpu_PerRequestContext r
                 cntRle = req->zstdRleBlockCountMax;
                 cntCmp = req->zstdCmpBlockCountMax;
             }
+            else if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasSingleSubmission))
+            {
+                cntRle = cntRaw = cntCmp = zstdgpu_OutputSizeToBlockCount(req->zstdUncompressedFramesByteCount);
+
+                req->zstdRawBlockCountMax = cntRaw;
+                req->zstdRleBlockCountMax = cntRle;
+                req->zstdCmpBlockCountMax = cntCmp;
+            }
             else
             {
                 cntRaw = CNTRS(Blocks_RAW);
@@ -1800,6 +1899,16 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithInteralMemory(zstdgpu_PerRequestContext r
             {
                 cntLit = req->zstdUncompressedLitByteCountMax;
                 cntSeq = req->zstdUncompressedSeqElemCountMax;
+            }
+            else if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasSingleSubmission))
+            {
+                // NOTE(pamartis): it's a huge overestimate, but it's best we can do safely,
+                // a single output byte requires 1 byte for literal storage
+                cntLit = req->zstdUncompressedFramesByteCount;
+                cntSeq = zstdgpu_OutputSizeToSequenceCount(req->zstdUncompressedFramesByteCount);
+
+                req->zstdUncompressedLitByteCountMax = cntLit;
+                req->zstdUncompressedSeqElemCountMax = cntSeq;
             }
             else
             {

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -2938,41 +2938,29 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         {
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Init FSE Table]");
             BIND_RS_PS_SRT(InitFseTable);
-
             // NOTE: we run 4 ExecuteIndirects (per argument) in order to be able to (but we don't do this for prototype)
             // switch PSO to more optimial (depending on maximal FSE table size) because D3D12 doesn't allow to switch PSOs in ExecuteIndirect.
 
-            // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
+            // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch.
+            // Slot 2 = table type (0=HufW, 1=LLen, 2=Offs, 3=MLen); the shader derives the bases from Counters.
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Huffman Weights");
-            uint32_t tableStartIndex = 0;
-            cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 2);
-            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartHufW(0, req->zstdCmpBlockCountMax), 3);
-            cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_HufW, 4);
+            cmdList->SetComputeRoot32BitConstant(1, 0u /* HufW */, 2);
             zstdgpu_DispatchIndirect(cmdList, InitFseTable, FseHufW);
             PIXEndEvent(cmdList);
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Literal Lengths");
-            tableStartIndex += req->zstdCmpBlockCountMax;
-            cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 2);
-            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartLLen(0, req->zstdCmpBlockCountMax), 3);
-            cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_LLen, 4);
+            cmdList->SetComputeRoot32BitConstant(1, 1u /* LLen */, 2);
             zstdgpu_DispatchIndirect(cmdList, InitFseTable, FseLLen);
             PIXEndEvent(cmdList);
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Offsets");
-            tableStartIndex += req->zstdCmpBlockCountMax + 1;
-            cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 2);
-            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartOffs(0, req->zstdCmpBlockCountMax), 3);
-            cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_Offs, 4);
+            cmdList->SetComputeRoot32BitConstant(1, 2u /* Offs */, 2);
             zstdgpu_DispatchIndirect(cmdList, InitFseTable, FseOffs);
             PIXEndEvent(cmdList);
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"FSEs for Match Lengths");
-            tableStartIndex += req->zstdCmpBlockCountMax + 1;
-            cmdList->SetComputeRoot32BitConstant(1, tableStartIndex, 2);
-            cmdList->SetComputeRoot32BitConstant(1, zstdgpu_ComputeFseDataStartMLen(0, req->zstdCmpBlockCountMax), 3);
-            cmdList->SetComputeRoot32BitConstant(1, kzstdgpu_FseElemMaxCount_MLen, 4);
+            cmdList->SetComputeRoot32BitConstant(1, 3u /* MLen */, 2);
             zstdgpu_DispatchIndirect(cmdList, InitFseTable, FseMLen);
             PIXEndEvent(cmdList);
             PIXEndEvent(cmdList);
@@ -3009,8 +2997,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Decode Uncompressed Huffman Weights]");
         BIND_RS_PS_SRT(DecodeHuffmanWeights);
         // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
-        cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCountMax, 2);
-        cmdList->SetComputeRoot32BitConstant(1, req->resInfo.CompressedData_ByteSize, 3);
+        cmdList->SetComputeRoot32BitConstant(1, req->resInfo.CompressedData_ByteSize, 2);
 
         ZSTDGPU_KERNEL_SCOPE(DecodeHuffmanWeights, cmdList,
             zstdgpu_DispatchIndirect(cmdList, DecodeHuffmanWeights, DecodeHuffmanWeights);
@@ -3043,14 +3030,14 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         {
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Path: FSE-compressed Huffman Weights]");
             {
-                cmdList->SetComputeRoot32BitConstant(1, /** HuffmaTableIndexBase*/0, 2);
+                cmdList->SetComputeRoot32BitConstant(1, /** fseCompressed = 1 */1u, 2);
                 zstdgpu_DispatchIndirect(cmdList, InitHuffmanTable, FseHufW);
             }
             PIXEndEvent(cmdList);
 
             PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Path: Uncompressed Huffman Weights]");
             {
-                cmdList->SetComputeRoot32BitConstant(1, /** HuffmaTableIndexBase = zstdCmpBlockCount meaning indices are reversed */req->zstdCmpBlockCountMax, 2);
+                cmdList->SetComputeRoot32BitConstant(1, /** fseCompressed = 0 */0u, 2);
                 zstdgpu_DispatchIndirect(cmdList, InitHuffmanTable, HUF_WgtStreams);
             }
             PIXEndEvent(cmdList);
@@ -3077,8 +3064,6 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Decompress Literals]");
         BIND_RS_PS_SRT(DecompressLiterals);
         // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
-        cmdList->SetComputeRoot32BitConstant(1, req->zstdCmpBlockCountMax, 2);
-
         ZSTDGPU_KERNEL_SCOPE(DecompressLiterals, cmdList,
             zstdgpu_DispatchIndirect(cmdList, DecompressLiterals, DecompressLiterals);
         );

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -1381,6 +1381,12 @@ uint32_t zstdgpu_IsReadbackRequired(zstdgpu_PerRequestContext inPerRequestContex
     return 0;
 }
 
+uint32_t zstdgpu_IsAnyStageReadbackRequired(zstdgpu_PerRequestContext inPerRequestContext)
+{
+    uint32_t requiredFlags = kzstdgpu_SetupFlags_HasFrameInfoConstants | kzstdgpu_SetupFlags_HasBlockInfoConstants;
+    return (requiredFlags == (inPerRequestContext->setupFlags & requiredFlags)) ? 0 : 1;
+}
+
 ZSTDGPU_ENUM(Status) zstdgpu_GetGpuMemoryRequirement(uint32_t *outDefaultHeapByteCount, uint32_t *outUploadHeapByteCount, uint32_t *outReadbackHeapByteCount, uint32_t *outShaderVisibleDescriptorCount, zstdgpu_PerRequestContext req, uint32_t stageIndex)
 {
     uint32_t proceed = 1;
@@ -1454,6 +1460,70 @@ ZSTDGPU_ENUM(Status) zstdgpu_GetGpuMemoryRequirement(uint32_t *outDefaultHeapByt
         *outShaderVisibleDescriptorCount    = zstdgpu_Count_SRTs_Stage(stageIndex);
 
         #undef CNTRS
+        return ZSTDGPU_ENUM_CONST(StatusSuccess);
+    }
+    return ZSTDGPU_ENUM_CONST(StatusInvalidArgument);
+}
+
+static void zstdgpu_GetAllStageGpuMemoryRequirementInternal(uint32_t *outDefaultHeapByteCount,
+                                                            uint32_t *outUploadHeapByteCount,
+                                                            uint32_t *outReadbackHeapByteCount,
+                                                            zstdgpu_PerRequestContext req)
+{
+    uint32_t cntRaw, cntRle, cntCmp, cntLit, cntSeq;
+    zstdgpu_ResourceInfo_Stage_0_Init(&req->resInfo, req->zstdFrameCount, req->zstdCompressedFramesByteCount, zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_InputsGpuMemory) ? 1u : 0u);
+
+    cntRaw = req->zstdRawBlockCountMax;
+    cntRle = req->zstdRleBlockCountMax;
+    cntCmp = req->zstdCmpBlockCountMax;
+    zstdgpu_ResourceInfo_Stage_1_Init(&req->resInfo, cntRaw, cntRle, cntCmp);
+
+    cntLit = req->zstdUncompressedLitByteCountMax;
+    cntSeq = req->zstdUncompressedSeqElemCountMax;
+    zstdgpu_ResourceInfo_Stage_2_Init(&req->resInfo, cntLit, cntSeq, req->zstdUncompressedFramesByteCount, req->zstdUncompressedFrameCount);
+
+    *outDefaultHeapByteCount    = req->resInfo.gpuOnly_ByteCount[0]
+                                + req->resInfo.gpuOnly_ByteCount[1]
+                                + req->resInfo.gpuOnly_ByteCount[2];
+
+    *outUploadHeapByteCount     = req->resInfo.cpu2Gpu_ByteCount[0]
+                                + req->resInfo.cpu2Gpu_ByteCount[1]
+                                + req->resInfo.cpu2Gpu_ByteCount[2];
+
+    *outReadbackHeapByteCount   = req->resInfo.gpu2Cpu_ByteCount[0]
+                                + req->resInfo.gpu2Cpu_ByteCount[1]
+                                + req->resInfo.gpu2Cpu_ByteCount[2];
+}
+
+ZSTDGPU_ENUM(Status) zstdgpu_GetAllStageGpuMemoryRequirement(uint32_t *outDefaultHeapByteCount,
+                                                             uint32_t *outUploadHeapByteCount,
+                                                             uint32_t *outReadbackHeapByteCount,
+                                                             uint32_t *outShaderVisibleDescriptorCount,
+                                                             zstdgpu_PerRequestContext req)
+{
+    uint32_t proceed = 1;
+
+    proceed = proceed && (NULL != outDefaultHeapByteCount);
+    proceed = proceed && (NULL != outUploadHeapByteCount);
+    proceed = proceed && (NULL != outReadbackHeapByteCount);
+    proceed = proceed && (NULL != outShaderVisibleDescriptorCount);
+    proceed = proceed && (NULL != req);
+    proceed = proceed && (req->thisMemoryBlock == (void *)req);
+    proceed = proceed && (req->zstdFrameCount > 0);
+    proceed = proceed && (req->zstdCompressedFramesByteCount > 0);
+    proceed = proceed && (req->zstdUncompressedFrameCount == req->zstdFrameCount);
+    proceed = proceed && (req->zstdUncompressedFramesByteCount > 0);
+    proceed = proceed && (0 == zstdgpu_IsAnyStageReadbackRequired(req));
+    ZSTDGPU_ASSERT(proceed > 0);
+
+    if (proceed)
+    {
+        zstdgpu_GetAllStageGpuMemoryRequirementInternal(outDefaultHeapByteCount, outUploadHeapByteCount, outReadbackHeapByteCount, req);
+
+        *outShaderVisibleDescriptorCount    = zstdgpu_Count_SRTs_Stage(0)
+                                            + zstdgpu_Count_SRTs_Stage(1)
+                                            + zstdgpu_Count_SRTs_Stage(2);
+
         return ZSTDGPU_ENUM_CONST(StatusSuccess);
     }
     return ZSTDGPU_ENUM_CONST(StatusInvalidArgument);
@@ -1561,6 +1631,115 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithExternalMemory(zstdgpu_PerRequestContext 
         {
             zstdgpu_SubmitStage2(req, cmdList);
         }
+
+        return ZSTDGPU_ENUM_CONST(StatusSuccess);
+    }
+    return ZSTDGPU_ENUM_CONST(StatusInvalidArgument);
+}
+
+ZSTDGPU_ENUM(Status) zstdgpu_SubmitAllStagesWithExternalMemory(zstdgpu_PerRequestContext req,
+                                                               struct ID3D12GraphicsCommandList *cmdList,
+                                                               struct ID3D12Heap *defaultHeap,
+                                                               uint32_t defaultHeap_OffsetInBytes,
+                                                               struct ID3D12Heap *uploadHeap,
+                                                               uint32_t uploadHeap_OffsetInBytes,
+                                                               struct ID3D12Heap *readbackHeap,
+                                                               uint32_t readbackHeap_OffsetInBytes,
+                                                               struct ID3D12DescriptorHeap *shaderVisibleHeap,
+                                                               uint32_t shaderVisibileHeap_OffsetInDescriptors)
+{
+    uint32_t proceed = 1;
+    uint32_t defaultHeapMemReq = 0;
+    uint32_t uploadHeapMemReq = 0;
+    uint32_t readbackHeapMemReq = 0;
+    uint32_t shaderVisibleHeapDscCount = 0;
+    proceed = proceed && (0 == zstdgpu_IsAnyStageReadbackRequired(req));
+    proceed = proceed && (ZSTDGPU_ENUM_CONST(StatusSuccess) == zstdgpu_GetAllStageGpuMemoryRequirement(&defaultHeapMemReq, &uploadHeapMemReq, &readbackHeapMemReq, &shaderVisibleHeapDscCount, req));
+    proceed = proceed && (NULL != cmdList);
+    proceed = proceed && (NULL != defaultHeap || 0 == defaultHeapMemReq);
+    proceed = proceed && (NULL != uploadHeap || 0 == uploadHeapMemReq);
+    proceed = proceed && (NULL != readbackHeap || 0 == readbackHeapMemReq);
+    proceed = proceed && (NULL != shaderVisibleHeap || 0 == shaderVisibleHeapDscCount);
+    proceed = proceed && (req->zstdUncompressedLitByteCountMax == 0 || req->zstdCmpBlockCountMax > 0);
+    proceed = proceed && ZSTDGPU_IS_DEFAULT_ALIGNED(defaultHeap_OffsetInBytes);
+    proceed = proceed && ZSTDGPU_IS_DEFAULT_ALIGNED(uploadHeap_OffsetInBytes);
+    proceed = proceed && ZSTDGPU_IS_DEFAULT_ALIGNED(readbackHeap_OffsetInBytes);
+    ZSTDGPU_ASSERT(proceed > 0);
+    if (proceed)
+    {
+        uint32_t defaultOffs = defaultHeap_OffsetInBytes;
+        uint32_t uploadOffs = uploadHeap_OffsetInBytes;
+        uint32_t readbackOffs = readbackHeap_OffsetInBytes;
+        zstdgpu_ResourceDataGpu_Term(&req->resData, 0);
+        zstdgpu_ResourceDataGpu_Term(&req->resData, 1);
+        zstdgpu_ResourceDataGpu_Term(&req->resData, 2);
+
+        for (uint32_t stageIndex = 0; stageIndex < ZSTDGPU_ENUM_CONST(ResourceAllocation_StageCount); ++stageIndex)
+        {
+            if (NULL != defaultHeap)
+                defaultHeap->AddRef();
+
+            if (NULL != uploadHeap)
+                uploadHeap->AddRef();
+
+            if (NULL != readbackHeap)
+                readbackHeap->AddRef();
+
+            req->resData.gpuOnly_Heap[stageIndex] = defaultHeap;
+            req->resData.gpuOnly_HeapOffset[stageIndex] = defaultOffs;
+
+            req->resData.cpu2Gpu_Heap[stageIndex] = uploadHeap;
+            req->resData.cpu2Gpu_HeapOffset[stageIndex] = uploadOffs;
+
+            req->resData.gpu2Cpu_Heap[stageIndex] = readbackHeap;
+            req->resData.gpu2Cpu_HeapOffset[stageIndex] = readbackOffs;
+
+            defaultOffs   += req->resInfo.gpuOnly_ByteCount[stageIndex];
+            uploadOffs    += req->resInfo.cpu2Gpu_ByteCount[stageIndex];
+            readbackOffs  += req->resInfo.gpu2Cpu_ByteCount[stageIndex];
+
+            ZSTDGPU_ASSERT(ZSTDGPU_IS_DEFAULT_ALIGNED(defaultOffs));
+            ZSTDGPU_ASSERT(ZSTDGPU_IS_DEFAULT_ALIGNED(uploadOffs));
+            ZSTDGPU_ASSERT(ZSTDGPU_IS_DEFAULT_ALIGNED(readbackOffs));
+        }
+        ZSTDGPU_ASSERT(defaultHeapMemReq == defaultOffs - defaultHeap_OffsetInBytes);
+        ZSTDGPU_ASSERT(uploadHeapMemReq == uploadOffs - uploadHeap_OffsetInBytes);
+        ZSTDGPU_ASSERT(readbackHeapMemReq == readbackOffs - readbackHeap_OffsetInBytes);
+
+        zstdgpu_ResourceDataGpu_Init(&req->resData, &req->resInfo, req->device, 0);
+        zstdgpu_ResourceDataGpu_Init(&req->resData, &req->resInfo, req->device, 1);
+        zstdgpu_ResourceDataGpu_Init(&req->resData, &req->resInfo, req->device, 2);
+
+        if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_InputsGpuMemory))
+        {
+            zstdgpu_ResourceDataGpu_ReInitInputExternal(&req->resData, req->compressedFramesData, req->compressedFramesRefs);
+        }
+        zstdgpu_ResourceDataGpu_ReInitOutputsExternal(&req->resData, req->uncompressedFramesData, req->uncompressedFramesRefs);
+
+        // NOTE(pamartis): we need to do call upload callback right after initialising resources of stage == 0
+        if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_InputsCpuMemory))
+        {
+            req->uploadCallback(req->resData.cpu2Gpu.CompressedDataCpu, req->zstdCompressedFramesByteCount, req->resData.cpu2Gpu.FramesRefsCpu, req->zstdFrameCount, req->uploadUserdata);
+        }
+        memcpy(req->resData.cpu2Gpu.FseProbsDefaultCpu, kzstdgpuFseProbsDefault, sizeof(kzstdgpuFseProbsDefault));
+
+        D3D12AID_SAFE_RELEASE(req->srts.heap);
+        req->srts.heap = shaderVisibleHeap;
+        req->srts.heap->AddRef();
+        req->srts.heapOffset = shaderVisibileHeap_OffsetInDescriptors;
+        zstdgpu_ReCreate_SRTs(req->srts, req->device, req->resInfo, req->resData, 0);
+        req->srts.heapOffset += zstdgpu_Count_SRTs_Stage(0);
+
+        zstdgpu_ReCreate_SRTs(req->srts, req->device, req->resInfo, req->resData, 1);
+        req->srts.heapOffset += zstdgpu_Count_SRTs_Stage(1);
+
+        zstdgpu_ReCreate_SRTs(req->srts, req->device, req->resInfo, req->resData, 2);
+        req->srts.heapOffset += zstdgpu_Count_SRTs_Stage(2);
+
+        ZSTDGPU_ASSERT(shaderVisibleHeapDscCount == req->srts.heapOffset - shaderVisibileHeap_OffsetInDescriptors);
+        zstdgpu_SubmitStage0(req, cmdList);
+        zstdgpu_SubmitStage1(req, cmdList);
+        zstdgpu_SubmitStage2(req, cmdList);
 
         return ZSTDGPU_ENUM_CONST(StatusSuccess);
     }
@@ -1694,6 +1873,185 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithInteralMemory(zstdgpu_PerRequestContext r
         {
             zstdgpu_SubmitStage2(req, cmdList);
         }
+
+        return ZSTDGPU_ENUM_CONST(StatusSuccess);
+    }
+    return ZSTDGPU_ENUM_CONST(StatusInvalidArgument);
+}
+
+ZSTDGPU_ENUM(Status) zstdgpu_SubmitAllStagesWithInteralMemory(zstdgpu_PerRequestContext req,
+                                                              ID3D12GraphicsCommandList *cmdList)
+{
+    uint32_t proceed = 1;
+    proceed = proceed && (0 == zstdgpu_IsAnyStageReadbackRequired(req));
+    proceed = proceed && (NULL != req);
+    proceed = proceed && (NULL != cmdList);
+    proceed = proceed && (req->thisMemoryBlock == (void *)req);
+    proceed = proceed && (req->zstdFrameCount > 0);
+    proceed = proceed && (req->zstdCompressedFramesByteCount > 0);
+    proceed = proceed && (req->zstdUncompressedFrameCount == req->zstdFrameCount);
+    proceed = proceed && (req->zstdUncompressedFramesByteCount > 0);
+    ZSTDGPU_ASSERT(proceed > 0);
+
+    if (proceed)
+    {
+        ID3D12Device *device = req->device;
+        uint32_t dflt, upld, rdbk;
+        uint32_t dfltP, upldP, rdbkP;
+        zstdgpu_GetAllStageGpuMemoryRequirementInternal(&dflt, &upld, &rdbk, req);
+
+        dfltP = req->resData.gpuOnly_ByteCount[0]
+              + req->resData.gpuOnly_ByteCount[1]
+              + req->resData.gpuOnly_ByteCount[2];
+
+        upldP = req->resData.cpu2Gpu_ByteCount[0]
+              + req->resData.cpu2Gpu_ByteCount[1]
+              + req->resData.cpu2Gpu_ByteCount[2];
+
+        rdbkP = req->resData.gpu2Cpu_ByteCount[0]
+              + req->resData.gpu2Cpu_ByteCount[1]
+              + req->resData.gpu2Cpu_ByteCount[2];
+
+        // TODO(pamartis): currently we always re-create buffers because we don't track whether their position changed,
+        //                 but this must be done at some point
+        #define ZSTDGPU_BUFFER(type, name) D3D12AID_SAFE_RELEASE(req->resData.gpuOnly.name);
+            ZSTDGPU_ALL_BUFFERS_LIST_STAGE_0()
+            ZSTDGPU_ALL_BUFFERS_LIST_STAGE_1()
+            ZSTDGPU_ALL_BUFFERS_LIST_STAGE_2()
+        #undef ZSTDGPU_BUFFER
+
+        #define ZSTDGPU_BUFFER(type, name) D3D12AID_SAFE_RELEASE(req->resData.cpu2Gpu.name);
+            ZSTDGPU_BUFFERS_LIST_UPLOAD_STAGE_0()
+            ZSTDGPU_BUFFERS_LIST_UPLOAD_STAGE_1()
+            ZSTDGPU_BUFFERS_LIST_UPLOAD_STAGE_2()
+        #undef ZSTDGPU_BUFFER
+
+        #define ZSTDGPU_BUFFER(type, name) D3D12AID_SAFE_RELEASE(req->resData.gpu2Cpu.name);
+            ZSTDGPU_BUFFERS_LIST_READBACK_STAGE_0()
+            ZSTDGPU_BUFFERS_LIST_READBACK_STAGE_1()
+            ZSTDGPU_BUFFERS_LIST_READBACK_STAGE_2()
+        #undef ZSTDGPU_BUFFER
+
+        if (dfltP < dflt)
+        {
+            D3D12AID_SAFE_RELEASE(req->resData.gpuOnly_Heap[0]);
+            D3D12AID_SAFE_RELEASE(req->resData.gpuOnly_Heap[1]);
+            D3D12AID_SAFE_RELEASE(req->resData.gpuOnly_Heap[2]);
+        }
+
+        if (upldP < upld)
+        {
+            D3D12AID_SAFE_RELEASE(req->resData.cpu2Gpu_Heap[0]);
+            D3D12AID_SAFE_RELEASE(req->resData.cpu2Gpu_Heap[1]);
+            D3D12AID_SAFE_RELEASE(req->resData.cpu2Gpu_Heap[2]);
+        }
+
+        if (rdbkP < rdbk)
+        {
+            D3D12AID_SAFE_RELEASE(req->resData.gpu2Cpu_Heap[0]);
+            D3D12AID_SAFE_RELEASE(req->resData.gpu2Cpu_Heap[1]);
+            D3D12AID_SAFE_RELEASE(req->resData.gpu2Cpu_Heap[2]);
+        }
+
+        // NOTE(pamartis): when initialising a heap in single submission mode, we set exact memory requirement
+        // use shared pointer
+        #define INIT_HEAP(name, stage, heap)                                            \
+            req->resData.name##_Heap[stage] = heap;                                     \
+            req->resData.name##_HeapOffset[stage] = offs;                               \
+            req->resData.name##_ByteCount[stage] = req->resInfo.name##_ByteCount[stage];\
+            offs += req->resInfo.name##_ByteCount[stage];                               \
+            ZSTDGPU_ASSERT(ZSTDGPU_IS_DEFAULT_ALIGNED(offs))
+
+        if (NULL == req->resData.gpuOnly_Heap[0] && 0 != dflt)
+        {
+            ID3D12Heap *heap = d3d12aid_Heap_Create_WithHeapTypeAndFlags(device, dflt, 0, D3D12_HEAP_TYPE_DEFAULT, D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS);
+            uint32_t offs = 0;
+            INIT_HEAP(gpuOnly, 0, heap);
+            INIT_HEAP(gpuOnly, 1, heap);
+            INIT_HEAP(gpuOnly, 2, heap);
+            ZSTDGPU_ASSERT(offs == dflt);
+
+            heap->AddRef();
+            heap->AddRef();
+        }
+        // TODO(pamartis): currently we always re-create buffers because we don't track whether their position changed,
+        //                 but this must be done at some point
+        zstdgpu_ResourceDataGpu_Init_GpuOnly(&req->resData, &req->resInfo, device, 0);
+        zstdgpu_ResourceDataGpu_Init_GpuOnly(&req->resData, &req->resInfo, device, 1);
+        zstdgpu_ResourceDataGpu_Init_GpuOnly(&req->resData, &req->resInfo, device, 2);
+
+        if (NULL == req->resData.cpu2Gpu_Heap[0] && 0 != upld)
+        {
+            ID3D12Heap *heap = d3d12aid_Heap_Create_WithHeapTypeAndFlags(device, upld, 0, D3D12_HEAP_TYPE_UPLOAD, D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS);
+            uint32_t offs = 0;
+            INIT_HEAP(cpu2Gpu, 0, heap);
+            INIT_HEAP(cpu2Gpu, 1, heap);
+            INIT_HEAP(cpu2Gpu, 2, heap);
+            ZSTDGPU_ASSERT(offs == upld);
+            heap->AddRef();
+            heap->AddRef();
+        }
+        // TODO(pamartis): currently we always re-create buffers because we don't track whether their position changed,
+        //                 but this must be done at some point
+        zstdgpu_ResourceDataGpu_Init_CpuToGpu(&req->resData, &req->resInfo, device, 0);
+        zstdgpu_ResourceDataGpu_Init_CpuToGpu(&req->resData, &req->resInfo, device, 1);
+        zstdgpu_ResourceDataGpu_Init_CpuToGpu(&req->resData, &req->resInfo, device, 2);
+
+        if (NULL == req->resData.gpu2Cpu_Heap[0] && 0 != rdbk)
+        {
+            ID3D12Heap *heap = d3d12aid_Heap_Create_WithHeapTypeAndFlags(device, rdbk, 0, D3D12_HEAP_TYPE_READBACK, D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS);
+            uint32_t offs = 0;
+            INIT_HEAP(gpu2Cpu, 0, heap);
+            INIT_HEAP(gpu2Cpu, 1, heap);
+            INIT_HEAP(gpu2Cpu, 2, heap);
+            ZSTDGPU_ASSERT(offs == rdbk);
+            heap->AddRef();
+            heap->AddRef();
+        }
+        // TODO(pamartis): currently we always re-create buffers because we don't track whether their position changed,
+        //                 but this must be done at some point
+        zstdgpu_ResourceDataGpu_Init_GpuToCpu(&req->resData, &req->resInfo, device, 0);
+        zstdgpu_ResourceDataGpu_Init_GpuToCpu(&req->resData, &req->resInfo, device, 1);
+        zstdgpu_ResourceDataGpu_Init_GpuToCpu(&req->resData, &req->resInfo, device, 2);
+        #undef INIT_HEAP
+
+        if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_InputsGpuMemory))
+        {
+            zstdgpu_ResourceDataGpu_ReInitInputExternal(&req->resData, req->compressedFramesData, req->compressedFramesRefs);
+        }
+
+        zstdgpu_ResourceDataGpu_ReInitOutputsExternal(&req->resData, req->uncompressedFramesData, req->uncompressedFramesRefs);
+
+        if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_InputsCpuMemory))
+        {
+            req->uploadCallback(req->resData.cpu2Gpu.CompressedDataCpu, req->zstdCompressedFramesByteCount, req->resData.cpu2Gpu.FramesRefsCpu, req->zstdFrameCount, req->uploadUserdata);
+        }
+        memcpy(req->resData.cpu2Gpu.FseProbsDefaultCpu, kzstdgpuFseProbsDefault, sizeof(kzstdgpuFseProbsDefault));
+
+        if (NULL == req->srts.heap)
+        {
+            const uint32_t srtCount = zstdgpu_Count_SRTs_Stage(0)
+                                    + zstdgpu_Count_SRTs_Stage(1)
+                                    + zstdgpu_Count_SRTs_Stage(2);
+
+            req->srts.heap = d3d12aid_DescriptorHeap_Create(req->device, srtCount, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE);
+            req->srts.heapOffset = 0;
+        }
+
+        // TODO(pamartis): descriptors should be re-created only when buffers were re-created
+        //                 but currently we always re-create buffers
+        zstdgpu_ReCreate_SRTs(req->srts, req->device, req->resInfo, req->resData, 0);
+        req->srts.heapOffset += zstdgpu_Count_SRTs_Stage(0);
+
+        zstdgpu_ReCreate_SRTs(req->srts, req->device, req->resInfo, req->resData, 1);
+        req->srts.heapOffset += zstdgpu_Count_SRTs_Stage(1);
+
+        zstdgpu_ReCreate_SRTs(req->srts, req->device, req->resInfo, req->resData, 2);
+        req->srts.heapOffset += zstdgpu_Count_SRTs_Stage(2);
+
+        zstdgpu_SubmitStage0(req, cmdList);
+        zstdgpu_SubmitStage1(req, cmdList);
+        zstdgpu_SubmitStage2(req, cmdList);
 
         return ZSTDGPU_ENUM_CONST(StatusSuccess);
     }

--- a/zstd/zstdgpu/zstdgpu.h
+++ b/zstd/zstdgpu/zstdgpu.h
@@ -214,9 +214,23 @@ ZSTDGPU_API zstdgpu_Status zstdgpu_SetupBlockInfoConstants(zstdgpu_PerRequestCon
 ZSTDGPU_API uint32_t zstdgpu_IsReadbackRequired(zstdgpu_PerRequestContext inPerRequestContext, uint32_t stageIndex);
 
 /**
+ *  @brief      Returns 1 if a CPU readback/fence is required after any stages, 0 otherwise. This API
+ *              mainly exist to ensure `zstdgpu_PerRequestContext` has sufficient information to not
+ *              require any readbacks, so calling code could check: `assert(0 == zstdgpu_IsAnyStageReadbackRequired(ctx))`
+ */
+ZSTDGPU_API uint32_t zstdgpu_IsAnyStageReadbackRequired(zstdgpu_PerRequestContext inPerRequestContext);
+
+/**
  *  @brief      Returns memory requirement for each heap type per submission stage for a given `zstdgpu_PerRequestContext`
  */
 ZSTDGPU_API zstdgpu_Status zstdgpu_GetGpuMemoryRequirement(uint32_t *outDefaultHeapByteCount, uint32_t *outUploadHeapByteCount, uint32_t *outReadbackHeapByteCount, uint32_t *outShaderVisibleDescriptorCount, zstdgpu_PerRequestContext inPerRequestContext, uint32_t stageIndex);
+
+/**
+ *  @brief      Returns memory requirement for each heap type for all submission stages for a given `zstdgpu_PerRequestContext`
+ *
+ *  @note       It's valid to call this function only when `zstdgpu_IsAnyStageReadbackRequired` returns `0`
+ */
+ZSTDGPU_API zstdgpu_Status zstdgpu_GetAllStageGpuMemoryRequirement(uint32_t *outDefaultHeapByteCount, uint32_t *outUploadHeapByteCount, uint32_t *outReadbackHeapByteCount, uint32_t *outShaderVisibleDescriptorCount, zstdgpu_PerRequestContext inPerRequestContext);
 
 /**
  *  @brief      Submits all required decompression commands into a command list for a given `stageIndex` with externally
@@ -240,6 +254,25 @@ ZSTDGPU_API zstdgpu_Status zstdgpu_SubmitWithExternalMemory(zstdgpu_PerRequestCo
                                                             uint32_t shaderVisibileHeapOffsetInDescriptors);
 
 /**
+ *  @brief      Submits all required decompression commands into a command list for all stages (single-submission mode)
+ *              with externally supplied memory.
+ *
+ *  @note       It's valid to call this function only when `zstdgpu_IsAnyStageReadbackRequired` returns `0`
+ *
+ *  @note       The caller must compute required memory via `zstdgpu_GetAllStageGpuMemoryRequirement`
+ */
+ZSTDGPU_API zstdgpu_Status zstdgpu_SubmitAllStagesWithExternalMemory(zstdgpu_PerRequestContext inPerRequestContext,
+                                                                     struct ID3D12GraphicsCommandList *cmdList,
+                                                                     struct ID3D12Heap *defaultHeap,
+                                                                     uint32_t defaultHeapOffsetInBytes,
+                                                                     struct ID3D12Heap *uploadHeap,
+                                                                     uint32_t uploadHeapOffsetInBytes,
+                                                                     struct ID3D12Heap *readbackHeap,
+                                                                     uint32_t readbackHeap_OffsetInBytes,
+                                                                     struct ID3D12DescriptorHeap *shaderVisibleHeap,
+                                                                     uint32_t shaderVisibileHeapOffsetInDescriptors);
+
+/**
  *  @brief      Submits all required decompression commands into a command list for a given `stageIndex` with internally
  *              allocated memory.
  *
@@ -247,3 +280,12 @@ ZSTDGPU_API zstdgpu_Status zstdgpu_SubmitWithExternalMemory(zstdgpu_PerRequestCo
  *              for `stageIndex` supplied into this function.
  */
 ZSTDGPU_API zstdgpu_Status zstdgpu_SubmitWithInteralMemory(zstdgpu_PerRequestContext inPerRequestContext, uint32_t stageIndex, struct ID3D12GraphicsCommandList *cmdList);
+
+/**
+ *  @brief      Submits all required decompression commands into a command list for all stages (single-submission mode)
+ *              with internally allocated memory.
+ *
+ *  @note       It's valid to call this function only when `zstdgpu_IsAnyStageReadbackRequired` returns `0`
+ *
+ */
+ZSTDGPU_API zstdgpu_Status zstdgpu_SubmitAllStagesWithInteralMemory(zstdgpu_PerRequestContext inPerRequestContext, struct ID3D12GraphicsCommandList *cmdList);

--- a/zstd/zstdgpu/zstdgpu.h
+++ b/zstd/zstdgpu/zstdgpu.h
@@ -213,8 +213,20 @@ ZSTDGPU_API zstdgpu_Status zstdgpu_SetupBlockInfoConstants(zstdgpu_PerRequestCon
  */
 ZSTDGPU_API uint32_t zstdgpu_IsReadbackRequired(zstdgpu_PerRequestContext inPerRequestContext, uint32_t stageIndex);
 
+/**
+ *  @brief      Returns memory requirement for each heap type per submission stage for a given `zstdgpu_PerRequestContext`
+ */
 ZSTDGPU_API zstdgpu_Status zstdgpu_GetGpuMemoryRequirement(uint32_t *outDefaultHeapByteCount, uint32_t *outUploadHeapByteCount, uint32_t *outReadbackHeapByteCount, uint32_t *outShaderVisibleDescriptorCount, zstdgpu_PerRequestContext inPerRequestContext, uint32_t stageIndex);
 
+/**
+ *  @brief      Submits all required decompression commands into a command list for a given `stageIndex` with externally
+ *              supplied memory.
+ *
+ *  @note       The caller must wait for GPU idle before calling this function if `zstdgpu_IsReadbackRequired` return `1`
+ *              for `stageIndex` supplied into this function.
+ *
+ *  @note       The caller must compute required memory for a given `stageIndex` via `zstdgpu_GetGpuMemoryRequirement`
+ */
 ZSTDGPU_API zstdgpu_Status zstdgpu_SubmitWithExternalMemory(zstdgpu_PerRequestContext inPerRequestContext,
                                                             uint32_t stageIndex,
                                                             struct ID3D12GraphicsCommandList *cmdList,
@@ -227,4 +239,11 @@ ZSTDGPU_API zstdgpu_Status zstdgpu_SubmitWithExternalMemory(zstdgpu_PerRequestCo
                                                             struct ID3D12DescriptorHeap *shaderVisibleHeap,
                                                             uint32_t shaderVisibileHeapOffsetInDescriptors);
 
+/**
+ *  @brief      Submits all required decompression commands into a command list for a given `stageIndex` with internally
+ *              allocated memory.
+ *
+ *  @note       The caller must wait for GPU idle before calling this function if `zstdgpu_IsReadbackRequired` return `1`
+ *              for `stageIndex` supplied into this function.
+ */
 ZSTDGPU_API zstdgpu_Status zstdgpu_SubmitWithInteralMemory(zstdgpu_PerRequestContext inPerRequestContext, uint32_t stageIndex, struct ID3D12GraphicsCommandList *cmdList);

--- a/zstd/zstdgpu/zstdgpu.h
+++ b/zstd/zstdgpu/zstdgpu.h
@@ -188,6 +188,8 @@ ZSTDGPU_API zstdgpu_Status zstdgpu_SetupInputsAsFramesInGpuMemory(uint32_t *outS
 
 ZSTDGPU_API zstdgpu_Status zstdgpu_SetupOutputs(zstdgpu_PerRequestContext inPerRequestContext, struct ID3D12Resource *framesMemory, uint32_t framesMemorySizeInBytes, struct ID3D12Resource *frames, uint32_t frameCount);
 
+ZSTDGPU_API zstdgpu_Status zstdgpu_SetupAllStageSubmission(zstdgpu_PerRequestContext inPerRequestContext);
+
 /**
  *  @brief      Specifies the number of blocks of each type from a CPU pre-scan.
  *              When set, `zstdgpu_GetGpuMemoryRequirement` for stage 1 uses these counts instead of

--- a/zstd/zstdgpu/zstdgpu_resources.h
+++ b/zstd/zstdgpu/zstdgpu_resources.h
@@ -255,6 +255,7 @@ static void zstdgpu_ResourceInfo_InitZero(zstdgpu_ResourceInfo *outInfo)
 }
 
 #define ZSTDGPU_ALIGN_DEFAULT(offset) zstdgpu_AlignUp(offset, 0x10000)
+#define ZSTDGPU_IS_DEFAULT_ALIGNED(offset) (0 == (offset & (0x10000 - 1)))
 
 // initialize the counts, sizes and offsets
 #define ZSTDGPU_BUFFER(type, name)                                      \

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -625,11 +625,13 @@ static void zstdgpu_ShaderEntry_InitResources(ZSTDGPU_PARAM_INOUT(zstdgpu_InitRe
         return;
     }
 
+    const uint32_t cmpBlockCnt = srt.inoutCounters[0].Blocks_CMP;
+
     ZSTDGPU_FOR_WORK_ITEMS(i, 1, threadId, kzstdgpu_TgSizeX_InitCounters)
     {
-        srt.inoutFseInfos[kzstdgpu_FseRleTableCount + srt.cmpBlockCount * 1 + 0] = zstdgpu_CreateFseInfo(kzstdgpu_FseDefaultProbCount_LLen, kzstdgpu_FseDefaultProbAccuracy_LLen);
-        srt.inoutFseInfos[kzstdgpu_FseRleTableCount + srt.cmpBlockCount * 2 + 1] = zstdgpu_CreateFseInfo(kzstdgpu_FseDefaultProbCount_Offs, kzstdgpu_FseDefaultProbAccuracy_Offs);
-        srt.inoutFseInfos[kzstdgpu_FseRleTableCount + srt.cmpBlockCount * 3 + 2] = zstdgpu_CreateFseInfo(kzstdgpu_FseDefaultProbCount_MLen, kzstdgpu_FseDefaultProbAccuracy_MLen);
+        srt.inoutFseInfos[zstdgpu_ComputeFseIndexLLen(0, cmpBlockCnt)] = zstdgpu_CreateFseInfo(kzstdgpu_FseDefaultProbCount_LLen, kzstdgpu_FseDefaultProbAccuracy_LLen);
+        srt.inoutFseInfos[zstdgpu_ComputeFseIndexOffs(0, cmpBlockCnt)] = zstdgpu_CreateFseInfo(kzstdgpu_FseDefaultProbCount_Offs, kzstdgpu_FseDefaultProbAccuracy_Offs);
+        srt.inoutFseInfos[zstdgpu_ComputeFseIndexMLen(0, cmpBlockCnt)] = zstdgpu_CreateFseInfo(kzstdgpu_FseDefaultProbCount_MLen, kzstdgpu_FseDefaultProbAccuracy_MLen);
     }
 
     // Initialize 256 dense RLE entries at the beginning of FSE element buffers.
@@ -647,11 +649,11 @@ static void zstdgpu_ShaderEntry_InitResources(ZSTDGPU_PARAM_INOUT(zstdgpu_InitRe
     // NOTE(pamartis): We start from `srt.cmpBlockCount * kzstdgpu_MaxCount_FseProbs` because
     // it's the maximal size of FSE probabilities used for Huffman Weights FSE tables, but those don't have "default" probabilities,
     // and therefore not initialised.
-    uint32_t dstStart = srt.cmpBlockCount * kzstdgpu_MaxCount_FseProbs;
+    uint32_t dstStart = cmpBlockCnt * kzstdgpu_MaxCount_FseProbs;
     uint32_t srcStart = 0;
 
     // NOTE(pamartis): The reason we use extra `kzstdgpu_MaxCount_FseProbs` is to be able to store default probabilities
-    const uint32_t dstTableStride = srt.cmpBlockCount * kzstdgpu_MaxCount_FseProbs + kzstdgpu_MaxCount_FseProbs;
+    const uint32_t dstTableStride = cmpBlockCnt * kzstdgpu_MaxCount_FseProbs + kzstdgpu_MaxCount_FseProbs;
 
     ZSTDGPU_FOR_WORK_ITEMS(i, kzstdgpu_FseDefaultProbCount_LLen, threadId, kzstdgpu_TgSizeX_InitCounters)
     {
@@ -2337,7 +2339,8 @@ static void zstdgpu_ShaderEntry_DecodeHuffmanWeights(ZSTDGPU_PARAM_INOUT(zstdgpu
     if (threadId >= huffmanWeightsTableCount)
         return;
 
-    const uint32_t hufTableIndex = srt.compressedBlockCount - 1 - threadId;
+    // Uncompressed Huffman weight tables are stored at the end of inHufRefs[0..srt.inCounters[0].Blocks_CMP) buffer
+    const uint32_t hufTableIndex = srt.inCounters[0].Blocks_CMP - 1 - threadId;
 
     zstdgpu_Forward_BitBuffer bitBuffer;
     zstdgpu_Forward_BitBuffer_InitWithSegment(bitBuffer, srt.inCompressedData, srt.inHufRefs[hufTableIndex], srt.compressedBufferSizeInBytes);
@@ -2745,7 +2748,7 @@ static void zstdgpu_ShaderEntry_DecompressLiterals(ZSTDGPU_PARAM_INOUT(zstdgpu_D
         srt.inHufLitIdToLitStreamId,
         srt.inCounters[0].HufLit,
         srt.inCounters[0].HUF_Streams,
-        srt.huffmanTableSlotCount,
+        srt.inCounters[0].Blocks_CMP, // The number of Huffman table slots is the same as the number of Compressed blocks
         groupId,
         htIndex,
         htGroupStart,
@@ -2834,7 +2837,7 @@ static void zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(ZSTDGPU_
         srt.inHufLitIdToLitStreamId,
         srt.inCounters[0].HufLit,
         srt.inCounters[0].HUF_Streams,
-        srt.huffmanTableSlotCount,
+        srt.inCounters[0].Blocks_CMP, // The number of Huffman table slots is the same as the number of Compressed blocks
         groupId,
         htIndex,
         htGroupStart,

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -1599,8 +1599,9 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t initResou
 
 #define ZSTDGPU_INIT_FSE_TABLE_SRT()                                                                    \
     ZSTDGPU_RO_BUFFER_DECL(zstdgpu_FseInfo                      , FseInfos                      , 0)    \
+    ZSTDGPU_RO_BUFFER_DECL(zstdgpu_Counters                     , Counters                      , 1)    \
     \
-    ZSTDGPU_RO_TYPED_BUFFER_DECL(int32_t, int16_t               , FseProbs                      , 1)    \
+    ZSTDGPU_RO_TYPED_BUFFER_DECL(int32_t, int16_t               , FseProbs                      , 2)    \
     \
     ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , FseElems                      , 0)
 
@@ -1626,6 +1627,8 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t initResou
 #define ZSTDGPU_INIT_HUFFMAN_TABLE_SRT()                                                                \
     ZSTDGPU_RO_TYPED_BUFFER_DECL(uint32_t, uint8_t              , DecompressedHuffmanWeights    , 0)    \
     ZSTDGPU_RO_TYPED_BUFFER_DECL(uint32_t, uint8_t              , DecompressedHuffmanWeightCount, 1)    \
+    \
+    ZSTDGPU_RO_BUFFER_DECL(zstdgpu_Counters                     , Counters                      , 2)    \
     \
     ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , HuffmanTableInfo              , 0)    \
     ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , HuffmanTableCodeAndSymbol     , 1)    \
@@ -1727,10 +1730,11 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t initResou
     ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , DestSequenceOffsets           , 0)
 
 #define ZSTDGPU_MEMSET_MEMCPY_SRT()                                                                     \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , CompressedData                , 0)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , BlockSizePrefix               , 1)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , PerFrameBlockCountAll         , 2)    \
-    ZSTDGPU_RO_BUFFER_DECL(zstdgpu_OffsetAndSize                , UnCompressedFramesRefs        , 3)    \
+    ZSTDGPU_RO_BUFFER_DECL(zstdgpu_Counters                     , Counters                      , 0)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , CompressedData                , 1)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , BlockSizePrefix               , 2)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , PerFrameBlockCountAll         , 3)    \
+    ZSTDGPU_RO_BUFFER_DECL(zstdgpu_OffsetAndSize                , UnCompressedFramesRefs        , 4)    \
     \
     ZSTDGPU_RW_TYPED_BUFFER_DECL(uint32_t, uint8_t              , UnCompressedFramesData        , 0)
 
@@ -1821,7 +1825,6 @@ typedef struct zstdgpu_DecompressHuffmanWeights_SRT
 typedef struct zstdgpu_DecodeHuffmanWeights_SRT
 {
     ZSTDGPU_DECODE_HUFFMAN_WEIGHTS_SRT()
-    uint32_t    compressedBlockCount;
     uint32_t    compressedBufferSizeInBytes;
 } zstdgpu_DecodeHuffmanWeights_SRT;
 
@@ -1833,13 +1836,11 @@ typedef struct zstdgpu_InitHuffmanTable_SRT
 typedef struct zstdgpu_InitHuffmanTable_And_DecompressLiterals_SRT
 {
     ZSTDGPU_INIT_HUFFMAN_TABLE_AND_DECOMPRESS_LITERALS_SRT()
-    uint32_t    huffmanTableSlotCount;
 } zstdgpu_InitHuffmanTable_And_DecompressLiterals_SRT;
 
 typedef struct zstdgpu_DecompressLiterals_SRT
 {
     ZSTDGPU_DECOMPRESS_LITERALS_SRT()
-    uint32_t    huffmanTableSlotCount;
 } zstdgpu_DecompressLiterals_SRT;
 
 typedef struct zstdgpu_DecompressSequences_SRT

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -964,6 +964,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
     bool d3dDbg = false;
     bool d3dGfx = false;
     bool outFrm = false;
+    bool ssm = false;
 
     const wchar_t *zstFilePath = L"data\\group_0_cmp17_block8192.zst";
     wchar_t *zstFilePathStorage = NULL;
@@ -1096,6 +1097,10 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
                 {
                     outFrm = true;
                 }
+                else if (0 == wcscmp(argv[argi], L"--ssm"))
+                {
+                    ssm = true;
+                }
                 else
                 {
                     debugPrint(L"Unknown argv[%d] %s\n", argi, argv[argi]);
@@ -1120,6 +1125,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
                 debugPrint(L"\t--prf-lvl <0, 1, 2>       [Optional] Chooses the level of profiling: 0 - overall bandwidth in GB/s, 1 - stage cost, 2 - internal pass cost.\n");
                 debugPrint(L"\t--idx-{min,max} <number>  [Optional] Chooses the {minimal, maximal} index of the frame to decompress in multi-frame .zst file. Both values are clamped to the number of available frames.\n");
                 debugPrint(L"\t--out-frm                 [Optional] Outputs decompressed frames to files with <source_name.frame_N> name.\n");
+                debugPrint(L"\t--ssm                     [Optional] Forces single-submission mode with automatic scratch estimation.\n");
                 if (badArg)
                 {
                     return 1;
@@ -1343,8 +1349,23 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
         defaultUploadCallbackUserData[1] = (void *)zstdInFrameRefs;
         zstdgpu_SetupInputsAsFramesInCpuMemory(&stageCount, perRequestContext, fbInfo.frameCount, zstdDataSize, zstdgpu_DefaultUploadCallback, defaultUploadCallbackUserData);
     }
+    if (ssm)
+    {
+        zstdgpu_SetupAllStageSubmission(perRequestContext);
+    }
     if (blkCnt)
     {
+        /**
+         *  NOTE(pamartis):
+         *  Depending on whether `zstdgpu_SetupAllStageSubmission` was called or not,
+         *  calling `zstdgpu_SetupFrameInfoConstants` / `zstdgpu_SetupBlockInfoConstants`
+         *  either:
+         *
+         *  - improves scratch memory estimation (`zstdgpu_SetupAllStageSubmission` was called)
+         *
+         *  - enables elimination of mandatory wait for completion on GPU of the command list
+         *    populated with commands for the previous stage (if `zstdgpu_SetupAllStageSubmission` was NOT called)
+         */
         zstdgpu_SetupFrameInfoConstants(perRequestContext, fbInfo.rawBlockCount, fbInfo.rleBlockCount, fbInfo.cmpBlockCount);
         if (seqCnt)
         {

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -1271,26 +1271,6 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
         ZSTD_decompress(zstdReferenceUncompressedData, zstdReferenceUncompressedDataSize, zstdData, zstdDataSize);
     }
 
-#if 0
-    {
-        for (uint32_t i = 0; i < fbInfo.frameCount; ++i)
-        {
-            zstdgpu_CollectBlocks(
-                zstdCpu.BlocksRAWRefs,
-                zstdCpu.BlocksRLERefs,
-                zstdCpu.BlocksCMPRefs,
-                zstdCpu.FramesRefs,
-                zstdCpu.Frames,
-                i,
-                fbInfo.frameCount,
-                zstdData,
-                zstdBufferSize,
-                zstdDataSize
-            );
-        }
-    }
-#endif
-
     zstdgpu_ResourceDataCpu zstdCpu;
     if (chkCpu)
     {

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -1230,6 +1230,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
         debugPrint(L"[FAIL] Couldn't load create D3D12 device with venId=%u, devId=%u. Early Out.\n", gpuVenId, gpuDevId);
         return ERROR_SYSTEM_DEVICE_NOT_FOUND;
     }
+    device->SetStablePowerState(TRUE);
 
     d3d12aid_CmdQueue cmdQueue;
 #ifdef _GAMING_XBOX
@@ -1761,6 +1762,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
     if (NULL != zstFilePathStorage)
         free(zstFilePathStorage);
 
+    device->SetStablePowerState(FALSE);
     zstdgpu_Demo_PlatformTerm(device);
     debugPrint(L"Finished.\n");
     return 0;

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -1426,70 +1426,97 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
             //      [Stage1 - Req J]                  [Stage2 - Req J  ]                  [Stage0 - Req J+1]                  [Stage1 - Req J+1]
             //
             {
-                uint32_t *const StageTimestamp [3] = { &Stage0_Stamp, &Stage1_Stamp, &Stage2_Stamp };
-                uint32_t *const ReadbackTimestamp[2] = { &Readback0_Stamp, &Readback1_Stamp };
-                for (uint32_t stageIndex = 0; stageIndex < 3; ++stageIndex)
+                #define RECREATE_HEAP(name, i)                      \
+                    if (name##HeapSizeReq > name##HeapSize[i])      \
+                    {                                               \
+                        D3D12AID_SAFE_RELEASE(name##Heap[i]);       \
+                        name##Heap[i] = d3d12aid_Heap_Create(device, name##HeapSizeReq, 0, name##Type);\
+                        name##HeapSize[i] = name##HeapSizeReq;      \
+                    }
+                D3D12_HEAP_TYPE defaultType = D3D12_HEAP_TYPE_DEFAULT;
+                D3D12_HEAP_TYPE uploadType = D3D12_HEAP_TYPE_UPLOAD;
+                D3D12_HEAP_TYPE readbackType = D3D12_HEAP_TYPE_READBACK;
+                if (0 == zstdgpu_IsAnyStageReadbackRequired(perRequestContext))
                 {
-                    if (extMem /** a scenario with supplying external memory */)
+                    if (extMem)
                     {
                         uint32_t defaultHeapSizeReq = 0;
                         uint32_t uploadHeapSizeReq = 0;
                         uint32_t readbackHeapSizeReq = 0;
                         uint32_t descriptorCountReq = 0;
 
-                        zstdgpu_GetGpuMemoryRequirement(&defaultHeapSizeReq, &uploadHeapSizeReq, &readbackHeapSizeReq, &descriptorCountReq, perRequestContext, stageIndex);
+                        zstdgpu_GetAllStageGpuMemoryRequirement(&defaultHeapSizeReq, &uploadHeapSizeReq, &readbackHeapSizeReq, &descriptorCountReq, perRequestContext);
 
-                        if (defaultHeapSizeReq > defaultHeapSize[stageIndex])
+                        RECREATE_HEAP(default, 0)
+                        RECREATE_HEAP(upload, 0)
+                        RECREATE_HEAP(readback, 0)
+
+                        if (descriptorCountReq > descriptorCount[0])
                         {
-                            D3D12AID_SAFE_RELEASE(defaultHeap[stageIndex]);
-
-                            defaultHeap[stageIndex] = d3d12aid_Heap_Create(device, defaultHeapSizeReq, 0, D3D12_HEAP_TYPE_DEFAULT);
-                            defaultHeapSize[stageIndex] = defaultHeapSizeReq;
+                            D3D12AID_SAFE_RELEASE(descriptorHeap[0]);
+                            descriptorHeap[0] =  d3d12aid_DescriptorHeap_Create(device, descriptorCountReq, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE);
+                            descriptorCount[0] = descriptorCountReq;
                         }
 
-                        if (uploadHeapSizeReq > uploadHeapSize[stageIndex])
-                        {
-                            D3D12AID_SAFE_RELEASE(uploadHeap[stageIndex]);
-
-                            uploadHeap[stageIndex] = d3d12aid_Heap_Create(device, uploadHeapSizeReq, 0, D3D12_HEAP_TYPE_UPLOAD);
-                            uploadHeapSize[stageIndex] = uploadHeapSizeReq;
-                        }
-
-                        if (readbackHeapSizeReq > readbackHeapSize[stageIndex])
-                        {
-                            D3D12AID_SAFE_RELEASE(readbackHeap[stageIndex]);
-
-                            readbackHeap[stageIndex] = d3d12aid_Heap_Create(device, readbackHeapSizeReq, 0, D3D12_HEAP_TYPE_READBACK);
-                            readbackHeapSize[stageIndex] = readbackHeapSizeReq;
-                        }
-
-                        if (descriptorCountReq > descriptorCount[stageIndex])
-                        {
-                            D3D12AID_SAFE_RELEASE(descriptorHeap[stageIndex]);
-                            descriptorHeap[stageIndex] =  d3d12aid_DescriptorHeap_Create(device, descriptorCountReq, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE);
-                            descriptorCount[stageIndex] = descriptorCountReq;
-                        }
-
-                        d3d12aid_Timestamp_PushScope(*StageTimestamp[stageIndex], timestamps, cmdList,
-                            zstdgpu_SubmitWithExternalMemory(perRequestContext, stageIndex, cmdList, defaultHeap[stageIndex], 0, uploadHeap[stageIndex], 0, readbackHeap[stageIndex], 0, descriptorHeap[stageIndex], 0);
+                        d3d12aid_Timestamp_PushScope(Stage0_Stamp, timestamps, cmdList,
+                            zstdgpu_SubmitAllStagesWithExternalMemory(perRequestContext, cmdList, defaultHeap[0], 0, uploadHeap[0], 0, readbackHeap[0], 0, descriptorHeap[0], 0);
                         );
-
                     }
                     else
                     {
-                        d3d12aid_Timestamp_PushScope(*StageTimestamp[stageIndex], timestamps, cmdList,
-                            zstdgpu_SubmitWithInteralMemory(perRequestContext, stageIndex, cmdList);
-                        );
-                    }
-                    if (stageIndex < 2 && zstdgpu_IsReadbackRequired(perRequestContext, stageIndex))
-                    {
-                        d3d12aid_Timestamp_PushScope(*ReadbackTimestamp[stageIndex], timestamps, cmdList,
-                            d3d12aid_CmdQueue_SubmitCmdList(&cmdQueue, 0);
-                            d3d12aid_CmdQueue_CpuWaitForGpuIdle(&cmdQueue);
-                            cmdList = d3d12aid_CmdQueue_StartCmdList(&cmdQueue, 0/** cmdListId */);
+                        d3d12aid_Timestamp_PushScope(Stage0_Stamp, timestamps, cmdList,
+                            zstdgpu_SubmitAllStagesWithInteralMemory(perRequestContext, cmdList);
                         );
                     }
                 }
+                else
+                {
+                    uint32_t *const StageTimestamp [3] = { &Stage0_Stamp, &Stage1_Stamp, &Stage2_Stamp };
+                    uint32_t *const ReadbackTimestamp[2] = { &Readback0_Stamp, &Readback1_Stamp };
+                    for (uint32_t stageIndex = 0; stageIndex < 3; ++stageIndex)
+                    {
+                        if (extMem /** a scenario with supplying external memory */)
+                        {
+                            uint32_t defaultHeapSizeReq = 0;
+                            uint32_t uploadHeapSizeReq = 0;
+                            uint32_t readbackHeapSizeReq = 0;
+                            uint32_t descriptorCountReq = 0;
+
+                            zstdgpu_GetGpuMemoryRequirement(&defaultHeapSizeReq, &uploadHeapSizeReq, &readbackHeapSizeReq, &descriptorCountReq, perRequestContext, stageIndex);
+
+                            RECREATE_HEAP(default, stageIndex)
+                            RECREATE_HEAP(upload, stageIndex)
+                            RECREATE_HEAP(readback, stageIndex)
+
+                            if (descriptorCountReq > descriptorCount[stageIndex])
+                            {
+                                D3D12AID_SAFE_RELEASE(descriptorHeap[stageIndex]);
+                                descriptorHeap[stageIndex] =  d3d12aid_DescriptorHeap_Create(device, descriptorCountReq, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE);
+                                descriptorCount[stageIndex] = descriptorCountReq;
+                            }
+
+                            d3d12aid_Timestamp_PushScope(*StageTimestamp[stageIndex], timestamps, cmdList,
+                                zstdgpu_SubmitWithExternalMemory(perRequestContext, stageIndex, cmdList, defaultHeap[stageIndex], 0, uploadHeap[stageIndex], 0, readbackHeap[stageIndex], 0, descriptorHeap[stageIndex], 0);
+                            );
+
+                        }
+                        else
+                        {
+                            d3d12aid_Timestamp_PushScope(*StageTimestamp[stageIndex], timestamps, cmdList,
+                                zstdgpu_SubmitWithInteralMemory(perRequestContext, stageIndex, cmdList);
+                            );
+                        }
+                        if (stageIndex < 2 && zstdgpu_IsReadbackRequired(perRequestContext, stageIndex))
+                        {
+                            d3d12aid_Timestamp_PushScope(*ReadbackTimestamp[stageIndex], timestamps, cmdList,
+                                d3d12aid_CmdQueue_SubmitCmdList(&cmdQueue, 0);
+                                d3d12aid_CmdQueue_CpuWaitForGpuIdle(&cmdQueue);
+                                cmdList = d3d12aid_CmdQueue_StartCmdList(&cmdQueue, 0/** cmdListId */);
+                            );
+                        }
+                    }
+                }
+                #undef RECREATE_HEAP
 
                 {
                     D3D12_RESOURCE_BARRIER barrier;

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -1426,11 +1426,11 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
             //      [Stage1 - Req J]                  [Stage2 - Req J  ]                  [Stage0 - Req J+1]                  [Stage1 - Req J+1]
             //
             {
-                if (extMem)
+                uint32_t *const StageTimestamp [3] = { &Stage0_Stamp, &Stage1_Stamp, &Stage2_Stamp };
+                uint32_t *const ReadbackTimestamp[2] = { &Readback0_Stamp, &Readback1_Stamp };
+                for (uint32_t stageIndex = 0; stageIndex < 3; ++stageIndex)
                 {
-                    uint32_t *const StageTimestamp [3] = { &Stage0_Stamp, &Stage1_Stamp, &Stage2_Stamp };
-                    uint32_t *const ReadbackTimestamp[2] = { &Readback0_Stamp, &Readback1_Stamp };
-                    for (uint32_t stageIndex = 0; stageIndex < 3; ++stageIndex)
+                    if (extMem /** a scenario with supplying external memory */)
                     {
                         uint32_t defaultHeapSizeReq = 0;
                         uint32_t uploadHeapSizeReq = 0;
@@ -1474,36 +1474,23 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
                             zstdgpu_SubmitWithExternalMemory(perRequestContext, stageIndex, cmdList, defaultHeap[stageIndex], 0, uploadHeap[stageIndex], 0, readbackHeap[stageIndex], 0, descriptorHeap[stageIndex], 0);
                         );
 
-                        if (stageIndex < 2 && zstdgpu_IsReadbackRequired(perRequestContext, stageIndex))
-                        {
-                            d3d12aid_Timestamp_PushScope(*ReadbackTimestamp[stageIndex], timestamps, cmdList,
-                                d3d12aid_CmdQueue_SubmitCmdList(&cmdQueue, 0);
-                                d3d12aid_CmdQueue_CpuWaitForGpuIdle(&cmdQueue);
-                                cmdList = d3d12aid_CmdQueue_StartCmdList(&cmdQueue, 0/** cmdListId */);
-                            );
-                        }
                     }
-                }
-                else
-                {
-                    uint32_t *const StageTimestampInt[3] = { &Stage0_Stamp, &Stage1_Stamp, &Stage2_Stamp };
-                    uint32_t *const ReadbackTimestampInt[2] = { &Readback0_Stamp, &Readback1_Stamp };
-                    for (uint32_t stageIndex = 0; stageIndex < 3; ++stageIndex)
+                    else
                     {
-                        d3d12aid_Timestamp_PushScope(*StageTimestampInt[stageIndex], timestamps, cmdList,
+                        d3d12aid_Timestamp_PushScope(*StageTimestamp[stageIndex], timestamps, cmdList,
                             zstdgpu_SubmitWithInteralMemory(perRequestContext, stageIndex, cmdList);
                         );
-
-                        if (stageIndex < 2 && zstdgpu_IsReadbackRequired(perRequestContext, stageIndex))
-                        {
-                            d3d12aid_Timestamp_PushScope(*ReadbackTimestampInt[stageIndex], timestamps, cmdList,
-                                d3d12aid_CmdQueue_SubmitCmdList(&cmdQueue, 0);
-                                d3d12aid_CmdQueue_CpuWaitForGpuIdle(&cmdQueue);
-                                cmdList = d3d12aid_CmdQueue_StartCmdList(&cmdQueue, 0/** cmdListId */);
-                            );
-                        }
+                    }
+                    if (stageIndex < 2 && zstdgpu_IsReadbackRequired(perRequestContext, stageIndex))
+                    {
+                        d3d12aid_Timestamp_PushScope(*ReadbackTimestamp[stageIndex], timestamps, cmdList,
+                            d3d12aid_CmdQueue_SubmitCmdList(&cmdQueue, 0);
+                            d3d12aid_CmdQueue_CpuWaitForGpuIdle(&cmdQueue);
+                            cmdList = d3d12aid_CmdQueue_StartCmdList(&cmdQueue, 0/** cmdListId */);
+                        );
                     }
                 }
+
                 {
                     D3D12_RESOURCE_BARRIER barrier;
                     d3d12aid_MappedBuffer_BeginTransfer(&barrier, &zstdUnCompressedFramesMemory, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -968,6 +968,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
     bool simGpu = false;
     bool d3dDbg = false;
     bool d3dGfx = false;
+    bool outFrm = false;
 
     const wchar_t *zstFilePath = L"data\\group_0_cmp17_block8192.zst";
     wchar_t *zstFilePathStorage = NULL;
@@ -1096,6 +1097,10 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
                 {
                     nextMaxFrame = true;
                 }
+                else if (0 == wcscmp(argv[argi], L"--out-frm"))
+                {
+                    outFrm = true;
+                }
                 else
                 {
                     debugPrint(L"Unknown argv[%d] %s\n", argi, argv[argi]);
@@ -1119,6 +1124,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
                 debugPrint(L"\t--seq-cnt                 [Optional] Also uses SetupBlockInfoConstants (implies --blk-cnt). Merges all stages into single submission.\n");
                 debugPrint(L"\t--prf-lvl <0, 1, 2>       [Optional] Chooses the level of profiling: 0 - overall bandwidth in GB/s, 1 - stage cost, 2 - internal pass cost.\n");
                 debugPrint(L"\t--idx-{min,max} <number>  [Optional] Chooses the {minimal, maximal} index of the frame to decompress in multi-frame .zst file. Both values are clamped to the number of available frames.\n");
+                debugPrint(L"\t--out-frm                 [Optional] Outputs decompressed frames to files with <source_name.frame_N> name.\n");
                 if (badArg)
                 {
                     return 1;
@@ -1596,7 +1602,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
                     }
                 }
 
-                if (frameIndex == 0)
+                if (frameIndex == 0 && outFrm /** output decompressed frame data to files if requested via command line */)
                 {
 #ifdef _MSC_VER
                     __pragma(warning(push))

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -940,7 +940,7 @@ ZSTDGPU_API void zstdgpu_ReadbackGpuResults(zstdgpu_PerRequestContext req, ID3D1
 ZSTDGPU_API void zstdgpu_RetrieveGpuResults(zstdgpu_ResourceDataCpu *outGpuResources, zstdgpu_PerRequestContext req);
 
 ZSTDGPU_API void zstdgpu_ReadbackTimestamps(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandList *cmdList);
-ZSTDGPU_API void zstdgpu_RetrieveTimestamps(const wchar_t **outTimestampScopeNames, uint64_t *outTimestampScopeClocks, uint32_t *inoutTimestampScopeCnt, zstdgpu_PerRequestContext req, uint32_t stageIndex);
+ZSTDGPU_API uint64_t zstdgpu_RetrieveTimestamps(const wchar_t **outTimestampScopeNames, uint64_t *outTimestampScopeClocks, uint32_t *inoutTimestampScopeCnt, zstdgpu_PerRequestContext req, uint32_t stageIndex);
 
 // Entry point
 #ifndef _GAMING_XBOX
@@ -1239,9 +1239,6 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
 #endif
 
     #define ZSTDGPU_TS_LIST()   \
-        ZSTDGPU_TS(Stage0)      \
-        ZSTDGPU_TS(Stage1)      \
-        ZSTDGPU_TS(Stage2)      \
         ZSTDGPU_TS(Readback0)   \
         ZSTDGPU_TS(Readback1)
 
@@ -1474,20 +1471,15 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
                             descriptorCount[0] = descriptorCountReq;
                         }
 
-                        d3d12aid_Timestamp_PushScope(Stage0_Stamp, timestamps, cmdList,
-                            zstdgpu_SubmitAllStagesWithExternalMemory(perRequestContext, cmdList, defaultHeap[0], 0, uploadHeap[0], 0, readbackHeap[0], 0, descriptorHeap[0], 0);
-                        );
+                        zstdgpu_SubmitAllStagesWithExternalMemory(perRequestContext, cmdList, defaultHeap[0], 0, uploadHeap[0], 0, readbackHeap[0], 0, descriptorHeap[0], 0);
                     }
                     else
                     {
-                        d3d12aid_Timestamp_PushScope(Stage0_Stamp, timestamps, cmdList,
-                            zstdgpu_SubmitAllStagesWithInteralMemory(perRequestContext, cmdList);
-                        );
+                        zstdgpu_SubmitAllStagesWithInteralMemory(perRequestContext, cmdList);
                     }
                 }
                 else
                 {
-                    uint32_t *const StageTimestamp [3] = { &Stage0_Stamp, &Stage1_Stamp, &Stage2_Stamp };
                     uint32_t *const ReadbackTimestamp[2] = { &Readback0_Stamp, &Readback1_Stamp };
                     for (uint32_t stageIndex = 0; stageIndex < 3; ++stageIndex)
                     {
@@ -1511,16 +1503,11 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
                                 descriptorCount[stageIndex] = descriptorCountReq;
                             }
 
-                            d3d12aid_Timestamp_PushScope(*StageTimestamp[stageIndex], timestamps, cmdList,
-                                zstdgpu_SubmitWithExternalMemory(perRequestContext, stageIndex, cmdList, defaultHeap[stageIndex], 0, uploadHeap[stageIndex], 0, readbackHeap[stageIndex], 0, descriptorHeap[stageIndex], 0);
-                            );
-
+                            zstdgpu_SubmitWithExternalMemory(perRequestContext, stageIndex, cmdList, defaultHeap[stageIndex], 0, uploadHeap[stageIndex], 0, readbackHeap[stageIndex], 0, descriptorHeap[stageIndex], 0);
                         }
                         else
                         {
-                            d3d12aid_Timestamp_PushScope(*StageTimestamp[stageIndex], timestamps, cmdList,
-                                zstdgpu_SubmitWithInteralMemory(perRequestContext, stageIndex, cmdList);
-                            );
+                            zstdgpu_SubmitWithInteralMemory(perRequestContext, stageIndex, cmdList);
                         }
                         if (stageIndex < 2 && zstdgpu_IsReadbackRequired(perRequestContext, stageIndex))
                         {
@@ -1656,39 +1643,48 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
                 {
                     cmdQueue.queue->GetTimestampFrequency(&freqGpuClocks);
                 }
-                const wchar_t *timestampScopeNames[16];
-                uint64_t timestampScopeClocks[16];
+                const wchar_t *timestampScopeNames[22];
+                uint64_t timestampScopeClocks[22];
                 uint64_t clks = 0;
+                uint64_t clksAll = 0;
                 #define ZSTDGPU_TS(name)                                                                        \
                     if (name##_Stamp != ~0u && prfLevel > 0)                                                    \
                     {                                                                                           \
                         clks = d3d12aid_Timestamps_GetScopeDelta(&timestamps, kBackBufferIndex, name##_Stamp);  \
-                        const uint64_t usec = (clks * 1000000) / freqGpuClocks;                                 \
-                        debugPrint(L"[PERF] %u frame: %7llu us - '" #name "' \n", frameIndex, usec);                  \
+                        clksAll += clks;                                                                        \
+                        if (prfLevel > 0)                                                                       \
+                        {                                                                                       \
+                            const uint64_t usec = (clks * 1000000) / freqGpuClocks;                             \
+                            debugPrint(L"[PERF] %u frame: %7llu us - '" #name "' \n", frameIndex, usec);        \
+                        }                                                                                       \
                     }
 
                 #define ZSTDGPU_DETAIL_TS(stage) \
-                    if (prfLevel > 1)            \
                     {                            \
-                        uint32_t timestampScopeCount = _countof(timestampScopeClocks);                                                                              \
-                        zstdgpu_RetrieveTimestamps(timestampScopeNames, timestampScopeClocks, &timestampScopeCount, perRequestContext, stage);                      \
-                        for (uint32_t i = 0; i < timestampScopeCount; ++i)                                                                                          \
-                        {                                                                                                                                           \
-                            debugPrint(L"[PERF] %u frame: \t%7llu us - 'Stage"#stage" :: %s'\n", frameIndex,  (timestampScopeClocks[i] * 1000000) / freqGpuClocks, timestampScopeNames[i]);  \
-                        }                                                                                                                                           \
+                        uint32_t timestampScopeCount = _countof(timestampScopeClocks);                                                                  \
+                        clks = zstdgpu_RetrieveTimestamps(timestampScopeNames, timestampScopeClocks, &timestampScopeCount, perRequestContext, stage);   \
+                        clksAll += clks;                                                                                                                \
+                        if (prfLevel > 0)                                                                                                               \
+                        {                                                                                                                               \
+                            const uint64_t usec = (clks * 1000000) / freqGpuClocks;                                                                     \
+                            debugPrint(L"[PERF] %u frame: %7llu us - 'Stage" #stage "' \n", frameIndex, usec);                                          \
+                            if (prfLevel > 1)                                                                                                           \
+                            {                                                                                                                           \
+                                for (uint32_t i = 0; i < timestampScopeCount; ++i)                                                                      \
+                                {                                                                                                                       \
+                                    debugPrint(L"[PERF] %u frame: \t%7llu us - 'Stage"#stage" :: %s'\n", frameIndex,  (timestampScopeClocks[i] * 1000000) / freqGpuClocks, timestampScopeNames[i]);  \
+                                }                                                                                                                       \
+                            }                                                                                                                           \
+                        }                                                                                                                               \
                     }
-                    ZSTDGPU_TS(Stage0)
                     ZSTDGPU_DETAIL_TS(0)
                     ZSTDGPU_TS(Readback0)
-                    ZSTDGPU_TS(Stage1)
                     ZSTDGPU_DETAIL_TS(1)
                     ZSTDGPU_TS(Readback1)
-                    ZSTDGPU_TS(Stage2)
                     ZSTDGPU_DETAIL_TS(2)
                     if (prfLevel == 0)
                     {
-                        clks = d3d12aid_Timestamps_GetDelta(&timestamps, kBackBufferIndex, Stage0_Stamp, Stage2_Stamp + 1);
-                        const uint64_t ns = (clks * 1000000000) / freqGpuClocks;
+                        const uint64_t ns = (clksAll * 1000000000) / freqGpuClocks;
                         const double decompressionThroughput = (double)zstdUnCompressedFramesMemorySizeInBytes / ns;
                         debugPrint(L"[PERF] %u frame: Decompression throughput %lf (GB/s)\n", frameIndex, decompressionThroughput);
                     }

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -298,7 +298,6 @@ static void zstdgpu_Test_DecompressHuffmanWeights(zstdgpu_ResourceDataCpu & cpuR
         // NOTE(pamartis): We don't need to set CPU-side Huffman Weight Counts because they're not computed within kernel
         // like in the "Decompress" case, and only read instead. And therefore we want to use GPU data
         //srt.inoutDecompressedHuffmanWeightCount = cpuRes.DecompressedHuffmanWeightCount;
-        srt.compressedBlockCount                = gpuReadbackRes.Counters->Blocks_CMP;
         srt.compressedBufferSizeInBytes         = zstdDataBufferSize;
         for (uint32_t i = 0; i < gpuReadbackRes.Counters->HUF_WgtStreams; ++i)
         {
@@ -366,9 +365,7 @@ static void zstdgpu_Test_DecompressLiterals(zstdgpu_ResourceDataCpu & cpuRes, zs
         zstdgpu_Init_InitHuffmanTable_And_DecompressLiterals_SRT(srt, gpuReadbackRes);
         srt.inCompressedData            = cpuRes.CompressedData;
         srt.inoutDecompressedLiterals   = cpuRes.DecompressedLiterals;
-        srt.huffmanTableSlotCount       = gpuReadbackRes.Counters->Blocks_CMP;
-
-        const uint32_t htSlotCount = srt.huffmanTableSlotCount;
+        const uint32_t htSlotCount = gpuReadbackRes.Counters->Blocks_CMP;
         const uint32_t hufLitCount = gpuReadbackRes.Counters->HufLit;
         const uint32_t hufLitStreamCountTotal = gpuReadbackRes.Counters->HUF_Streams;
 
@@ -816,7 +813,6 @@ static void zstdgpu_Validate_GpuDecompressOnCpu(zstdgpu_ResourceDataCpu & zstdCp
     {
         zstdgpu_DecodeHuffmanWeights_SRT srt;
         zstdgpu_Init_DecodeHuffmanWeights_SRT(srt, zstdCpu);
-        srt.compressedBlockCount        = zstdCmpBlockCount;
         srt.compressedBufferSizeInBytes = zstdInfo.CompressedData_ByteSize;
         for (uint32_t i = 0; i < CNTRS(HUF_WgtStreams); ++i)
         {
@@ -840,7 +836,6 @@ static void zstdgpu_Validate_GpuDecompressOnCpu(zstdgpu_ResourceDataCpu & zstdCp
         // Run Literal Decompression
         zstdgpu_InitHuffmanTable_And_DecompressLiterals_SRT srt;
         zstdgpu_Init_InitHuffmanTable_And_DecompressLiterals_SRT(srt, zstdCpu);
-        srt.huffmanTableSlotCount = zstdCmpBlockCount;
         for (uint32_t groupId = 0; groupId < groupPrefix; ++groupId)
         {
             zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(srt, groupId, 0, 1);


### PR DESCRIPTION
This PR adds a couple of public APIs to simplify necessary steps to submit decompression pipeline into a single command list that becomes possible if the caller can either specify required frame/block-level constant or is fine to rely on library default estimator:
- `zstdgpu_SetupAllStageSubmission` enables single submission without specifying frame/block-level constants upfront via `zstdgpu_SetupFrameInfoConstants` / `zstdgpu_SetupBlockInfoConstants` (command line `--ssm`)
- `zstdgpu_SubmitAllStagesWithExternalMemory`, `zstdgpu_GetAllStageGpuMemoryRequirement`, `zstdgpu_SubmitAllStagesWithInteralMemory`

Additionally, this PR 
- re-visits internal timestamps handling to measure GPU time
- excludes optional zstdgpu-side memory upload from decompression time measurement
- makes sure it's fine to specify all frame/block-level constants that are larger than discovered during data parsing
- always enable `SetStablePowerState`
- makes sure decompressed frames aren't written to disk unless requested via `--out-frm`

