### PR TITLE
Update GpuDecompressBenchmark to use Microsoft.Direct3D.DirectStorage.1.4.0-preview2-2606.904

### DIFF
--- a/Samples/GpuDecompressionBenchmark/GpuDecompressionBenchmark.vcxproj
+++ b/Samples/GpuDecompressionBenchmark/GpuDecompressionBenchmark.vcxproj
@@ -172,13 +172,13 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
-    <Import Project="..\packages\Microsoft.Direct3D.DirectStorage.1.4.0-preview1-2603.504\build\native\targets\Microsoft.Direct3D.DirectStorage.targets" Condition="Exists('..\packages\Microsoft.Direct3D.DirectStorage.1.4.0-preview1-2603.504\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" />
+    <Import Project="..\packages\Microsoft.Direct3D.DirectStorage.1.4.0-preview2-2606.904\build\native\targets\Microsoft.Direct3D.DirectStorage.targets" Condition="Exists('..\packages\Microsoft.Direct3D.DirectStorage.1.4.0-preview2-2606.904\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Direct3D.DirectStorage.1.4.0-preview1-2603.504\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Direct3D.DirectStorage.1.4.0-preview1-2603.504\build\native\targets\Microsoft.Direct3D.DirectStorage.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Direct3D.DirectStorage.1.4.0-preview2-2606.904\build\native\targets\Microsoft.Direct3D.DirectStorage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Direct3D.DirectStorage.1.4.0-preview2-2606.904\build\native\targets\Microsoft.Direct3D.DirectStorage.targets'))" />
   </Target>
 </Project>

--- a/Samples/GpuDecompressionBenchmark/packages.config
+++ b/Samples/GpuDecompressionBenchmark/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Direct3D.DirectStorage" version="1.4.0-preview1-2603.504" targetFramework="native" />
+  <package id="Microsoft.Direct3D.DirectStorage" version="1.4.0-preview2-2606.904" targetFramework="native" />
   <package id="zlib-msvc-x64" version="1.2.11.8900" targetFramework="native" />
 </packages>


### PR DESCRIPTION
This commit updates the GPUDecompressionBenchmark to use DirectStorage nuget version 1.4.0-preview2-2606.904 to improve GACL BC1-5 performance.