### PR TITLE
zstdgpu/asserts: adds support for minimal proper asserts

### DIFF
--- a/zstd/ThirdParty/tta_assert.h
+++ b/zstd/ThirdParty/tta_assert.h
@@ -1,0 +1,352 @@
+/**
+ * Copyright (c) 2026 Pavel Martishevsky
+ *
+ * This header is distributed under the MIT License. See notice at the end of this file.
+ *
+ * tta_assert.h - A multi-mode assert macro for C/C++ supporting unit test mode
+ */
+
+#ifndef TTA_ASSERT_H
+#define TTA_ASSERT_H
+
+/* clang-format off */
+#ifdef __cplusplus
+#   define TTA_ASSERT_API extern "C"
+#   define TTA_ASSERT_MAY_THROW_API extern
+#else
+#   define TTA_ASSERT_API
+#   define TTA_ASSERT_MAY_THROW_API
+#endif
+
+/**
+ *  @brief  Compile-time modes controlling assertion macros behaviour
+ *              - passthrough: executes condition only in `TTA_ASSERT_IF{_MSG}` or `TTA_ASSERT_RET{_MSG}`,
+ *                             `TTA_ASSERT{_MSG}` assertions are compiled out and don't carry any overhead
+ *
+ *              - instrumented: executes the condition, reports details of the assertion to the calling site via
+ *                              callback set in `tta_AssertSetReportCback`, optionally calls a debugreak or throw/longjmp
+ */
+#define TTA_ASSERT_MODE_PASSTHROUGH 0
+#define TTA_ASSERT_MODE_INSTRUMENTED 1
+
+/**
+ *  @brief  The enum specifying runtime assertion level of reporting when instrumentation is enabled
+ *          via `TTA_ASSERT_MODE` being set to `TTA_ASSERT_MODE_INSTRUMENTED`
+ */
+enum tta_AssertReportLevel
+{
+    ktta_AssertReportLevel_Print         = 0,   /**< every assertion triggers a callback setup through `tta_AssertSetReportCback` */
+    ktta_AssertReportLevel_PrintAndBreak = 1,   /**< same _Print + assertion triggers a debugbreak when debugger is attached */
+    ktta_AssertReportLevel_PrintAndThrow = 2,   /**< same _Print + assertion calls `throw`/`longjmp` to `catch`/`setjmp` later
+                                                     mainly to support reusing existing code with asserts in tests */
+    ktta_AssertReportLevel_ForceInt      = 0x3fffffff
+};
+
+#ifndef __cplusplus
+typedef enum tta_AssertReportLevel tta_AssertReportLevel;
+#endif
+
+#if defined(_MSC_VER)
+#   define TTA_BREAK() __debugbreak()
+#elif defined(__clang__) && __has_builtin(__builtin_debugtrap)
+#   define TTA_BREAK() __builtin_debugtrap()
+#else
+#   error Unknown compiler
+#endif
+
+#if defined(_MSC_VER)
+#   ifdef __cplusplus
+#       define TTA_FUNC __FUNCSIG__
+#   else
+#       define TTA_FUNC __FUNCTION__
+#   endif
+#elif defined(__clang__)
+#   define TTA_FUNC __PRETTY_FUNCTION__
+#else
+#   error Unknown compiler
+#endif
+/* clang-format on */
+
+/** @brief  Function type used as a callback implementing how assertion information is used / printed */
+TTA_ASSERT_API typedef void tta_AssertReportCback(const char *expr, const char *file, int line, const char *func, const char *msg, void *args);
+
+TTA_ASSERT_API int tta_AssertAlways_0(void);
+TTA_ASSERT_API int tta_AssertAlways_1(void);
+
+TTA_ASSERT_API tta_AssertReportLevel  tta_AssertGetReportLevel(void);
+TTA_ASSERT_API tta_AssertReportCback *tta_AssertGetReportCback(void);
+
+/** @brief  Function to setup assertion level of reporting */
+TTA_ASSERT_API void tta_AssertSetReportLevel(tta_AssertReportLevel level);
+
+/** @brief  Function to setup a callback that receive assertion information */
+TTA_ASSERT_API void tta_AssertSetReportCback(tta_AssertReportCback *cback);
+
+/** @brief  Function that is called by assert macros in instrumented mode to pass information to the `tta_AssertReportCback` */
+TTA_ASSERT_MAY_THROW_API int tta_AssertReport(const char *cond, const char *, int, const char *, const char *, ...);
+
+/**
+ *  @brief  The function that could be used to implement testing by re-using existing code containing TTA_ASSERT:
+ *              1. Just pass the `callback` that executes a code with TTA_ASSERT, and `userdata` for it
+ *              2. If TTA_ASSERT is triggered by any code executed by `callback` (not necessarily triggered within `callback`
+ *                 which assumes arbitrarily nesting), this function returns `1`, otherwise it returns `0`,
+ *                 so it's really easy to count failed tests `failed += tta_AssertCallAndCatch(&my_test, my_test_userdata);`
+ *  @note   For now, it's not reentrant: any code executed within callback is not allowed to call `tta_AssertCallAndCatch`
+ *  @warning  When `TTA_ASSERT_NOEXCEPT` is enabled, this function uses `setjmp`/`longjmp` internally.
+ *            `longjmp` over C++ objects with non-trivial destructors is undefined behavior (C++ $21.10.4, CERT ERR52-CPP).
+ *            Ensure no RAII objects (`std::string`, `std::vector`, smart pointers, lock guards, etc.) are alive between
+ *            the `TTA_ASSERT` call site and the `tta_AssertCallAndCatch` frame when using `TTA_ASSERT_NOEXCEPT`.
+ */
+TTA_ASSERT_MAY_THROW_API int tta_AssertCallAndCatch(int (*callback)(void *), void *userdata);
+
+#endif /* TTA_ASSERT_H */
+
+/* clang-format off */
+/**
+ *  Assert macros.
+ *
+ *  To switch compile-time mode:
+ *      #undef  TTA_ASSERT_MODE
+ *      #define TTA_ASSERT_MODE TTA_ASSERT_MODE_INSTRUMENTED
+ *      #include "tta_assert.h"
+ *
+ *  Because the header file can be included multiple times, the macro are undefined first
+ */
+#ifdef TTA_ASSERT
+#   undef TTA_ASSERT
+#endif
+
+#ifdef TTA_ASSERT_MSG
+#   undef TTA_ASSERT_MSG
+#endif
+
+#ifdef TTA_ASSERT_RET
+#   undef TTA_ASSERT_RET
+#endif
+
+#ifdef TTA_ASSERT_RET_MSG
+#   undef TTA_ASSERT_RET_MSG
+#endif
+
+#ifdef TTA_ASSERT_IF
+#   undef TTA_ASSERT_IF
+#endif
+
+#ifdef TTA_ASSERT_IF_MSG
+#   undef TTA_ASSERT_IF_MSG
+#endif
+
+/**
+ *  `TTA_ASSERT_MODE` is set to passthrough by default
+ */
+#ifndef TTA_ASSERT_MODE
+#   define TTA_ASSERT_MODE TTA_ASSERT_MODE_PASSTHROUGH
+#endif
+
+#if TTA_ASSERT_MODE == TTA_ASSERT_MODE_PASSTHROUGH
+#   define TTA_ASSERT_MSG(cond, msg, ...)           ((void)sizeof((cond) != 0))
+#   define TTA_ASSERT_IF_MSG(cond, msg, ...)        if (!!(cond))
+#   define TTA_ASSERT_RET_MSG(cond, retv, msg, ...) do { if (!(cond)) return (retv); } while (0)
+#elif TTA_ASSERT_MODE == TTA_ASSERT_MODE_INSTRUMENTED
+#   define TTA_ASSERT_MSG(cond, msg, ...)                                           \
+        (!!(cond) ||                                                                \
+            (                                                                       \
+                (                                                                   \
+                    tta_AssertReport(#cond, __FILE__, __LINE__, TTA_FUNC, msg, ##__VA_ARGS__) &&   \
+                    (TTA_BREAK(), tta_AssertAlways_1())                             \
+                ),                                                                  \
+                tta_AssertAlways_0()                                                \
+            )                                                                       \
+        )
+
+#   define TTA_ASSERT_IF_MSG(cond, msg, ...)            \
+        if (TTA_ASSERT_MSG(cond, msg, ##__VA_ARGS__))
+
+#   define TTA_ASSERT_RET_MSG(cond, retv, msg, ...)                                \
+        do                                                                         \
+        {                                                                          \
+            if (!TTA_ASSERT_MSG(cond, msg, ##__VA_ARGS__))                         \
+                return (retv);                                                     \
+        } while (0)
+#else
+#   error Unknown TTA_ASSERT_MODE.
+#endif /* TTA_ASSERT_MODE == TTA_ASSERT_MODE_PASSTHROUGH */
+
+#define TTA_ASSERT(cond)            TTA_ASSERT_MSG(cond, 0)
+#define TTA_ASSERT_IF(cond)         TTA_ASSERT_IF_MSG(cond, 0)
+#define TTA_ASSERT_RET(cond, retv)  TTA_ASSERT_RET_MSG(cond, retv, 0)
+/* clang-format on */
+
+/**
+ *  Define TTA_ASSERT_IMPL in exactly one translation unit to provide storage.
+ */
+#ifdef TTA_ASSERT_IMPL
+
+#ifndef TTA_ASSERT_IMPL_PRESENT
+#define TTA_ASSERT_IMPL_PRESENT 1
+
+static void tta_AssertReportCback_Default(const char *expr, const char *file, int line, const char *func, const char *msg, void *args)
+{
+    (void)expr;
+    (void)file;
+    (void)line;
+    (void)func;
+    (void)msg;
+    (void)args;
+}
+
+static volatile int tta_zero = 0;
+static volatile int tta_one  = 1;
+
+int tta_AssertAlways_0(void)
+{
+    return tta_zero;
+}
+
+int tta_AssertAlways_1(void)
+{
+    return tta_one;
+}
+
+static tta_AssertReportCback *tta_Cback = &tta_AssertReportCback_Default;
+static tta_AssertReportLevel  tta_Level = ktta_AssertReportLevel_Print;
+
+tta_AssertReportLevel tta_AssertGetReportLevel(void)
+{
+    return tta_Level;
+}
+
+tta_AssertReportCback *tta_AssertGetReportCback(void)
+{
+    return tta_Cback;
+}
+
+void tta_AssertSetReportLevel(tta_AssertReportLevel level)
+{
+    tta_Level = level;
+}
+
+void tta_AssertSetReportCback(tta_AssertReportCback *cback)
+{
+    tta_Cback = cback ? cback : &tta_AssertReportCback_Default;
+}
+
+/* clang-format off */
+#if defined(__cplusplus) && !(defined(TTA_ASSERT_NOEXCEPT) && TTA_ASSERT_NOEXCEPT)
+    struct tta_AssertExcept
+    {
+        const char *msg;
+        tta_AssertExcept(const char *m) : msg(m)
+        {
+        }
+    };
+#else
+    /*
+     * TTA_ASSERT_NOEXCEPT / C mode: uses setjmp/longjmp instead of C++ exceptions.
+     * WARNING: longjmp over C++ objects with non-trivial destructors is undefined behavior.
+     * See C++ $21.10.4 and CERT ERR52-CPP.
+     */
+#   ifdef _MSC_VER
+#       pragma warning(push)
+#       pragma warning(disable : 4820) /* struct padding in system headers */
+#   endif
+#   include <setjmp.h>
+#   ifdef _MSC_VER
+#       pragma warning(pop)
+#   endif
+    static jmp_buf     tta_jmpbuf;
+    static const char *tta_error;
+#endif
+/* clang-format on */
+
+#include <stdarg.h>
+
+/* Debugger presence detection, current support only WIN32 */
+#if defined(_WIN32)
+    TTA_ASSERT_API __declspec(dllimport) int __stdcall IsDebuggerPresent(void);
+    static int tta_IsDebuggerPresent(void) { return IsDebuggerPresent(); }
+#else
+    static int tta_IsDebuggerPresent(void) { return 1; }
+#endif
+
+int tta_AssertReport(const char *cond, const char *file, int line, const char *func, const char *msg, ...)
+{
+    va_list args;
+    va_start(args, msg);
+    tta_Cback(cond, file, line, func, msg, &args);
+    va_end(args);
+    if (tta_Level == ktta_AssertReportLevel_PrintAndThrow)
+    {
+#if defined(__cplusplus) && !(defined(TTA_ASSERT_NOEXCEPT) && TTA_ASSERT_NOEXCEPT)
+        throw tta_AssertExcept("tta_Except");
+#else
+        tta_error = "tta_Except";
+        longjmp(tta_jmpbuf, 1);
+#endif
+    }
+    return tta_Level == ktta_AssertReportLevel_PrintAndBreak && tta_IsDebuggerPresent();
+}
+
+int tta_AssertCallAndCatch(int (*callback)(void *), void *userdata)
+{
+    tta_AssertReportCback *prev_cback = tta_Cback;
+    tta_AssertReportLevel  prev_level = tta_Level;
+    volatile int           failed     = 0;
+    tta_Level                         = ktta_AssertReportLevel_PrintAndThrow;
+#if defined(__cplusplus) && !(defined(TTA_ASSERT_NOEXCEPT) && TTA_ASSERT_NOEXCEPT)
+    try
+#else
+    if (setjmp(tta_jmpbuf) == 0)
+#endif
+    {
+        callback(userdata);
+    }
+#if defined(__cplusplus) && !(defined(TTA_ASSERT_NOEXCEPT) && TTA_ASSERT_NOEXCEPT)
+    catch (tta_AssertExcept &)
+    {
+        failed = 1;
+    }
+#   ifdef _MSC_VER
+#       pragma warning(push)
+#       pragma warning(disable : 4571) /* catch(...) semantics changed since VC++ 7.1 */
+#   endif
+    catch (...)
+#   ifdef _MSC_VER
+#       pragma warning(pop)
+#   endif
+#else
+    else
+#endif
+    {
+        failed = 1;
+    }
+    tta_Cback = prev_cback;
+    tta_Level = prev_level;
+    return (int)failed;
+}
+
+#endif /* #ifndef TTA_ASSERT_IMPL_PRESENT */
+
+#endif /* #ifdef TTA_ASSERT_IMPL */
+
+/**
+ * Copyright (c) 2026 Pavel Martishevsky
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */

--- a/zstd/platform/x64/zstdgpu_demo_platform.cpp
+++ b/zstd/platform/x64/zstdgpu_demo_platform.cpp
@@ -31,6 +31,18 @@
 #include <dxgi1_6.h>
 #include <dxgidebug.h>
 
+#include "zstdgpu_assert.h"
+
+#define D3D12AID_CHECK(call)                            \
+    do                                                  \
+    {                                                   \
+        HRESULT hr = call;                              \
+        ZSTDGPU_ASSERT_MSG(S_OK == hr, "S_OK != 0x%08lx " #call "\n", hr); \
+    }                                                   \
+    while(0)
+
+#define D3D12AID_ASSERT(cond) ZSTDGPU_ASSERT(cond)
+
 #define D3D12AID_CMD_QUEUE_LATENCY_FRAME_MAX_COUNT 2
 #define D3D12AID_API_STATIC 1
 #include <d3d12aid.h>

--- a/zstd/zstdgpu/Shaders/ZstdGpuParseCompressedBlocks.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuParseCompressedBlocks.hlsl
@@ -38,7 +38,7 @@ ZSTDGPU_PARSE_COMPRESSED_BLOCKS_SRT()
 #define __XBOX_ENABLE_WAVE32 1
 #endif
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=4), UAV(u0, numDescriptors=26)), RootConstants(b0, num32BitConstants=4)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=4), UAV(u0, numDescriptors=25)), RootConstants(b0, num32BitConstants=4)")]
 [numthreads(kzstdgpu_TgSizeX_ParseCompressedBlocks, 1, 1)]
 void main(uint2 groupId : SV_GroupId, uint threadId : SV_GroupThreadId)
 {

--- a/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
@@ -95,7 +95,6 @@ void main()
         zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_FinaliseSequenceOffsets,  ZstdCounters[0].Seq_Streams_DecodedItems, kzstdgpu_TgSizeX_FinaliseSequenceOffsets);
         zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_PrefixSequenceOffsets,    ZstdCounters[0].Seq_Streams,              kzstdgpu_TgSizeX_PrefixSequenceOffsets);
         zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_PropagateFseIndex,        ZstdCounters[0].Seq_Streams,              kzstdgpu_TgSizeX_PropagateFseIndex);
-        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_PropagateFseIndex_HufW,   ZstdCounters[0].Cmp_Lit,                  kzstdgpu_TgSizeX_PropagateFseIndex);
 
         // Update derived counter field in Counters (kept for shader bounds checks)
         ZstdCounters[0].DecompressSequencesGroups = ZSTDGPU_TG_COUNT(ZstdCounters[0].Seq_Streams, Consts.decompressSequences_StreamsPerTG);

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -15,7 +15,6 @@
 #define ZSTDGPU_ENABLE_TIMESTAMPS 1
 
 #include <stdint.h>
-#include <assert.h>
 #include <stdio.h>
 
 #include "zstdgpu.h"
@@ -31,12 +30,24 @@
 #   include <dxgidebug.h>
 #endif
 
+#include "zstdgpu_assert.h"
+
+#define D3D12AID_CHECK(call)                            \
+    do                                                  \
+    {                                                   \
+        HRESULT hr = call;                              \
+        ZSTDGPU_ASSERT_MSG(S_OK == hr, "S_OK != 0x%08lx " #call "\n", hr); \
+    }                                                   \
+    while(0)
+
+#define D3D12AID_ASSERT(cond) ZSTDGPU_ASSERT(cond)
+
 #define D3D12AID_CMD_QUEUE_LATENCY_FRAME_MAX_COUNT 2
 #define D3D12AID_API_STATIC 1
 #include "d3d12aid.h"
-#include "zstdgpu_resources.h"
-
 #include <pix3.h>
+
+#include "zstdgpu_resources.h"
 
 #include "ZstdGpuComputeDestSequenceOffsets.h"
 #include "ZstdGpuComputePrefixSum.h"

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -2587,16 +2587,12 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         zstdgpu_DispatchIndirect(cmdList, Memset, Memset_CmpBlockLookback);
         cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.BlockSeqCountPrefixLookback->GetGPUVirtualAddress());
         zstdgpu_DispatchIndirect(cmdList, Memset, Memset_CmpBlockLookback);
-        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.CmpLitCompactionLookback->GetGPUVirtualAddress());
-        zstdgpu_DispatchIndirect(cmdList, Memset, Memset_CmpBlockLookback);
         cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.LitStreamCountPrefixLookback->GetGPUVirtualAddress());
         zstdgpu_DispatchIndirect(cmdList, Memset, Memset_CmpBlockLookback);
         cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.HufLitCompactionLookback->GetGPUVirtualAddress());
         zstdgpu_DispatchIndirect(cmdList, Memset, Memset_CmpBlockLookback);
 
         // Group 2: FseIndexLookback{HufW,LLen,Offs,MLen} -- same shape as CmpBlockLookback (lookbackBlockCount uint32 each)
-        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.FseIndexLookbackHufW->GetGPUVirtualAddress());
-        zstdgpu_DispatchIndirect(cmdList, Memset, Memset_CmpBlockLookback);
         cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.FseIndexLookbackLLen->GetGPUVirtualAddress());
         zstdgpu_DispatchIndirect(cmdList, Memset, Memset_CmpBlockLookback);
         cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.FseIndexLookbackOffs->GetGPUVirtualAddress());
@@ -2653,7 +2649,7 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     }
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier with Resources for [Parse Compressed Blocks] and [Memcpy RAW blocks, Memset RLE blocks]");
-        D3D12_RESOURCE_BARRIER barriers[21];
+        D3D12_RESOURCE_BARRIER barriers[20];
 
         uint32_t bc = 0;
         {
@@ -2668,7 +2664,6 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.FseProbs);
             // last written by [InitResources :: Memset :: Stage 1]
             // next written/updated by [Propagate FSE Index]
-            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.FseIndexLookbackHufW);
             setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.FseIndexLookbackLLen);
             setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.FseIndexLookbackOffs);
             setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.FseIndexLookbackMLen);
@@ -2725,7 +2720,7 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [Readback Counters :: After Block Parse] and [Update Dispatch Args] and [Compute `Per-Huffman Table` Literal Stream Count Prefix]");
-        D3D12_RESOURCE_BARRIER barriers[16];
+        D3D12_RESOURCE_BARRIER barriers[15];
         uint32_t bc = 0;
         {
             // last written by [Parse Compressed Blocks]
@@ -2760,8 +2755,8 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.SeqStreamToOffsFseId);
             setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.SeqStreamToMLenFseId);
             // last written by [Parse Compressed Blocks] with un-propagated values
-            // next read+written by [Propagate FSE Index] HufW dispatch (in-place propagation, indexed by cmp block)
-            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.CmpLitToHufWFseId);
+            // next read by [Propagate FSE Index] HufW dispatch (in-place propagation, indexed by cmp block)
+            //setResourceUavToSrvCopyIndirectSync(barriers, bc ++, req->resData.gpuOnly.HufLitIdToHufWId_DBG);
         }
 
         // last read by ExecuteIndirect as INDIRECT_ARGUMENT
@@ -2848,11 +2843,6 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             cmdList->SetComputeRootUnorderedAccessView(1, req->resData.gpuOnly.SeqStreamToMLenFseId->GetGPUVirtualAddress());
             cmdList->SetComputeRootUnorderedAccessView(2, req->resData.gpuOnly.FseIndexLookbackMLen->GetGPUVirtualAddress());
             zstdgpu_DispatchIndirect(cmdList, PropagateFseIndex, PropagateFseIndex);
-
-            // Propagate HufW FSE indices across all cmp blocks
-            cmdList->SetComputeRootUnorderedAccessView(1, req->resData.gpuOnly.CmpLitToHufWFseId->GetGPUVirtualAddress());
-            cmdList->SetComputeRootUnorderedAccessView(2, req->resData.gpuOnly.FseIndexLookbackHufW->GetGPUVirtualAddress());
-            zstdgpu_DispatchIndirect(cmdList, PropagateFseIndex, PropagateFseIndex_HufW);
         });
         PIXEndEvent(cmdList);
     }
@@ -2963,7 +2953,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier with Resources for [Init FSE Table] and [Group Lilteral Streams]");
-        D3D12_RESOURCE_BARRIER barriers[19];
+        D3D12_RESOURCE_BARRIER barriers[18];
         uint32_t bc = 0;
         // last written by [Update Dispatch Args] and [Compute `Per-Huffman Table` Literal Stream Count Prefix]
         // next read by [Group Lilteral Streams] and [Init FSE Table] and [Decompress Literals]
@@ -2988,9 +2978,6 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         // last written by [Compute `Per-Huffman Table` Literal Stream Count Prefix]
         // next read by [Init Huffman Table and Decompress Literals]
         setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.LitGroupEndPerHuffmanTable);
-        // last written by [Parse Compressed Blocks] (HufW propagation)
-        // next: not read downstream, but transitioned for resource-state hygiene
-        setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.FseIndexLookbackHufW);
         // last written by [Parse Compressed Blocks]
         // next read by [Init Huffman Table and Decompress Literals]
         setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.LitRefs);

--- a/zstd/zstdgpu/zstdgpu.h
+++ b/zstd/zstdgpu/zstdgpu.h
@@ -218,7 +218,7 @@ ZSTDGPU_API uint32_t zstdgpu_IsReadbackRequired(zstdgpu_PerRequestContext inPerR
 /**
  *  @brief      Returns 1 if a CPU readback/fence is required after any stages, 0 otherwise. This API
  *              mainly exist to ensure `zstdgpu_PerRequestContext` has sufficient information to not
- *              require any readbacks, so calling code could check: `assert(0 == zstdgpu_IsAnyStageReadbackRequired(ctx))`
+ *              require any readbacks, so calling code could check: `ZSTDGPU_ASSERT(0 == zstdgpu_IsAnyStageReadbackRequired(ctx))`
  */
 ZSTDGPU_API uint32_t zstdgpu_IsAnyStageReadbackRequired(zstdgpu_PerRequestContext inPerRequestContext);
 

--- a/zstd/zstdgpu/zstdgpu.vcxproj
+++ b/zstd/zstdgpu/zstdgpu.vcxproj
@@ -33,6 +33,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="zstdgpu.h" />
+    <ClInclude Include="zstdgpu_assert.h" />
     <ClInclude Include="zstdgpu_lds.h" />
     <ClInclude Include="zstdgpu_lds_hlsl.h" />
     <ClInclude Include="zstdgpu_reference_store.h" />

--- a/zstd/zstdgpu/zstdgpu_assert.h
+++ b/zstd/zstdgpu/zstdgpu_assert.h
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Microsoft. All rights reserved.
+ * This code is licensed under the MIT License (MIT).
+ * THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+ * ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+ * IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+ *
+ * Advanced Technology Group (ATG)
+ * Author(s):   Pavel Martishevsky (pamartis@microsoft.com)
+ *
+ * Contains zstdgpu-specific assert macro definition
+ */
+
+#pragma once
+
+#ifndef ZSTDGPU_ASSERT_H
+#define ZSTDGPU_ASSERT_H
+
+#ifndef ZSTDGPU_ASSERT
+#   ifdef __hlsl_dx_compiler
+#       define ZSTDGPU_ASSERT(cond)
+#       define ZSTDGPU_ASSERT_MSG(cond, msg, ...)
+#   else
+#       ifdef NDEBUG
+            /**
+             *  NOTE(pamartis): it's not a bug, we keep asserts in instrumented mode
+             *  while the development is ongoing. Without debugger, they are configured
+             *  to not break and produce useful output to the log if something breaks
+             */
+#           define TTA_ASSERT_MODE TTA_ASSERT_MODE_INSTRUMENTED
+#       else
+#           define TTA_ASSERT_MODE TTA_ASSERT_MODE_INSTRUMENTED
+#       endif
+#       include <tta_assert.h>
+#       define ZSTDGPU_ASSERT(cond) TTA_ASSERT(cond)
+#       define ZSTDGPU_ASSERT_MSG(cond, msg, ...) TTA_ASSERT_MSG(cond, msg, __VA_ARGS__)
+#   endif
+#endif
+
+#ifndef ZSTDGPU_BREAK
+#   ifdef __hlsl_dx_compiler
+#       define ZSTDGPU_BREAK()
+#   else
+#       define ZSTDGPU_BREAK() ZSTDGPU_ASSERT(0)
+#   endif
+#endif
+
+#endif /* #define ZSTDGPU_ASSERT_H */

--- a/zstd/zstdgpu/zstdgpu_reference_store.cpp
+++ b/zstd/zstdgpu/zstdgpu_reference_store.cpp
@@ -14,7 +14,6 @@
 
 #include <memory.h>
 #include <stdlib.h>
-#include <assert.h>
 #include "zstdgpu_structs.h"
 
 #define ZSTDGPU_DISABLE_RESOURCE_DATA_GPU 1
@@ -364,7 +363,7 @@ void zstdgpu_ReferenceStore_Report_FseTable(const int16_t *probs, uint32_t symCo
     STORE(MLen, fseIndex)
     else
     {
-        __debugbreak();
+        ZSTDGPU_BREAK();
     }
 #undef STORE
 }
@@ -398,7 +397,7 @@ void zstdgpu_ReferenceStore_Report_FseDefaultTable(const int16_t *probs, uint32_
     STORE(MLen)
     else
     {
-        __debugbreak();
+        ZSTDGPU_BREAK();
     }
 #undef STORE
 }
@@ -420,7 +419,7 @@ void zstdgpu_ReferenceStore_Report_FseProbSymbol(uint32_t symbol)
     STORE(MLen)
     else
     {
-        __debugbreak();
+        ZSTDGPU_BREAK();
     }
 #undef STORE
 }
@@ -441,7 +440,7 @@ void zstdgpu_ReferenceStore_Report_FseProbRepeatTable()
     STORE(MLen)
     else
     {
-        __debugbreak();
+        ZSTDGPU_BREAK();
     }
 #undef STORE
 }
@@ -589,10 +588,8 @@ static uint32_t zstdgpu_SequenceOffsets_Update(ZSTDGPU_PARAM_INOUT(uint32_t) off
                 }
                 else
                 {
-#ifndef __hlsl_dx_compiler
-                    // offset must no be zero
-                    __debugbreak();
-#endif
+                    // offset must not be zero
+                    ZSTDGPU_BREAK();
                 }
                 offset3 = offset2;
                 offset2 = offset1;

--- a/zstd/zstdgpu/zstdgpu_reference_store.cpp
+++ b/zstd/zstdgpu/zstdgpu_reference_store.cpp
@@ -37,11 +37,11 @@ static uint32_t GBlockIndexRAW = 0;
 static uint32_t GBlockIndexRLE = 0;
 static uint32_t GBlockIndexCMP = 0;
 
-// This mirrors GPU `Counters.Cmp_Lit`-- a compacted index that increments per Compressed_Block
-// whose literal section is a Huffman-compressed literal (Cmp/Treeless, i.e., `literalBlockType >= 2`).
+// This mirrors GPU `Counters.HufLit`-- a compacted index that increments per Compressed_Block
+// whose literal section is a Huffman-compressed literal (Cmp only/not Treeless, i.e., `literalBlockType == 2`).
 
-// It's used to index to build `CmpLitToHufWFseId`
-static uint32_t GCmpLitIndex = 0;
+// It's used to index to build `HufLitToHufWFseId`
+static uint32_t GHufLitIndex = 0;
 
 static uint32_t GHufCompressedLiteralCount = 0;
 static uint32_t GHufDecompressedLiteralOffset = 0;
@@ -228,7 +228,6 @@ void zstdgpu_ReferenceStore_Report_CompressedLiteralDecompressedSizeAndStreamCou
 {
     GHufDecompressedLiteralSize = size;
     GHufDecompressedLiteralStreamCount = streamCount;
-    GCmpLitIndex++;
     zstdgpu_AppendLastBlockSize(size);
 }
 
@@ -272,11 +271,6 @@ void zstdgpu_ReferenceStore_Report_FseProbTableType(ZSTDGPU_ENUM(ReferenceStore_
 {
     ZSTDGPU_ASSERT(type != ZSTDGPU_ENUM_CONST(ReferenceStore_FseForceInt));
     GFseProbTableTypePending = type;
-
-    if (type == ZSTDGPU_ENUM_CONST(ReferenceStore_FseHufW))
-    {
-        GZstd.CmpLitToHufWFseId[GCmpLitIndex - 1] = GLastTableIndex_FseHufW;
-    }
 }
 
 #include <intrin.h>
@@ -461,7 +455,7 @@ void zstdgpu_ReferenceStore_Report_FseCompressedHuffmanWeightSubBlock(const void
 
     GZstd.DecompressedHuffmanWeightCount[index] = 0;
 
-    GZstd.CmpLitToHufWFseId[GCmpLitIndex - 1] = GLastTableIndex_FseHufW = index;
+    GZstd.HufLitIdToHufWId_DBG[GHufLitIndex ++] = GLastTableIndex_FseHufW = index;
 }
 
 void zstdgpu_ReferenceStore_Report_HuffmanWeightSubBlock(const void *base, uint32_t size, uint32_t weightCount)
@@ -475,7 +469,7 @@ void zstdgpu_ReferenceStore_Report_HuffmanWeightSubBlock(const void *base, uint3
     ZSTDGPU_ASSERT(weightCount < kzstdgpu_MaxCount_HuffmanWeights);
     GZstd.DecompressedHuffmanWeightCount[index] = (uint8_t)weightCount;
 
-    GZstd.CmpLitToHufWFseId[GCmpLitIndex - 1] = GLastTableIndex_FseHufW = index;
+    GZstd.HufLitIdToHufWId_DBG[GHufLitIndex ++] = GLastTableIndex_FseHufW = index;
 }
 
 void zstdgpu_ReferenceStore_Report_DecompressedHuffmanWeights(const uint8_t *weights, uint32_t weightCount)
@@ -906,45 +900,43 @@ ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_FseTables(const zs
     if (tst->Counters->FseHufW != GFseCompressedHuffmanWeightCount)
         return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
-    if (tst->Counters->Cmp_Lit != GCmpLitIndex)
+    if (tst->Counters->HufLit != GHufLitIndex)
         return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
-    uint32_t cmpLitId = 0;
+    // Validate Referred FSE Tables
+    #define VALIDATE_FSE_TABLE_CONTENT(refIdx, tstIdx, infoOfs, elemFn) \
+        izstdgpu_ReferenceStore_Validate_FseTable(          \
+            refIdx,                                         \
+            tstIdx,                                         \
+            infoOfs, GBlockCountCMP, elemFn,                \
+            ref->FseInfos,                                  \
+            tst->FseInfos,                                  \
+            ref->FseProbs,                                  \
+            tst->FseProbs,                                  \
+            ref->FseElems,                                  \
+            tst->FseElems                                   \
+        )
+    for (uint32_t i = 0; i < GHufLitIndex; ++i)
+    {
+        if (ref->HufLitIdToHufWId_DBG[i] < GFseProbTableIndexHufW)
+        {
+            // When HufW table index is less than the total number of FSE table count,
+            // it's an actual FSE index, otherwise -- it encodes the index of an uncompressed Huffman Weights Stream
+            if (!(tst->HufLitIdToHufWId_DBG[i] < GFseProbTableIndexHufW))
+                return ZSTDGPU_ENUM_CONST(Validate_Failed);
+
+            if (ZSTDGPU_ENUM_CONST(Validate_Success) != VALIDATE_FSE_TABLE_CONTENT(ref->HufLitIdToHufWId_DBG[i],
+                                                                                   tst->HufLitIdToHufWId_DBG[i],
+                                                                                   kzstdgpu_FseRleTableCount, zstdgpu_ComputeFseDataStartHufW)
+               )
+            {
+                return ZSTDGPU_ENUM_CONST(Validate_Failed);
+            }
+        }
+    }
+
     for (uint32_t i = 0; i < GBlockCountCMP; ++i)
     {
-         // Validate Referred FSE Tables
-        #define VALIDATE_FSE_TABLE_CONTENT(refIdx, tstIdx, infoOfs, elemFn) \
-            izstdgpu_ReferenceStore_Validate_FseTable(          \
-                refIdx,                                         \
-                tstIdx,                                         \
-                infoOfs, GBlockCountCMP, elemFn,                \
-                ref->FseInfos,                                  \
-                tst->FseInfos,                                  \
-                ref->FseProbs,                                  \
-                tst->FseProbs,                                  \
-                ref->FseElems,                                  \
-                tst->FseElems                                   \
-            )
-
-        // NOTE(pamartis): When FSE HufW table index is less than the total number of FSE table count --
-        // it's an actual FSE index, when it's greater or equal --
-        // it encodes the index of an uncompressed Huffman Weights Stream
-        if (ref->CompressedBlocks[i].litStreamIndex != ~0u)
-        {
-            if (ref->CmpLitToHufWFseId[cmpLitId] < GFseProbTableIndexHufW)
-            {
-                if (!(tst->CmpLitToHufWFseId[cmpLitId] < GFseProbTableIndexHufW))
-                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
-
-                if (ZSTDGPU_ENUM_CONST(Validate_Success) != VALIDATE_FSE_TABLE_CONTENT(
-                        ref->CmpLitToHufWFseId[cmpLitId],
-                        tst->CmpLitToHufWFseId[cmpLitId],
-                        kzstdgpu_FseRleTableCount, zstdgpu_ComputeFseDataStartHufW))
-                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
-            }
-            cmpLitId += 1;
-        }
-
         // FSE LLen/Offs/MLen indices are now stored per-sequence-stream in `SeqStreamTo*FseId`.
         // Compressed blocks with no sequences (`seqStreamIndex == ~0u`) have no FSE seq tables to validate.
         const uint32_t refSeqStreamIdx = ref->CompressedBlocks[i].seqStreamIndex;
@@ -1011,7 +1003,6 @@ ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_CompressedBlocksDa
 
     //if (0 != memcmp(tstCmpBlocks, refCmpBlocks, sizeof(refCmpBlocks[0]) * GBlockCountCMP))
     {
-        uint32_t cmpLitId = 0;
         for (uint32_t i = 0; i < GBlockCountCMP; ++i)
         {
             if (tstCmpBlocks[i].litStreamIndex == ~0u)
@@ -1064,30 +1055,9 @@ ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_CompressedBlocksDa
                     return ZSTDGPU_ENUM_CONST(Validate_Failed);
             }
 
-            if (refCmpBlocks[i].litStreamIndex != ~0u)
-            {
-                if (tstCmpBlocks[i].litStreamIndex == ~0u)
-                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
-
-                uint32_t refFseCompressedHuffmanWeightsIndex = ref->CmpLitToHufWFseId[cmpLitId];
-                uint32_t tstFseCompressedHuffmanWeightsIndex = tst->CmpLitToHufWFseId[cmpLitId];
-
-                if (refFseCompressedHuffmanWeightsIndex >= kzstdgpu_FseProbTableIndex_Repeat)
-                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
-
-                if (tstFseCompressedHuffmanWeightsIndex >= kzstdgpu_FseProbTableIndex_Repeat)
-                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
-
-                if (ZSTDGPU_ENUM_CONST(Validate_Success) != izstdgpu_ReferenceStore_Validate_OffsetAndSize(&ref->HufRefs[refFseCompressedHuffmanWeightsIndex], &tst->HufRefs[tstFseCompressedHuffmanWeightsIndex]))
-                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
-
-                cmpLitId += 1;
-            }
-            else
-            {
-                if (refCmpBlocks[i].litStreamIndex != tstCmpBlocks[i].litStreamIndex)
-                    return ZSTDGPU_ENUM_CONST(Validate_Failed);
-            }
+            // litStreamIndex is either identical (on GPU it is created by ordered append) or equals to ~0u (invalid)
+            if (refCmpBlocks[i].litStreamIndex != tstCmpBlocks[i].litStreamIndex)
+                return ZSTDGPU_ENUM_CONST(Validate_Failed);
         }
     }
     return ZSTDGPU_ENUM_CONST(Validate_Success);
@@ -1095,17 +1065,17 @@ ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_CompressedBlocksDa
 
 ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_DecompressedHuffmanWeights(const zstdgpu_ResourceDataCpu *resourceDataCpu)
 {
-    if (resourceDataCpu->Counters->Cmp_Lit != GCmpLitIndex)
+    if (resourceDataCpu->Counters->HufLit != GHufLitIndex)
         return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
     const zstdgpu_ResourceDataCpu *ref = &GZstd;
     const zstdgpu_ResourceDataCpu *tst = resourceDataCpu;
 
-    for (uint32_t i = 0; i < GCmpLitIndex; ++i)
+    for (uint32_t i = 0; i < GHufLitIndex; ++i)
     {
         // Validate decompressed Fse-compressed Huffman Weights and their counts
-        uint32_t tstHuffmanWeightStreamIndex = tst->CmpLitToHufWFseId[i];
-        uint32_t refHuffmanWeightStreamIndex = ref->CmpLitToHufWFseId[i];
+        uint32_t tstHuffmanWeightStreamIndex = tst->HufLitIdToHufWId_DBG[i];
+        uint32_t refHuffmanWeightStreamIndex = ref->HufLitIdToHufWId_DBG[i];
 
         if (refHuffmanWeightStreamIndex >= kzstdgpu_FseProbTableIndex_Repeat)
             return ZSTDGPU_ENUM_CONST(Validate_Failed);
@@ -1139,17 +1109,17 @@ ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_DecompressedHuffma
 
 ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_DecodedHuffmanWeights(const zstdgpu_ResourceDataCpu * resourceDataCpu)
 {
-    if (resourceDataCpu->Counters->Cmp_Lit != GCmpLitIndex)
+    if (resourceDataCpu->Counters->HufLit != GHufLitIndex)
         return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
     const zstdgpu_ResourceDataCpu *ref = &GZstd;
     const zstdgpu_ResourceDataCpu *tst = resourceDataCpu;
 
-    for (uint32_t i = 0; i < GCmpLitIndex; ++i)
+    for (uint32_t i = 0; i < GHufLitIndex; ++i)
     {
         // Validate decoded uncompressed Huffman Weights and their counts
-        uint32_t tstHuffmanWeightStreamIndex = tst->CmpLitToHufWFseId[i];
-        uint32_t refHuffmanWeightStreamIndex = ref->CmpLitToHufWFseId[i];
+        uint32_t tstHuffmanWeightStreamIndex = tst->HufLitIdToHufWId_DBG[i];
+        uint32_t refHuffmanWeightStreamIndex = ref->HufLitIdToHufWId_DBG[i];
 
         if (refHuffmanWeightStreamIndex >= kzstdgpu_FseProbTableIndex_Repeat)
         return ZSTDGPU_ENUM_CONST(Validate_Failed);

--- a/zstd/zstdgpu/zstdgpu_resources.h
+++ b/zstd/zstdgpu/zstdgpu_resources.h
@@ -83,7 +83,7 @@
     ZSTDGPU_BUFFER(uint8_t                                  , DecompressedHuffmanWeightCount)   \
     \
     ZSTDGPU_BUFFER(zstdgpu_LitStreamInfo                    , LitRefs                       )   \
-    ZSTDGPU_BUFFER(uint32_t                                 , CmpLitToHufWFseId             )   \
+    ZSTDGPU_BUFFER(uint32_t                                 , HufLitIdToHufWId_DBG          )   \
     ZSTDGPU_BUFFER(uint32_t                                 , HufWIdToHufLitId              )   \
     ZSTDGPU_BUFFER(uint32_t                                 , HufLitIdToLitStreamId         )   \
     ZSTDGPU_BUFFER(zstdgpu_OffsetAndSize                    , SeqStreamToRef                )   \
@@ -93,13 +93,11 @@
     ZSTDGPU_BUFFER(uint32_t                                 , SeqStreamToBlockId            )   \
     ZSTDGPU_BUFFER(uint32_t                                 , BlockSeqCountPrefixLookback   )   \
     ZSTDGPU_BUFFER(uint32_t                                 , SeqCountPrefixLookback        )   \
-    ZSTDGPU_BUFFER(uint32_t                                 , CmpLitCompactionLookback      )   \
     ZSTDGPU_BUFFER(uint32_t                                 , LitStreamCountPrefixLookback  )   \
     ZSTDGPU_BUFFER(uint32_t                                 , HufLitCompactionLookback      )   \
     \
     ZSTDGPU_BUFFER(zstdgpu_OffsetAndSize                    , HufRefs                       )   \
     ZSTDGPU_BUFFER(zstdgpu_CompressedBlockData              , CompressedBlocks              )   \
-    ZSTDGPU_BUFFER(uint32_t                                 , FseIndexLookbackHufW          )   \
     ZSTDGPU_BUFFER(uint32_t                                 , FseIndexLookbackLLen          )   \
     ZSTDGPU_BUFFER(uint32_t                                 , FseIndexLookbackOffs          )   \
     ZSTDGPU_BUFFER(uint32_t                                 , FseIndexLookbackMLen          )   \
@@ -323,7 +321,7 @@ static void zstdgpu_ResourceInfo_Stage_1_InitSize(zstdgpu_ResourceInfo *outInfo,
 
     const uint32_t HufRefs_Count = cmpBlockCount;
     const uint32_t LitRefs_Count = cmpBlockCount * 4;
-    const uint32_t CmpLitToHufWFseId_Count  = cmpBlockCount;
+    const uint32_t HufLitIdToHufWId_DBG_Count = cmpBlockCount;
     const uint32_t HufWIdToHufLitId_Count = cmpBlockCount;
     const uint32_t HufLitIdToLitStreamId_Count = cmpBlockCount;
     const uint32_t SeqStreamToRef_Count       = cmpBlockCount;
@@ -332,16 +330,14 @@ static void zstdgpu_ResourceInfo_Stage_1_InitSize(zstdgpu_ResourceInfo *outInfo,
     const uint32_t SeqStreamToMLenFseId_Count = cmpBlockCount;
     const uint32_t SeqStreamToBlockId_Count   = cmpBlockCount;
     const uint32_t CompressedBlocks_Count = cmpBlockCount;
-    const uint32_t FseIndexLookbackHufW_Count = zstdgpu_GetLookbackBlockCount(cmpBlockCount);
-    const uint32_t FseIndexLookbackLLen_Count = FseIndexLookbackHufW_Count;
-    const uint32_t FseIndexLookbackOffs_Count = FseIndexLookbackHufW_Count;
-    const uint32_t FseIndexLookbackMLen_Count = FseIndexLookbackHufW_Count;
+    const uint32_t FseIndexLookbackLLen_Count = zstdgpu_GetLookbackBlockCount(cmpBlockCount);;
+    const uint32_t FseIndexLookbackOffs_Count = FseIndexLookbackLLen_Count;
+    const uint32_t FseIndexLookbackMLen_Count = FseIndexLookbackLLen_Count;
     const uint32_t LitGroupEndPerHuffmanTable_Count = cmpBlockCount + zstdgpu_GetLookbackBlockCount(cmpBlockCount);
-    const uint32_t BlockSeqCountPrefixLookback_Count = FseIndexLookbackHufW_Count;
-    const uint32_t SeqCountPrefixLookback_Count = FseIndexLookbackHufW_Count;
-    const uint32_t CmpLitCompactionLookback_Count = FseIndexLookbackHufW_Count;
-    const uint32_t LitStreamCountPrefixLookback_Count = FseIndexLookbackHufW_Count;
-    const uint32_t HufLitCompactionLookback_Count = FseIndexLookbackHufW_Count;
+    const uint32_t BlockSeqCountPrefixLookback_Count = FseIndexLookbackLLen_Count;
+    const uint32_t SeqCountPrefixLookback_Count = FseIndexLookbackLLen_Count;
+    const uint32_t LitStreamCountPrefixLookback_Count = FseIndexLookbackLLen_Count;
+    const uint32_t HufLitCompactionLookback_Count = FseIndexLookbackLLen_Count;
 
     const uint32_t HuffmanTableCodeAndSymbol_Count = kzstdgpu_MaxCount_HuffmanWeights * cmpBlockCount;
     const uint32_t HuffmanTableRankIndex_Count = kzstdgpu_MaxCount_HuffmanWeightRanks * cmpBlockCount;

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -3268,10 +3268,8 @@ static uint32_t zstdgpu_SequenceOffsets_Update(ZSTDGPU_PARAM_INOUT(uint32_t) off
                 }
                 else
                 {
-#ifndef __hlsl_dx_compiler
-                    // offset must no be zero
-                    __debugbreak();
-#endif
+                    // offset must not be zero
+                    ZSTDGPU_BREAK();
                 }
                 offset3 = offset2;
                 offset2 = offset1;

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -627,7 +627,6 @@ static void zstdgpu_ShaderEntry_InitResources(ZSTDGPU_PARAM_INOUT(zstdgpu_InitRe
             srt.inoutCounters[0].HUF_Streams_DecodedBytes                    = 0;
             srt.inoutCounters[0].Seq_Streams                                 = 0;
             srt.inoutCounters[0].HUF_Streams                                 = 0;
-            srt.inoutCounters[0].Cmp_Lit                                     = 0;
             srt.inoutCounters[0].HufLit                                      = 0;
             srt.inoutCounters[0].RAW_Streams                                 = 0;
             srt.inoutCounters[0].RLE_Streams                                 = 0;
@@ -1317,33 +1316,23 @@ static void zstdgpu_ShaderEntry_ParseCompressedBlocks(ZSTDGPU_PARAM_INOUT(zstdgp
 
     srt.inoutBlockSizePrefix[blockIndexInFrame] = outBlockData.literal.size;
 
-    const bool isCmpLit = (literalBlockType >= 2);
     // A "HufLit" is a literal block that carries a Huffman Table (literalBlockType == 2, i.e. FullTree).
     // Its hufLitId (compacted, in cmpLit-encounter order) keys the per-HT literal stream range.
     const bool isHufLit = (literalBlockType == 2);
 
     #ifndef __hlsl_dx_compiler
-        const uint32_t cmpLitId = srt.inoutCounters[0].Cmp_Lit;
         const uint32_t hufLitId = srt.inoutCounters[0].HufLit;
     #endif
 
-    const uint32_t cmpLitCountPerWave = WaveActiveCountBits(isCmpLit);
     const uint32_t hufLitCountPerWave = WaveActiveCountBits(isHufLit);
     if (WaveIsFirstLane())
     {
-        InterlockedAdd(srt.inoutCounters[0].Cmp_Lit, cmpLitCountPerWave);
         InterlockedAdd(srt.inoutCounters[0].HufLit, hufLitCountPerWave);
     }
 
     #ifdef __hlsl_dx_compiler
-        const uint32_t cmpLitId = zstdgpu_OrderedAppendIndex(srt.inoutCmpLitCompactionLookback, isCmpLit, threadId, kzstdgpu_TgSizeX_ParseCompressedBlocks);
         const uint32_t hufLitId = zstdgpu_OrderedAppendIndex(srt.inoutHufLitCompactionLookback, isHufLit, threadId, kzstdgpu_TgSizeX_ParseCompressedBlocks);
     #endif
-
-    ZSTDGPU_BRANCH if (isCmpLit)
-    {
-        srt.inoutCmpLitToHufWFseId[cmpLitId] = fseTableIndexHufW;
-    }
 
     //
     // NOTE(pamartis): every thread with a literal block storing Huffman table writes:
@@ -1359,6 +1348,7 @@ static void zstdgpu_ShaderEntry_ParseCompressedBlocks(ZSTDGPU_PARAM_INOUT(zstdgp
     {
         srt.inoutHufWIdToHufLitId[fseTableIndexHufW]  = hufLitId;
         srt.inoutHufLitIdToLitStreamId[hufLitId]      = outBlockData.litStreamIndex;
+        srt.inoutHufLitIdToHufWId_DBG[hufLitId]       = fseTableIndexHufW;
     }
 
     // `Sequences_Section_Header`

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -319,7 +319,6 @@ typedef struct zstdgpu_Counters
     uint32_t HUF_Streams_DecodedBytes;
     uint32_t Seq_Streams;
     uint32_t HUF_Streams;
-    uint32_t Cmp_Lit;
     uint32_t HufLit;
     uint32_t RAW_Streams;
     uint32_t RLE_Streams;
@@ -352,9 +351,8 @@ static const uint32_t kzstdgpu_DispatchSlot_ParseCompressedBlocks        = 15;
 static const uint32_t kzstdgpu_DispatchSlot_Memset_CmpBlockLookback      = 16;
 static const uint32_t kzstdgpu_DispatchSlot_Memset_AllBlockLookback      = 17;
 static const uint32_t kzstdgpu_DispatchSlot_PropagateFseIndex            = 18;
-static const uint32_t kzstdgpu_DispatchSlot_PropagateFseIndex_HufW       = 19;
-static const uint32_t kzstdgpu_DispatchSlot_Memset_CmpBlockCount         = 20;
-static const uint32_t kzstdgpu_DispatchSlot_Count                        = 21;
+static const uint32_t kzstdgpu_DispatchSlot_Memset_CmpBlockCount         = 19;
+static const uint32_t kzstdgpu_DispatchSlot_Count                        = 20;
 
 #if defined(_GAMING_XBOX) || defined(__XBOX_SCARLETT) || defined(__XBOX_ONE)
 static const uint32_t kzstdgpu_DispatchSlot_CmdsPerSlot                  = 1;
@@ -1598,12 +1596,11 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t initResou
     ZSTDGPU_RW_TYPED_BUFFER_DECL(int32_t, int16_t               , FseProbs                      , 18)   \
     ZSTDGPU_RW_TYPED_BUFFER_DECL(uint32_t, uint8_t              , DecompressedHuffmanWeightCount, 19)   \
     \
-    ZSTDGPU_RW_BUFFER_DECL_GLC(uint32_t                         , CmpLitCompactionLookback      , 20)   \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , CmpLitToHufWFseId             , 21)   \
-    ZSTDGPU_RW_BUFFER_DECL_GLC(uint32_t                         , LitStreamCountPrefixLookback  , 22)   \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , HufWIdToHufLitId              , 23)   \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , HufLitIdToLitStreamId         , 24)   \
-    ZSTDGPU_RW_BUFFER_DECL_GLC(uint32_t                         , HufLitCompactionLookback      , 25)
+    ZSTDGPU_RW_BUFFER_DECL_GLC(uint32_t                         , LitStreamCountPrefixLookback  , 20)   \
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , HufWIdToHufLitId              , 21)   \
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , HufLitIdToLitStreamId         , 22)   \
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , HufLitIdToHufWId_DBG          , 23)   \
+    ZSTDGPU_RW_BUFFER_DECL_GLC(uint32_t                         , HufLitCompactionLookback      , 24)
 
 #define ZSTDGPU_INIT_FSE_TABLE_SRT()                                                                    \
     ZSTDGPU_RO_BUFFER_DECL(zstdgpu_FseInfo                      , FseInfos                      , 0)    \

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -27,25 +27,7 @@
 #   endif
 #endif
 
-#ifndef ZSTDGPU_ASSERT
-#   ifdef __hlsl_dx_compiler
-#       define ZSTDGPU_ASSERT(cond) ZSTDGPU_UNUSED(cond)
-#   else
-#       ifdef NDEBUG
-#           define ZSTDGPU_ASSERT(cond) ZSTDGPU_UNUSED(cond)
-#       else
-#           define ZSTDGPU_ASSERT(cond) assert(cond)
-#       endif
-#   endif
-#endif
-
-#ifndef ZSTDGPU_BREAK
-#   ifdef __hlsl_dx_compiler
-#       define ZSTDGPU_BREAK()
-#   else
-#       define ZSTDGPU_BREAK() __debugbreak()
-#   endif
-#endif
+#include "zstdgpu_assert.h"
 
 #ifndef ZSTDGPU_PRAGMA_GNUC
 #   if defined(__clang__) || defined(__GNUC__)  || defined(__hlsl_dx_compiler)

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -41,17 +41,28 @@
 #include <xmem.h>
 #endif
 
+#include "zstdgpu_assert.h"
+
+#define D3D12AID_CHECK(call)                            \
+    do                                                  \
+    {                                                   \
+        HRESULT hr = call;                              \
+        ZSTDGPU_ASSERT_MSG(S_OK == hr, "S_OK != 0x%08lx " #call "\n", hr); \
+    }                                                   \
+    while(0)
+
+#define D3D12AID_ASSERT(cond) ZSTDGPU_ASSERT(cond)
+
 #define D3D12AID_CMD_QUEUE_LATENCY_FRAME_MAX_COUNT 3
 #define D3D12AID_MAPPED_BUFFER_LATENCY_FRAME_MAX_COUNT 1
-#include <d3d12aid.h>
 
+#include <d3d12aid.h>
 #include <pix3.h>
 
-extern "C" {
-#include "zstd_decompress.h"
+extern "C"
+{
+    #include "zstd_decompress.h"
 }
-
-#include <assert.h>
 
 #include "zstdgpu_reference_store.h"
 #include "zstdgpu_shaders.h"
@@ -75,6 +86,7 @@ static void debugPrint(const wchar_t *format, ...)
     va_start(args, format);
     _vsnwprintf_s(buffer, bufferSize + 1, bufferSize, format, args);
     wprintf(buffer);
+    fflush(stdout);
     OutputDebugStringW(buffer);
     va_end(args);
 }
@@ -225,23 +237,26 @@ static void zstdgpu_Init_FinaliseSequenceOffsets_SRT(zstdgpu_FinaliseSequenceOff
 
 #include "zstdgpu_srt_decl_undef.h"
 
-#define STRINGIZE(x) STRINGIZE2(x)
-#define STRINGIZE2(x) #x
-#define VALIDATE(name)  \
-    do                  \
-    {                   \
-        if (ZSTDGPU_ENUM_CONST(Validate_Success) != zstdgpu_ReferenceStore_Validate_##name) \
-            debugPrint(L"[FAIL] Validation of '"#name"' failed in function: " __FUNCTION__ ", file: " __FILE__ ", line: " STRINGIZE(__LINE__) "\n");\
-    }                   \
-    while(0)
+#define VALIDATE(name, data) ZSTDGPU_ASSERT(ZSTDGPU_ENUM_CONST(Validate_Success) == zstdgpu_ReferenceStore_Validate_##name(data))
 
-#define VALIDATE_CND(cnd)   \
-    do                      \
-    {                       \
-        if (!(cnd))         \
-            debugPrint(L"[FAIL] Validation of '"#cnd"' failed in function: " __FUNCTION__ ", file: " __FILE__ ", line: " STRINGIZE(__LINE__) "\n");\
-    }                       \
-    while(0)
+template <class T> struct zstdgpu_RemoveRef      { using TResult = T; };
+template <class T> struct zstdgpu_RemoveRef<T&>  { using TResult = T; };
+template <class T> struct zstdgpu_RemoveRef<T&&> { using TResult = T; };
+template <class T>  using zstdgpu_NoRefType = typename zstdgpu_RemoveRef<T>::TResult;
+
+template<typename TLambda>
+static uint32_t zstdgpu_ValidateUntilFirstAssert(TLambda && lambda)
+{
+    tta_AssertReportLevel lvl = tta_AssertGetReportLevel();
+    tta_AssertSetReportLevel(ktta_AssertReportLevel_PrintAndThrow);
+    uint32_t hasError = tta_AssertCallAndCatch([](void* u) -> int
+    {
+        (*static_cast<zstdgpu_NoRefType<TLambda> *>(u))();
+        return 0;
+    }, (void *)&lambda);
+    tta_AssertSetReportLevel(lvl);
+    return hasError;
+}
 
 static void zstdgpu_Test_DecompressHuffmanWeights(zstdgpu_ResourceDataCpu & cpuRes, zstdgpu_ResourceDataCpu & gpuReadbackRes, uint32_t zstdDataBufferSize, bool chkGpu, bool simGpu)
 {
@@ -254,8 +269,8 @@ static void zstdgpu_Test_DecompressHuffmanWeights(zstdgpu_ResourceDataCpu & cpuR
     {
         uint32_t* tmp = gpuReadbackRes.CompressedData;
         gpuReadbackRes.CompressedData = cpuRes.CompressedData;
-        VALIDATE(DecompressedHuffmanWeights(&gpuReadbackRes));
-        VALIDATE(DecodedHuffmanWeights(&gpuReadbackRes));
+        VALIDATE(DecompressedHuffmanWeights, &gpuReadbackRes);
+        VALIDATE(DecodedHuffmanWeights, &gpuReadbackRes);
         gpuReadbackRes.CompressedData = tmp;
     }
 
@@ -283,7 +298,7 @@ static void zstdgpu_Test_DecompressHuffmanWeights(zstdgpu_ResourceDataCpu & cpuR
             gpuReadbackRes.CompressedData                   = cpuRes.CompressedData;
             gpuReadbackRes.DecompressedHuffmanWeights       = cpuRes.DecompressedHuffmanWeights;
             gpuReadbackRes.DecompressedHuffmanWeightCount   = cpuRes.DecompressedHuffmanWeightCount;
-            VALIDATE(DecompressedHuffmanWeights(&gpuReadbackRes));
+            VALIDATE(DecompressedHuffmanWeights, &gpuReadbackRes);
             gpuReadbackRes.CompressedData                   = CompressedData;
             gpuReadbackRes.DecompressedHuffmanWeights       = DecompressedHuffmanWeights;
             gpuReadbackRes.DecompressedHuffmanWeightCount   = DecompressedHuffmanWeightCount;
@@ -314,7 +329,7 @@ static void zstdgpu_Test_DecompressHuffmanWeights(zstdgpu_ResourceDataCpu & cpuR
 
             gpuReadbackRes.CompressedData                   = cpuRes.CompressedData;
             gpuReadbackRes.DecompressedHuffmanWeights       = cpuRes.DecompressedHuffmanWeights;
-            VALIDATE(DecodedHuffmanWeights(&gpuReadbackRes));
+            VALIDATE(DecodedHuffmanWeights, &gpuReadbackRes);
             gpuReadbackRes.CompressedData                   = CompressedData;
             gpuReadbackRes.DecompressedHuffmanWeights       = DecompressedHuffmanWeights;
         }
@@ -355,7 +370,7 @@ static void zstdgpu_Test_DecompressLiterals(zstdgpu_ResourceDataCpu & cpuRes, zs
     {
         uint32_t* tmp = gpuReadbackRes.CompressedData;
         gpuReadbackRes.CompressedData = cpuRes.CompressedData;
-        VALIDATE(DecompressedLiterals(&gpuReadbackRes));
+        VALIDATE(DecompressedLiterals, &gpuReadbackRes);
         gpuReadbackRes.CompressedData = tmp;
     }
 
@@ -396,7 +411,7 @@ static void zstdgpu_Test_DecompressLiterals(zstdgpu_ResourceDataCpu & cpuRes, zs
 
             gpuReadbackRes.CompressedData       = cpuRes.CompressedData;
             gpuReadbackRes.DecompressedLiterals = cpuRes.DecompressedLiterals;
-            VALIDATE(DecompressedLiterals(&gpuReadbackRes));
+            VALIDATE(DecompressedLiterals, &gpuReadbackRes);
             gpuReadbackRes.CompressedData       = CompressedData;
             gpuReadbackRes.DecompressedLiterals = DecompressedLiterals;
         }
@@ -414,7 +429,7 @@ static void zstdgpu_Test_DecompressSequences(zstdgpu_ResourceDataCpu & cpuRes, z
     {
         uint32_t* tmp = gpuReadbackRes.CompressedData;
         gpuReadbackRes.CompressedData = cpuRes.CompressedData;
-        VALIDATE(DecompressedSequences(&gpuReadbackRes));
+        VALIDATE(DecompressedSequences, &gpuReadbackRes);
         gpuReadbackRes.CompressedData = tmp;
     }
 
@@ -498,7 +513,7 @@ static void zstdgpu_Test_DecompressSequences(zstdgpu_ResourceDataCpu & cpuRes, z
             gpuReadbackRes.DecompressedSequenceMLen = cpuRes.DecompressedSequenceMLen;
             gpuReadbackRes.DecompressedSequenceOffs = cpuRes.DecompressedSequenceOffs;
 
-            VALIDATE(DecompressedSequences(&gpuReadbackRes));
+            VALIDATE(DecompressedSequences, &gpuReadbackRes);
 
             gpuReadbackRes.CompressedData           = CompressedData;
             gpuReadbackRes.DecompressedSequenceLLen = DecompressedSequenceLLen;
@@ -511,7 +526,6 @@ static void zstdgpu_Test_DecompressSequences(zstdgpu_ResourceDataCpu & cpuRes, z
 
 static void zstdgpu_Test_BlockPrefix(zstdgpu_ResourceDataCpu & cpuRes, zstdgpu_ResourceDataCpu & gpuReadbackRes)
 {
-    /** these buffers could be zero if some block types don't exist */
     const uint32_t refRleBlockCount = cpuRes.Counters->Blocks_RLE;
     const uint32_t refRawBlockCount = cpuRes.Counters->Blocks_RAW;
     const uint32_t refCmpBlockCount = cpuRes.Counters->Blocks_CMP;
@@ -519,26 +533,24 @@ static void zstdgpu_Test_BlockPrefix(zstdgpu_ResourceDataCpu & cpuRes, zstdgpu_R
                                     + refRawBlockCount
                                     + refCmpBlockCount;
 
-    VALIDATE_CND(refRleBlockCount == gpuReadbackRes.Counters->Blocks_RLE);
-    VALIDATE_CND(refRawBlockCount == gpuReadbackRes.Counters->Blocks_RAW);
-    VALIDATE_CND(refCmpBlockCount == gpuReadbackRes.Counters->Blocks_CMP);
+    ZSTDGPU_ASSERT_MSG(refRleBlockCount == gpuReadbackRes.Counters->Blocks_RLE, "%u != %u", refRleBlockCount, gpuReadbackRes.Counters->Blocks_RLE);
+    ZSTDGPU_ASSERT_MSG(refRawBlockCount == gpuReadbackRes.Counters->Blocks_RAW, "%u != %u", refRawBlockCount, gpuReadbackRes.Counters->Blocks_RAW);
+    ZSTDGPU_ASSERT_MSG(refCmpBlockCount == gpuReadbackRes.Counters->Blocks_CMP, "%u != %u", refCmpBlockCount, gpuReadbackRes.Counters->Blocks_CMP);
 
-    if (NULL != cpuRes.GlobalBlockIndexPerCmpBlock)
-        VALIDATE_CND(0 == memcmp(cpuRes.GlobalBlockIndexPerCmpBlock, gpuReadbackRes.GlobalBlockIndexPerCmpBlock, sizeof(cpuRes.GlobalBlockIndexPerCmpBlock[0]) * refCmpBlockCount));
-    else
-        VALIDATE_CND(NULL == gpuReadbackRes.GlobalBlockIndexPerCmpBlock);
+    #define CHK(name) 0 == memcmp(cpuRes.GlobalBlockIndexPer##name##Block, gpuReadbackRes.GlobalBlockIndexPer##name##Block, sizeof(cpuRes.GlobalBlockIndexPer##name##Block[0]) * ref##name##BlockCount)
 
-    if (NULL != cpuRes.GlobalBlockIndexPerRawBlock)
-        VALIDATE_CND(0 == memcmp(cpuRes.GlobalBlockIndexPerRawBlock, gpuReadbackRes.GlobalBlockIndexPerRawBlock, sizeof(cpuRes.GlobalBlockIndexPerRawBlock[0]) * refRawBlockCount));
-    else
-        VALIDATE_CND(NULL == gpuReadbackRes.GlobalBlockIndexPerRawBlock);
+    if (refRleBlockCount == gpuReadbackRes.Counters->Blocks_RLE)
+        ZSTDGPU_ASSERT_MSG(CHK(Rle), "Global block indices for Rle blocks don't match between CPU and GPU");
 
-    if (NULL != cpuRes.GlobalBlockIndexPerRleBlock)
-        VALIDATE_CND(0 == memcmp(cpuRes.GlobalBlockIndexPerRleBlock, gpuReadbackRes.GlobalBlockIndexPerRleBlock, sizeof(cpuRes.GlobalBlockIndexPerRleBlock[0]) * refRleBlockCount));
-    else
-        VALIDATE_CND(NULL == gpuReadbackRes.GlobalBlockIndexPerRleBlock);
+    if (refRawBlockCount == gpuReadbackRes.Counters->Blocks_RAW)
+        ZSTDGPU_ASSERT_MSG(CHK(Raw), "Global block indices for Raw blocks don't match between CPU and GPU");
 
-    VALIDATE_CND(0 == memcmp(cpuRes.BlockSizePrefix, gpuReadbackRes.BlockSizePrefix, sizeof(cpuRes.BlockSizePrefix[0]) * refAllBlockCount));
+    if (refCmpBlockCount == gpuReadbackRes.Counters->Blocks_CMP)
+        ZSTDGPU_ASSERT_MSG(CHK(Cmp), "Global block indices for Cmp blocks don't match between CPU and GPU");
+
+    #undef CHK
+
+    ZSTDGPU_ASSERT(0 == memcmp(cpuRes.BlockSizePrefix, gpuReadbackRes.BlockSizePrefix, sizeof(cpuRes.BlockSizePrefix[0]) * refAllBlockCount));
 }
 
 static uint32_t zstdgpu_Test_DecompressedDataPerBlockType(const uint32_t *gpuGlobalBlockIndex,
@@ -684,7 +696,7 @@ static void zstdgpu_Validate_GpuDecompressOnCpu(zstdgpu_ResourceDataCpu & zstdCp
             zstdgpu_ShaderEntry_ParseFrames(srt, i);
         }
     }
-    VALIDATE(Blocks(&zstdCpu));
+    VALIDATE(Blocks, &zstdCpu);
 
     {
         zstdgpu_InitResources_SRT srt = {};
@@ -739,7 +751,7 @@ static void zstdgpu_Validate_GpuDecompressOnCpu(zstdgpu_ResourceDataCpu & zstdCp
             }
         }
 
-        VALIDATE(CompressedBlocksData(&zstdCpu));
+        VALIDATE(CompressedBlocksData, &zstdCpu);
     }
     const uint32_t literalCount = CNTRS(HUF_Streams_DecodedBytes);
     const uint32_t sequenceCount = CNTRS(Seq_Streams_DecodedItems);
@@ -780,7 +792,7 @@ static void zstdgpu_Validate_GpuDecompressOnCpu(zstdgpu_ResourceDataCpu & zstdCp
         {
             zstdgpu_ShaderEntry_InitFseTable(srt, i, 0);
         }
-        VALIDATE(FseTables(&zstdCpu));
+        VALIDATE(FseTables, &zstdCpu);
     }
 
     {
@@ -791,7 +803,7 @@ static void zstdgpu_Validate_GpuDecompressOnCpu(zstdgpu_ResourceDataCpu & zstdCp
             zstdgpu_ShaderEntry_DecompressHuffmanWeights(srt, i);
         }
 
-        VALIDATE(DecompressedHuffmanWeights(&zstdCpu));
+        VALIDATE(DecompressedHuffmanWeights, &zstdCpu);
     }
 
     {
@@ -802,7 +814,7 @@ static void zstdgpu_Validate_GpuDecompressOnCpu(zstdgpu_ResourceDataCpu & zstdCp
         {
             zstdgpu_ShaderEntry_DecodeHuffmanWeights(srt, i);
         }
-        VALIDATE(DecodedHuffmanWeights(&zstdCpu));
+        VALIDATE(DecodedHuffmanWeights, &zstdCpu);
     }
 
     {
@@ -824,7 +836,7 @@ static void zstdgpu_Validate_GpuDecompressOnCpu(zstdgpu_ResourceDataCpu & zstdCp
         {
             zstdgpu_ShaderEntry_InitHuffmanTable_And_DecompressLiterals(srt, groupId, 0, 1);
         }
-        VALIDATE(DecompressedLiterals(&zstdCpu));
+        VALIDATE(DecompressedLiterals, &zstdCpu);
     }
 
     {
@@ -909,7 +921,7 @@ static void zstdgpu_Validate_GpuDecompressOnCpu(zstdgpu_ResourceDataCpu & zstdCp
             zstdgpu_ShaderEntry_FinaliseSequenceOffsets(srt, i);
         }
     }
-    VALIDATE(DecompressedSequences(&zstdCpu));
+    VALIDATE(DecompressedSequences, &zstdCpu);
     #undef CNTRS
 }
 
@@ -926,6 +938,21 @@ ZSTDGPU_API void zstdgpu_RetrieveGpuResults(zstdgpu_ResourceDataCpu *outGpuResou
 ZSTDGPU_API void zstdgpu_ReadbackTimestamps(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandList *cmdList);
 ZSTDGPU_API uint64_t zstdgpu_RetrieveTimestamps(const wchar_t **outTimestampScopeNames, uint64_t *outTimestampScopeClocks, uint32_t *inoutTimestampScopeCnt, zstdgpu_PerRequestContext req, uint32_t stageIndex);
 
+extern "C" void zstdgpu_AssertReportCback(const char *expr, const char *file, int line, const char *func, const char *msg, void *args)
+{
+    if (NULL != msg)
+    {
+        const size_t bufferSize = 1024;
+        char buffer[bufferSize + 1];
+        _vsnprintf_s(buffer, bufferSize + 1, bufferSize, msg, *(va_list*)args);
+        debugPrint(L"[FAIL] (%hs) : %hs at %hs:%d in %hs\n", expr, buffer, file, line, func);
+    }
+    else
+    {
+        debugPrint(L"[FAIL] (%hs) at %hs:%d in %hs\n", expr, file, line, func);
+    }
+}
+
 // Entry point
 #ifndef _GAMING_XBOX
 int wmain(int argc, wchar_t **argv)
@@ -938,6 +965,16 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
     UNREFERENCED_PARAMETER(lpCmdLine);
     UNREFERENCED_PARAMETER(nCmdShow);
 #endif
+
+    tta_AssertSetReportCback(&zstdgpu_AssertReportCback);
+    if (IsDebuggerPresent())
+    {
+        tta_AssertSetReportLevel(ktta_AssertReportLevel_PrintAndBreak);
+    }
+    else
+    {
+        tta_AssertSetReportLevel(ktta_AssertReportLevel_Print);
+    }
 
     bool extMem = false;
     bool blkCnt = false;
@@ -1273,17 +1310,33 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
         zstdgpu_ReferenceStore_Report_ChunkBase(zstdData);
         zstdgpu_ReferenceStore_AllocateMemory();
 
-        // NOTE(pamartis): this call to reference ZSTD decompressor populates zstdgpu_ReferenceStore with ground-truth  data
-        ZSTD_decompress(zstdReferenceUncompressedData, zstdReferenceUncompressedDataSize, zstdData, zstdDataSize);
+        if (0 != zstdgpu_ValidateUntilFirstAssert([&]() -> void
+        {
+            // NOTE(pamartis): this call to reference ZSTD decompressor populates zstdgpu_ReferenceStore with ground-truth  data
+            ZSTD_decompress(zstdReferenceUncompressedData, zstdReferenceUncompressedDataSize, zstdData, zstdDataSize);
+        }))
+        {
+            debugPrint(L"[FAIL] Encountered errors during Reference Decompression. Early Out.\n");
+            return 1;
+        }
     }
 
     zstdgpu_ResourceDataCpu zstdCpu;
     if (chkCpu)
     {
-        debugPrint(L"[VALIDATION] Running GPU Decompression code on CPU ('--chk-cpu' option was set).\n");
+        debugPrint(L"[INFO] Running GPU Decompression code on CPU ('--chk-cpu' option was set).\n");
+
         // NOTE(pamartis): We run GPU Decompression pipeline on CPU to catch possible errors/assert early
-        // TODO(pamartis): Because currently we don't know "frame count" and "uncompressed size" we pass that information from fbInfo.
-        zstdgpu_Validate_GpuDecompressOnCpu(zstdCpu, zstdData, zstdInFrameRefs, fbInfo.frameCount, zstdDataSize, fbInfo.frameByteCount);
+
+        if (0 != zstdgpu_ValidateUntilFirstAssert([&]() -> void
+        {
+            zstdgpu_Validate_GpuDecompressOnCpu(zstdCpu, zstdData, zstdInFrameRefs, fbInfo.frameCount, zstdDataSize, fbInfo.frameByteCount);
+        }))
+        {
+            debugPrint(L"[FAIL] Encountered errors during validation run of GPU code on CPU. Early Out.\n");
+            return 1;
+        }
+
         if (!simGpu)
         {
             zstdgpu_ResourceDataCpu_MarkReadOnly(&zstdCpu);
@@ -1860,3 +1913,10 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lp
     debugPrint(L"Finished.\n");
     return 0;
 }
+
+#define TTA_ASSERT_IMPL
+
+ZSTDGPU_WARN_PUSH_MSVC()
+ZSTDGPU_WARN_STOP_MSVC(4611) /* setjmp/C++ interaction in tta_assert's NOEXCEPT path; dead code under the Print report level */
+#include <tta_assert.h>
+ZSTDGPU_WARN_POP_MSVC()

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -739,17 +739,6 @@ static void zstdgpu_Validate_GpuDecompressOnCpu(zstdgpu_ResourceDataCpu & zstdCp
             }
         }
 
-        // CPU equivalent of the [Propagate FSE Index] dispatch that propagates FSE/Huffman table indices
-        // across all Huffman-compressed literals
-        {
-            uint32_t cpuLastHufWIndex = kzstdgpu_FseProbTableIndex_Unused;
-            const uint32_t cmpLitCount = CNTRS(Cmp_Lit);
-            for (uint32_t i = 0; i < cmpLitCount; ++i)
-            {
-                zstdgpu_PropagateFseIndexCpu(zstdCpu.CmpLitToHufWFseId[i], cpuLastHufWIndex);
-            }
-        }
-
         VALIDATE(CompressedBlocksData(&zstdCpu));
     }
     const uint32_t literalCount = CNTRS(HUF_Streams_DecodedBytes);


### PR DESCRIPTION
This PR adds support for a minimal assert system ([tta_assert](https://github.com/pm4rtx/tta_assert)) to allow controlling assert behaviour at runtime: only logging, logging and breaking, logging and throwing; at compile-time: compiled out or present; and allow optional `printf`-like messages with arguments. Also this PR eliminates raw `__debugbreak` usage left from initial prototype code. And finally, this PR removes several unused data streams (in a separate changelist).