### PR TITLE
zstdgpu/fixes: brings stability fixes and validation

### DIFF
--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -1558,7 +1558,7 @@ static void zstdgpu_RecomputeAndRetrieveBlockInfoConstants(uint32_t *outCntLit, 
     *outCntLit = cntLit;
 }
 
-ZSTDGPU_ENUM(Status) zstdgpu_GetGpuMemoryRequirement(uint32_t *outDefaultHeapByteCount, uint32_t *outUploadHeapByteCount, uint32_t *outReadbackHeapByteCount, uint32_t *outShaderVisibleDescriptorCount, zstdgpu_PerRequestContext req, uint32_t stageIndex)
+ZSTDGPU_ENUM(Status) zstdgpu_GetGpuMemoryRequirement(uint64_t *outDefaultHeapByteCount, uint64_t *outUploadHeapByteCount, uint64_t *outReadbackHeapByteCount, uint32_t *outShaderVisibleDescriptorCount, zstdgpu_PerRequestContext req, uint32_t stageIndex)
 {
     uint32_t proceed = 1;
     uint32_t stageCount = ZSTDGPU_ENUM_CONST(ResourceAllocation_StageCount);
@@ -1604,9 +1604,9 @@ ZSTDGPU_ENUM(Status) zstdgpu_GetGpuMemoryRequirement(uint32_t *outDefaultHeapByt
     return ZSTDGPU_ENUM_CONST(StatusInvalidArgument);
 }
 
-static void zstdgpu_GetAllStageGpuMemoryRequirementInternal(uint32_t *outDefaultHeapByteCount,
-                                                            uint32_t *outUploadHeapByteCount,
-                                                            uint32_t *outReadbackHeapByteCount,
+static void zstdgpu_GetAllStageGpuMemoryRequirementInternal(uint64_t *outDefaultHeapByteCount,
+                                                            uint64_t *outUploadHeapByteCount,
+                                                            uint64_t *outReadbackHeapByteCount,
                                                             zstdgpu_PerRequestContext req)
 {
     uint32_t cntRaw, cntRle, cntCmp, cntLit, cntSeq;
@@ -1631,9 +1631,9 @@ static void zstdgpu_GetAllStageGpuMemoryRequirementInternal(uint32_t *outDefault
                                 + req->resInfo.gpu2Cpu_ByteCount[2];
 }
 
-ZSTDGPU_ENUM(Status) zstdgpu_GetAllStageGpuMemoryRequirement(uint32_t *outDefaultHeapByteCount,
-                                                             uint32_t *outUploadHeapByteCount,
-                                                             uint32_t *outReadbackHeapByteCount,
+ZSTDGPU_ENUM(Status) zstdgpu_GetAllStageGpuMemoryRequirement(uint64_t *outDefaultHeapByteCount,
+                                                             uint64_t *outUploadHeapByteCount,
+                                                             uint64_t *outReadbackHeapByteCount,
                                                              uint32_t *outShaderVisibleDescriptorCount,
                                                              zstdgpu_PerRequestContext req)
 {
@@ -1673,19 +1673,19 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithExternalMemory(zstdgpu_PerRequestContext 
                                                 uint32_t stageIndex,
                                                 struct ID3D12GraphicsCommandList *cmdList,
                                                 struct ID3D12Heap *defaultHeap,
-                                                uint32_t defaultHeapOffsetInBytes,
+                                                uint64_t defaultHeapOffsetInBytes,
                                                 struct ID3D12Heap *uploadHeap,
-                                                uint32_t uploadHeapOffsetInBytes,
+                                                uint64_t uploadHeapOffsetInBytes,
                                                 struct ID3D12Heap *readbackHeap,
-                                                uint32_t readbackHeap_OffsetInBytes,
+                                                uint64_t readbackHeap_OffsetInBytes,
                                                 struct ID3D12DescriptorHeap *shaderVisibleHeap,
                                                 uint32_t shaderVisibileHeapOffsetInDescriptors)
 {
     uint32_t proceed = 1;
     uint32_t stageCount = ZSTDGPU_ENUM_CONST(ResourceAllocation_StageCount);
-    uint32_t defaultHeapMemReq = 0;
-    uint32_t uploadHeapMemReq = 0;
-    uint32_t readbackHeapMemReq = 0;
+    uint64_t defaultHeapMemReq = 0;
+    uint64_t uploadHeapMemReq = 0;
+    uint64_t readbackHeapMemReq = 0;
     uint32_t shaderVisibleHeapDscCount = 0;
     proceed = ZSTDGPU_ENUM_CONST(StatusSuccess) == zstdgpu_GetGpuMemoryRequirement(&defaultHeapMemReq, &uploadHeapMemReq, &readbackHeapMemReq, &shaderVisibleHeapDscCount, req, stageIndex);
     proceed = proceed && (req->thisMemoryBlock == (void *)req);
@@ -1776,18 +1776,18 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitWithExternalMemory(zstdgpu_PerRequestContext 
 ZSTDGPU_ENUM(Status) zstdgpu_SubmitAllStagesWithExternalMemory(zstdgpu_PerRequestContext req,
                                                                struct ID3D12GraphicsCommandList *cmdList,
                                                                struct ID3D12Heap *defaultHeap,
-                                                               uint32_t defaultHeap_OffsetInBytes,
+                                                               uint64_t defaultHeap_OffsetInBytes,
                                                                struct ID3D12Heap *uploadHeap,
-                                                               uint32_t uploadHeap_OffsetInBytes,
+                                                               uint64_t uploadHeap_OffsetInBytes,
                                                                struct ID3D12Heap *readbackHeap,
-                                                               uint32_t readbackHeap_OffsetInBytes,
+                                                               uint64_t readbackHeap_OffsetInBytes,
                                                                struct ID3D12DescriptorHeap *shaderVisibleHeap,
                                                                uint32_t shaderVisibileHeap_OffsetInDescriptors)
 {
     uint32_t proceed = 1;
-    uint32_t defaultHeapMemReq = 0;
-    uint32_t uploadHeapMemReq = 0;
-    uint32_t readbackHeapMemReq = 0;
+    uint64_t defaultHeapMemReq = 0;
+    uint64_t uploadHeapMemReq = 0;
+    uint64_t readbackHeapMemReq = 0;
     uint32_t shaderVisibleHeapDscCount = 0;
     proceed = proceed && (0 == zstdgpu_IsAnyStageReadbackRequired(req));
     proceed = proceed && (ZSTDGPU_ENUM_CONST(StatusSuccess) == zstdgpu_GetAllStageGpuMemoryRequirement(&defaultHeapMemReq, &uploadHeapMemReq, &readbackHeapMemReq, &shaderVisibleHeapDscCount, req));
@@ -1803,9 +1803,9 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitAllStagesWithExternalMemory(zstdgpu_PerReques
     ZSTDGPU_ASSERT(proceed > 0);
     if (proceed)
     {
-        uint32_t defaultOffs = defaultHeap_OffsetInBytes;
-        uint32_t uploadOffs = uploadHeap_OffsetInBytes;
-        uint32_t readbackOffs = readbackHeap_OffsetInBytes;
+        uint64_t defaultOffs = defaultHeap_OffsetInBytes;
+        uint64_t uploadOffs = uploadHeap_OffsetInBytes;
+        uint64_t readbackOffs = readbackHeap_OffsetInBytes;
         zstdgpu_ResourceDataGpu_Term(&req->resData, 0);
         zstdgpu_ResourceDataGpu_Term(&req->resData, 1);
         zstdgpu_ResourceDataGpu_Term(&req->resData, 2);
@@ -2002,8 +2002,8 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitAllStagesWithInteralMemory(zstdgpu_PerRequest
     if (proceed)
     {
         ID3D12Device *device = req->device;
-        uint32_t dflt, upld, rdbk;
-        uint32_t dfltP, upldP, rdbkP;
+        uint64_t dflt, upld, rdbk;
+        uint64_t dfltP, upldP, rdbkP;
         zstdgpu_GetAllStageGpuMemoryRequirementInternal(&dflt, &upld, &rdbk, req);
 
         dfltP = req->resData.gpuOnly_ByteCount[0]
@@ -2071,7 +2071,7 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitAllStagesWithInteralMemory(zstdgpu_PerRequest
         if (NULL == req->resData.gpuOnly_Heap[0] && 0 != dflt)
         {
             ID3D12Heap *heap = d3d12aid_Heap_Create_WithHeapTypeAndFlags(device, dflt, 0, D3D12_HEAP_TYPE_DEFAULT, D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS);
-            uint32_t offs = 0;
+            uint64_t offs = 0;
             INIT_HEAP(gpuOnly, 0, heap);
             INIT_HEAP(gpuOnly, 1, heap);
             INIT_HEAP(gpuOnly, 2, heap);
@@ -2089,7 +2089,7 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitAllStagesWithInteralMemory(zstdgpu_PerRequest
         if (NULL == req->resData.cpu2Gpu_Heap[0] && 0 != upld)
         {
             ID3D12Heap *heap = d3d12aid_Heap_Create_WithHeapTypeAndFlags(device, upld, 0, D3D12_HEAP_TYPE_UPLOAD, D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS);
-            uint32_t offs = 0;
+            uint64_t offs = 0;
             INIT_HEAP(cpu2Gpu, 0, heap);
             INIT_HEAP(cpu2Gpu, 1, heap);
             INIT_HEAP(cpu2Gpu, 2, heap);
@@ -2106,7 +2106,7 @@ ZSTDGPU_ENUM(Status) zstdgpu_SubmitAllStagesWithInteralMemory(zstdgpu_PerRequest
         if (NULL == req->resData.gpu2Cpu_Heap[0] && 0 != rdbk)
         {
             ID3D12Heap *heap = d3d12aid_Heap_Create_WithHeapTypeAndFlags(device, rdbk, 0, D3D12_HEAP_TYPE_READBACK, D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS);
-            uint32_t offs = 0;
+            uint64_t offs = 0;
             INIT_HEAP(gpu2Cpu, 0, heap);
             INIT_HEAP(gpu2Cpu, 1, heap);
             INIT_HEAP(gpu2Cpu, 2, heap);

--- a/zstd/zstdgpu/zstdgpu.h
+++ b/zstd/zstdgpu/zstdgpu.h
@@ -225,14 +225,14 @@ ZSTDGPU_API uint32_t zstdgpu_IsAnyStageReadbackRequired(zstdgpu_PerRequestContex
 /**
  *  @brief      Returns memory requirement for each heap type per submission stage for a given `zstdgpu_PerRequestContext`
  */
-ZSTDGPU_API zstdgpu_Status zstdgpu_GetGpuMemoryRequirement(uint32_t *outDefaultHeapByteCount, uint32_t *outUploadHeapByteCount, uint32_t *outReadbackHeapByteCount, uint32_t *outShaderVisibleDescriptorCount, zstdgpu_PerRequestContext inPerRequestContext, uint32_t stageIndex);
+ZSTDGPU_API zstdgpu_Status zstdgpu_GetGpuMemoryRequirement(uint64_t *outDefaultHeapByteCount, uint64_t *outUploadHeapByteCount, uint64_t *outReadbackHeapByteCount, uint32_t *outShaderVisibleDescriptorCount, zstdgpu_PerRequestContext inPerRequestContext, uint32_t stageIndex);
 
 /**
  *  @brief      Returns memory requirement for each heap type for all submission stages for a given `zstdgpu_PerRequestContext`
  *
  *  @note       It's valid to call this function only when `zstdgpu_IsAnyStageReadbackRequired` returns `0`
  */
-ZSTDGPU_API zstdgpu_Status zstdgpu_GetAllStageGpuMemoryRequirement(uint32_t *outDefaultHeapByteCount, uint32_t *outUploadHeapByteCount, uint32_t *outReadbackHeapByteCount, uint32_t *outShaderVisibleDescriptorCount, zstdgpu_PerRequestContext inPerRequestContext);
+ZSTDGPU_API zstdgpu_Status zstdgpu_GetAllStageGpuMemoryRequirement(uint64_t *outDefaultHeapByteCount, uint64_t *outUploadHeapByteCount, uint64_t *outReadbackHeapByteCount, uint32_t *outShaderVisibleDescriptorCount, zstdgpu_PerRequestContext inPerRequestContext);
 
 /**
  *  @brief      Submits all required decompression commands into a command list for a given `stageIndex` with externally
@@ -247,11 +247,11 @@ ZSTDGPU_API zstdgpu_Status zstdgpu_SubmitWithExternalMemory(zstdgpu_PerRequestCo
                                                             uint32_t stageIndex,
                                                             struct ID3D12GraphicsCommandList *cmdList,
                                                             struct ID3D12Heap *defaultHeap,
-                                                            uint32_t defaultHeapOffsetInBytes,
+                                                            uint64_t defaultHeapOffsetInBytes,
                                                             struct ID3D12Heap *uploadHeap,
-                                                            uint32_t uploadHeapOffsetInBytes,
+                                                            uint64_t uploadHeapOffsetInBytes,
                                                             struct ID3D12Heap *readbackHeap,
-                                                            uint32_t readbackHeap_OffsetInBytes,
+                                                            uint64_t readbackHeap_OffsetInBytes,
                                                             struct ID3D12DescriptorHeap *shaderVisibleHeap,
                                                             uint32_t shaderVisibileHeapOffsetInDescriptors);
 
@@ -266,11 +266,11 @@ ZSTDGPU_API zstdgpu_Status zstdgpu_SubmitWithExternalMemory(zstdgpu_PerRequestCo
 ZSTDGPU_API zstdgpu_Status zstdgpu_SubmitAllStagesWithExternalMemory(zstdgpu_PerRequestContext inPerRequestContext,
                                                                      struct ID3D12GraphicsCommandList *cmdList,
                                                                      struct ID3D12Heap *defaultHeap,
-                                                                     uint32_t defaultHeapOffsetInBytes,
+                                                                     uint64_t defaultHeapOffsetInBytes,
                                                                      struct ID3D12Heap *uploadHeap,
-                                                                     uint32_t uploadHeapOffsetInBytes,
+                                                                     uint64_t uploadHeapOffsetInBytes,
                                                                      struct ID3D12Heap *readbackHeap,
-                                                                     uint32_t readbackHeap_OffsetInBytes,
+                                                                     uint64_t readbackHeap_OffsetInBytes,
                                                                      struct ID3D12DescriptorHeap *shaderVisibleHeap,
                                                                      uint32_t shaderVisibileHeapOffsetInDescriptors);
 

--- a/zstd/zstdgpu/zstdgpu_reference_store.cpp
+++ b/zstd/zstdgpu/zstdgpu_reference_store.cpp
@@ -512,129 +512,6 @@ void zstdgpu_ReferenceStore_Report_CompressedSequences(const void *base, uint32_
     GZstd.CompressedBlocks[cmpBlockId].seqStreamIndex = i;
 }
 
-__pragma(warning(push))
-__pragma(warning(disable : 4505))
-static uint32_t zstdgpu_SequenceOffsets_Update(ZSTDGPU_PARAM_INOUT(uint32_t) offset1,
-                                               ZSTDGPU_PARAM_INOUT(uint32_t) offset2,
-                                               ZSTDGPU_PARAM_INOUT(uint32_t) offset3,
-                                               uint32_t offset,
-                                               uint32_t llen)
-{
-    uint32_t actualOffset = offset;
-    if (offset > 3u)
-    {
-        offset3 = offset2;
-        offset2 = offset1;
-        offset1 = offset;
-    }
-    else
-    {
-        if (llen != 0)
-        {
-            if (offset == 1u)
-            {
-                actualOffset = offset1;
-                //offset3 = offset3
-                //offset2 = offset2
-                //offset1 = actualOffset1
-            }
-            else if (offset == 2u)
-            {
-                actualOffset = offset2;
-                //offset3 = offset3
-                offset2 = offset1;
-                offset1 = actualOffset;
-            }
-            else
-            {
-                actualOffset = offset3;
-                offset3 = offset2;
-                offset2 = offset1;
-                offset1 = actualOffset;
-            }
-        }
-        else
-        {
-            if (offset == 1u)
-            {
-                actualOffset = offset2;
-                //offset3 = offset3
-                offset2 = offset1;
-                offset1 = actualOffset;
-            }
-            else if (offset == 2u)
-            {
-                actualOffset = offset3;
-                offset3 = offset2;
-                offset2 = offset1;
-                offset1 = actualOffset;
-            }
-            else
-            {
-                if (offset1 > 3u)
-                {
-                    // case 1: if we have actual offset (bit 31 is 0) -- we subtract a byte
-                    // case 2: if the offset is "repeat offset" (bit 31 is 1, bits 29 and 30 encode previous "repeat offset")
-                    //         which depending on previous block. We keep subtracting bytes
-                    actualOffset = offset1 - 1u;
-                }
-                else if (offset1 > 0) // we don't have valid offset, but we have to subtract one byte, so we re-encode "repeat offset"
-                {
-                    // in the encoding
-                    //      - we set offs[31] bit to 1 to mark this uint32_t as "encoded"
-                    //      - we set offs[30:29] to the "repeated offset"
-                    //      - we set all other bits to 1, so it behaves as -1 (which is a starting bit)
-                    actualOffset = zstdgpu_EncodeSeqRepeatOffset(offset1);
-                }
-                else
-                {
-                    // offset must not be zero
-                    ZSTDGPU_BREAK();
-                }
-                offset3 = offset2;
-                offset2 = offset1;
-                offset1 = actualOffset;
-            }
-        }
-    }
-    return actualOffset;
-}
-
-__pragma(warning(pop))
-
-static uint32_t zstdgpu_SequenceOffsets_Update2(ZSTDGPU_PARAM_INOUT(uint32_t) offset1,
-                                                ZSTDGPU_PARAM_INOUT(uint32_t) offset2,
-                                                ZSTDGPU_PARAM_INOUT(uint32_t) offset3,
-                                                uint32_t offset,
-                                                uint32_t llen)
-{
-    uint32_t encodedOffset = offset;
-    if (offset <= 3u)
-    {
-        offset += llen == 0u ? 1u : 0u;
-#if 0
-        if (offset == 4u)
-        {
-            // case 1: if we have an actual offset (bit 31 is 0) -- we subtract a byte
-            // case 2: if the offset is "repeat offset" (bit 31 is 1, bits 29 and 30 encode previous "repeat offset")
-            //         which depending on previous block. We keep subtracting bytes
-            encodedOffset = offset1 - 1u;
-        }
-        else
-        {
-            encodedOffset = (offset == 3u) ? offset3 : ((offset == 2u) ? offset2 : offset1);
-        }
-#else
-        encodedOffset = (offset < 3u) ? (offset < 2u ? offset1 : offset2) : (offset < 4u ? offset3 : (offset1 - 1u));
-#endif
-    }
-
-    offset3 = offset >= 3u ? offset2 : offset3;
-    offset2 = offset >= 2u ? offset1 : offset2;
-    offset1 = encodedOffset;
-    return encodedOffset;
-}
-
 static uint32_t GResolvedOffsetResetFrame = 0;
 
 static uint32_t GRecentOffset1 = 0u; // initialize to "invalid" offset that can't happen
@@ -703,7 +580,7 @@ void zstdgpu_ReferenceStore_Report_DecompressedSequences(const uint32_t *sequenc
         GZstd.DecompressedSequenceOffs[seqOffs + seqId] = offs;
 
 #if ENABLE_OFFSET_PROPAGATION
-        GZstd.DecompressedSequenceOffs[seqOffs + seqId] = zstdgpu_SequenceOffsets_Update2(recent1, recent2, recent3, offs, llen);
+        GZstd.DecompressedSequenceOffs[seqOffs + seqId] = zstdgpu_UpdatePreviousAndRecomputeIncoming(recent1, recent2, recent3, offs, llen);
 #endif
     }
     // NOTE(pamartis): accumulated match length are used to update the uncompressed size of compressed block

--- a/zstd/zstdgpu/zstdgpu_reference_store.cpp
+++ b/zstd/zstdgpu/zstdgpu_reference_store.cpp
@@ -168,16 +168,16 @@ void zstdgpu_ReferenceStore_Report_Block(const void *base, uint32_t size, ZSTDGP
 
 void zstdgpu_ReferenceStore_Report_RawLiteral(const void *base, uint32_t size)
 {
-    GZstd.CompressedBlocks[GBlockIndexCMP - 1].literal.offs = zstdgpu_EncodeRawLitOffset(izstdgpu_ReferenceStore_PtrToOffs(base));
-    GZstd.CompressedBlocks[GBlockIndexCMP - 1].literal.size = size;
+    GZstd.CompressedBlocks[GBlockIndexCMP - 1].literal.offs = izstdgpu_ReferenceStore_PtrToOffs(base);
+    GZstd.CompressedBlocks[GBlockIndexCMP - 1].literal.size = zstdgpu_EncodeRawLitTypeIntoLitSize(size);
     GZstd.CompressedBlocks[GBlockIndexCMP - 1].litStreamIndex = ~0u;
     zstdgpu_AppendLastBlockSize(size);
 }
 
 void zstdgpu_ReferenceStore_Report_RleLiteral(const void *base, uint32_t size)
 {
-    GZstd.CompressedBlocks[GBlockIndexCMP - 1].literal.offs = zstdgpu_EncodeRleLitOffset(*(uint8_t *)base);
-    GZstd.CompressedBlocks[GBlockIndexCMP - 1].literal.size = size;
+    GZstd.CompressedBlocks[GBlockIndexCMP - 1].literal.offs = *(uint8_t *)base;
+    GZstd.CompressedBlocks[GBlockIndexCMP - 1].literal.size = zstdgpu_EncodeRleLitTypeIntoLitSize(size);
     GZstd.CompressedBlocks[GBlockIndexCMP - 1].litStreamIndex = ~0u;
     zstdgpu_AppendLastBlockSize(size);
 }
@@ -188,8 +188,8 @@ void zstdgpu_ReferenceStore_Report_CompressedLiteral(const void* base, uint32_t 
     if (GCompressedBlockLiteralStreamIndex == 0)
     {
         GZstd.CompressedBlocks[GBlockIndexCMP - 1].litStreamIndex = hufCompressedLiteralIndex;
-        GZstd.CompressedBlocks[GBlockIndexCMP - 1].literal.offs = zstdgpu_EncodeCmpLitOffset(GHufDecompressedLiteralOffset);
-        GZstd.CompressedBlocks[GBlockIndexCMP - 1].literal.size = GHufDecompressedLiteralSize;
+        GZstd.CompressedBlocks[GBlockIndexCMP - 1].literal.offs = GHufDecompressedLiteralOffset;
+        GZstd.CompressedBlocks[GBlockIndexCMP - 1].literal.size = zstdgpu_EncodeCmpLitTypeIntoLitSize(GHufDecompressedLiteralSize);
     }
 
     GZstd.LitRefs[hufCompressedLiteralIndex].src.offs = izstdgpu_ReferenceStore_PtrToOffs(base);
@@ -261,8 +261,8 @@ void zstdgpu_ReferenceStore_Report_DecompressedLiteral(const uint8_t *literal, u
     }
 
     memcpy(GZstd.DecompressedLiterals + GHufDecompressedLiteralDataOffset, literal, size);
-    ZSTDGPU_ASSERT(GZstd.CompressedBlocks[GBlockIndexCMP - 1].literal.offs == zstdgpu_EncodeCmpLitOffset(GHufDecompressedLiteralDataOffset));
-    ZSTDGPU_ASSERT(GZstd.CompressedBlocks[GBlockIndexCMP - 1].literal.size == size);
+    ZSTDGPU_ASSERT(GZstd.CompressedBlocks[GBlockIndexCMP - 1].literal.offs == GHufDecompressedLiteralDataOffset);
+    ZSTDGPU_ASSERT(zstdgpu_DecodeLitSize(GZstd.CompressedBlocks[GBlockIndexCMP - 1].literal.size) == size);
     GHufDecompressedLiteralDataOffset += size;
 }
 
@@ -1023,7 +1023,7 @@ ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_CompressedBlocksDa
                 //ZSTDGPU_ASSERT(refCompressedBlockData.literal.offs == refHufLiteral[0].dstOffs);
                 //ZSTDGPU_ASSERT(tstCmpBlocks[i].literal.offs == tstHufLiteral[0].dstOffs);
 
-                if (refCmpBlocks[i].literal.size == refHufLiteral[0].dst.size)
+                if (zstdgpu_DecodeLitSize(refCmpBlocks[i].literal.size) == refHufLiteral[0].dst.size)
                 {
                     if (refHufLiteral[0].dst.size != tstHufLiteral[0].dst.size)
                         return ZSTDGPU_ENUM_CONST(Validate_Failed);
@@ -1040,9 +1040,9 @@ ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_CompressedBlocksDa
                                               + tstHufLiteral[2].dst.size
                                               + tstHufLiteral[3].dst.size;
 
-                    if (refCmpBlocks[i].literal.size != refDstSize)
+                    if (zstdgpu_DecodeLitSize(refCmpBlocks[i].literal.size) != refDstSize)
                         return ZSTDGPU_ENUM_CONST(Validate_Failed);
-                    if (tstCmpBlocks[i].literal.size != tstDstSize)
+                    if (zstdgpu_DecodeLitSize(tstCmpBlocks[i].literal.size) != tstDstSize)
                         return ZSTDGPU_ENUM_CONST(Validate_Failed);
                     if (refCmpBlocks[i].literal.size != tstCmpBlocks[i].literal.size)
                         return ZSTDGPU_ENUM_CONST(Validate_Failed);
@@ -1158,14 +1158,14 @@ ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_DecompressedLitera
         const zstdgpu_OffsetAndSize *refLit = &refData->CompressedBlocks[i].literal;
         const zstdgpu_OffsetAndSize *tstLit = &tstData->CompressedBlocks[i].literal;
 
-        const uint32_t refLitT = zstdgpu_DecodeLitOffsetType(refLit->offs);
-        const uint32_t tstLitT = zstdgpu_DecodeLitOffsetType(tstLit->offs);
+        const uint32_t refLitT = zstdgpu_DecodeLitType(refLit->size);
+        const uint32_t tstLitT = zstdgpu_DecodeLitType(tstLit->size);
 
         if (refLitT != tstLitT)
             return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
         // NOTE(pamartis): if the type of the offset not "compressed literal", then it's a non-compressed literal stored in the source data, so offsets are identical
-        if (zstdgpu_CheckLitOffsetTypeCmp(refLitT) == 0)
+        if (zstdgpu_IsLitTypeCmp(refLitT) == 0)
         {
             if (ZSTDGPU_ENUM_CONST(Validate_Success) != izstdgpu_ReferenceStore_Validate_OffsetAndSize(refLit, tstLit))
                 return ZSTDGPU_ENUM_CONST(Validate_Failed);
@@ -1176,9 +1176,9 @@ ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_DecompressedLitera
             if (refLit->size != tstLit->size)
                 return ZSTDGPU_ENUM_CONST(Validate_Failed);
 
-            const uint8_t *refDecLit = refData->DecompressedLiterals + zstdgpu_DecodeLitOffset(refLit->offs);
-            const uint8_t *tstDecLit = tstData->DecompressedLiterals + zstdgpu_DecodeLitOffset(tstLit->offs);
-            if (0 != memcmp(refDecLit, tstDecLit, refLit->size))
+            const uint8_t *refDecLit = refData->DecompressedLiterals + refLit->offs;
+            const uint8_t *tstDecLit = tstData->DecompressedLiterals + tstLit->offs;
+            if (0 != memcmp(refDecLit, tstDecLit, zstdgpu_DecodeLitSize(refLit->size)))
             {
                 return ZSTDGPU_ENUM_CONST(Validate_Failed);
             }

--- a/zstd/zstdgpu/zstdgpu_resources.h
+++ b/zstd/zstdgpu/zstdgpu_resources.h
@@ -160,20 +160,20 @@ typedef struct zstdgpu_ResourceInfo
         ZSTDGPU_ALL_BUFFERS_LIST()
     #undef  ZSTDGPU_BUFFER
 
-    uint32_t gpuOnly_ByteCount[kzstdgpu_ResourceAllocation_StageCount];
-    uint32_t cpu2Gpu_ByteCount[kzstdgpu_ResourceAllocation_StageCount];
-    uint32_t gpu2Cpu_ByteCount[kzstdgpu_ResourceAllocation_StageCount];
+    uint64_t gpuOnly_ByteCount[kzstdgpu_ResourceAllocation_StageCount];
+    uint64_t cpu2Gpu_ByteCount[kzstdgpu_ResourceAllocation_StageCount];
+    uint64_t gpu2Cpu_ByteCount[kzstdgpu_ResourceAllocation_StageCount];
 
     // declare byte offsets
-    #define ZSTDGPU_BUFFER(type, name) uint32_t name##_gpuOnlyByteOffset;
+    #define ZSTDGPU_BUFFER(type, name) uint64_t name##_gpuOnlyByteOffset;
         ZSTDGPU_ALL_BUFFERS_LIST()
     #undef  ZSTDGPU_BUFFER
 
-    #define ZSTDGPU_BUFFER(type, name) uint32_t name##_cpu2GpuByteOffset;
+    #define ZSTDGPU_BUFFER(type, name) uint64_t name##_cpu2GpuByteOffset;
         ZSTDGPU_ALL_BUFFERS_LIST_UPLOAD()
     #undef  ZSTDGPU_BUFFER
 
-    #define ZSTDGPU_BUFFER(type, name) uint32_t name##_gpu2CpuByteOffset;
+    #define ZSTDGPU_BUFFER(type, name) uint64_t name##_gpu2CpuByteOffset;
         ZSTDGPU_ALL_BUFFERS_LIST_READBACK()
     #undef  ZSTDGPU_BUFFER
 } zstdgpu_ResourceInfo;
@@ -223,9 +223,9 @@ typedef struct zstdgpu_ResourceDataGpu
     uint64_t cpu2Gpu_HeapOffset[kzstdgpu_ResourceAllocation_StageCount];
     uint64_t gpu2Cpu_HeapOffset[kzstdgpu_ResourceAllocation_StageCount];
 
-    uint32_t gpuOnly_ByteCount[kzstdgpu_ResourceAllocation_StageCount];
-    uint32_t cpu2Gpu_ByteCount[kzstdgpu_ResourceAllocation_StageCount];
-    uint32_t gpu2Cpu_ByteCount[kzstdgpu_ResourceAllocation_StageCount];
+    uint64_t gpuOnly_ByteCount[kzstdgpu_ResourceAllocation_StageCount];
+    uint64_t cpu2Gpu_ByteCount[kzstdgpu_ResourceAllocation_StageCount];
+    uint64_t gpu2Cpu_ByteCount[kzstdgpu_ResourceAllocation_StageCount];
 } zstdgpu_ResourceDataGpu;
 
 #endif /** ZSTDGPU_DISABLE_RESOURCE_DATA_GPU */
@@ -252,7 +252,7 @@ static void zstdgpu_ResourceInfo_InitZero(zstdgpu_ResourceInfo *outInfo)
     #undef  ZSTDGPU_BUFFER
 }
 
-#define ZSTDGPU_ALIGN_DEFAULT(offset) zstdgpu_AlignUp(offset, 0x10000)
+#define ZSTDGPU_ALIGN_DEFAULT(offset) zstdgpu_AlignUp64(offset, 0x10000)
 #define ZSTDGPU_IS_DEFAULT_ALIGNED(offset) (0 == (offset & (0x10000 - 1)))
 
 // initialize the counts, sizes and offsets
@@ -370,21 +370,21 @@ static void zstdgpu_ResourceInfo_Stage_2_InitSize(zstdgpu_ResourceInfo *outInfo,
 
 static void zstdgpu_ResourceInfo_Stage_0_InitOffsetGpuOnly(zstdgpu_ResourceInfo *outInfo)
 {
-    uint32_t byteOffset = 0;
+    uint64_t byteOffset = 0;
     ZSTDGPU_ALL_BUFFERS_LIST_STAGE_0()
     outInfo->gpuOnly_ByteCount[0] = byteOffset;
 }
 
 static void zstdgpu_ResourceInfo_Stage_1_InitOffsetGpuOnly(zstdgpu_ResourceInfo *outInfo)
 {
-    uint32_t byteOffset = 0;
+    uint64_t byteOffset = 0;
     ZSTDGPU_ALL_BUFFERS_LIST_STAGE_1()
     outInfo->gpuOnly_ByteCount[1] = byteOffset;
 }
 
 static void zstdgpu_ResourceInfo_Stage_2_InitOffsetGpuOnly(zstdgpu_ResourceInfo *outInfo)
 {
-    uint32_t byteOffset = 0;
+    uint64_t byteOffset = 0;
     ZSTDGPU_ALL_BUFFERS_LIST_STAGE_2()
     outInfo->gpuOnly_ByteCount[2] = byteOffset;
 }
@@ -397,21 +397,21 @@ static void zstdgpu_ResourceInfo_Stage_2_InitOffsetGpuOnly(zstdgpu_ResourceInfo 
 
 static void zstdgpu_ResourceInfo_Stage_0_InitOffsetCpu2Gpu(zstdgpu_ResourceInfo *outInfo)
 {
-    uint32_t byteOffset = 0;
+    uint64_t byteOffset = 0;
     ZSTDGPU_BUFFERS_LIST_UPLOAD_STAGE_0()
     outInfo->cpu2Gpu_ByteCount[0] = byteOffset;
 }
 
 static void zstdgpu_ResourceInfo_Stage_1_InitOffsetCpu2Gpu(zstdgpu_ResourceInfo *outInfo)
 {
-    uint32_t byteOffset = 0;
+    uint64_t byteOffset = 0;
     ZSTDGPU_BUFFERS_LIST_UPLOAD_STAGE_1()
     outInfo->cpu2Gpu_ByteCount[1] = byteOffset;
 }
 
 static void zstdgpu_ResourceInfo_Stage_2_InitOffsetCpu2Gpu(zstdgpu_ResourceInfo *outInfo)
 {
-    uint32_t byteOffset = 0;
+    uint64_t byteOffset = 0;
     ZSTDGPU_BUFFERS_LIST_UPLOAD_STAGE_2()
     outInfo->cpu2Gpu_ByteCount[2] = byteOffset;
 }
@@ -424,21 +424,21 @@ static void zstdgpu_ResourceInfo_Stage_2_InitOffsetCpu2Gpu(zstdgpu_ResourceInfo 
 
 static void zstdgpu_ResourceInfo_Stage_0_InitOffsetGpu2Cpu(zstdgpu_ResourceInfo *outInfo)
 {
-    uint32_t byteOffset = 0;
+    uint64_t byteOffset = 0;
     ZSTDGPU_BUFFERS_LIST_READBACK_STAGE_0()
     outInfo->gpu2Cpu_ByteCount[0] = byteOffset;
 }
 
 static void zstdgpu_ResourceInfo_Stage_1_InitOffsetGpu2Cpu(zstdgpu_ResourceInfo *outInfo)
 {
-    uint32_t byteOffset = 0;
+    uint64_t byteOffset = 0;
     ZSTDGPU_BUFFERS_LIST_READBACK_STAGE_1()
     outInfo->gpu2Cpu_ByteCount[1] = byteOffset;
 }
 
 static void zstdgpu_ResourceInfo_Stage_2_InitOffsetGpu2Cpu(zstdgpu_ResourceInfo *outInfo)
 {
-    uint32_t byteOffset = 0;
+    uint64_t byteOffset = 0;
     ZSTDGPU_BUFFERS_LIST_READBACK_STAGE_2()
     outInfo->gpu2Cpu_ByteCount[2] = byteOffset;
 }

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -395,6 +395,7 @@ static inline void zstdgpu_ParseFrameHeader(ZSTDGPU_PARAM_INOUT(uint64_t) window
         // 2^64-1 bytes (16 EB)."
         windowSize = uncompSize;
     }
+    ZSTDGPU_ASSERT(windowSize <= (1ull << kzstdgpu_SeqOffset_Encoded_BitBase) - 1ull);
 }
 
 static inline void zstdgpu_ShaderEntry_ParseFrame(ZSTDGPU_PARAM_INOUT(zstdgpu_FrameInfo) outFrameInfo,
@@ -3187,129 +3188,10 @@ static void zstdgpu_SequenceOffsets_Init(ZSTDGPU_PARAM_INOUT(uint32_t) offset1,
     //  - we initialize offset3 to "final" (resulting offset after executing all sequences) offset3 from previous block
     //
     // but we apply special encoding, so they could be either replaced by "non-repeat" offsets or used multiple times
-    // with "-1 byte" operation (when llen == 0 and "repeat" offset is 3), see `zstdgpu_SequenceOffsets_Update2`
+    // with "-1 byte" operation (when llen == 0 and "repeat" offset is 3), see `zstdgpu_UpdatePreviousAndRecomputeIncoming`
     offset1 = zstdgpu_EncodeSeqRepeatOffset(1);
     offset2 = zstdgpu_EncodeSeqRepeatOffset(2);
     offset3 = zstdgpu_EncodeSeqRepeatOffset(3);
-}
-
-static uint32_t zstdgpu_SequenceOffsets_Update(ZSTDGPU_PARAM_INOUT(uint32_t) offset1,
-                                               ZSTDGPU_PARAM_INOUT(uint32_t) offset2,
-                                               ZSTDGPU_PARAM_INOUT(uint32_t) offset3,
-                                               uint32_t offset,
-                                               uint32_t llen)
-{
-    uint32_t actualOffset = offset;
-    if (offset > 3u)
-    {
-        offset3 = offset2;
-        offset2 = offset1;
-        offset1 = offset;
-    }
-    else
-    {
-        if (llen != 0)
-        {
-            if (offset == 1u)
-            {
-                actualOffset = offset1;
-                //offset3 = offset3
-                //offset2 = offset2
-                //offset1 = actualOffset1
-            }
-            else if (offset == 2u)
-            {
-                actualOffset = offset2;
-                //offset3 = offset3
-                offset2 = offset1;
-                offset1 = actualOffset;
-            }
-            else
-            {
-                actualOffset = offset3;
-                offset3 = offset2;
-                offset2 = offset1;
-                offset1 = actualOffset;
-            }
-        }
-        else
-        {
-            if (offset == 1u)
-            {
-                actualOffset = offset2;
-                //offset3 = offset3
-                offset2 = offset1;
-                offset1 = actualOffset;
-            }
-            else if (offset == 2u)
-            {
-                actualOffset = offset3;
-                offset3 = offset2;
-                offset2 = offset1;
-                offset1 = actualOffset;
-            }
-            else
-            {
-                if (offset1 > 3u)
-                {
-                    // case 1: if we have actual offset (bit 31 is 0) -- we subtract a byte
-                    // case 2: if the offset is "repeat offset" (bit 31 is 1, bits 29 and 30 encode previous "repeat offset")
-                    //         which depending on previous block. We keep subtracting bytes
-                    actualOffset = offset1 - 1u;
-                }
-                else if (offset1 > 0) // we don't have valid offset, but we have to subtract one byte, so we re-encode "repeat offset"
-                {
-                    // in the encoding
-                    //      - we set offs[31] bit to 1 to mark this uint32_t as "encoded"
-                    //      - we set offs[30:29] to the "repeated offset"
-                    //      - we set all other bits to 1, so it behaves as -1 (which is a starting bit)
-                    actualOffset = zstdgpu_EncodeSeqRepeatOffset(offset1);
-                }
-                else
-                {
-                    // offset must not be zero
-                    ZSTDGPU_BREAK();
-                }
-                offset3 = offset2;
-                offset2 = offset1;
-                offset1 = actualOffset;
-            }
-        }
-    }
-    return actualOffset;
-}
-
-static uint32_t zstdgpu_SequenceOffsets_Update2(ZSTDGPU_PARAM_INOUT(uint32_t) offset1,
-                                                ZSTDGPU_PARAM_INOUT(uint32_t) offset2,
-                                                ZSTDGPU_PARAM_INOUT(uint32_t) offset3,
-                                                uint32_t offset,
-                                                uint32_t llen)
-{
-    uint32_t encodedOffset = offset;
-    if (offset <= 3u)
-    {
-        offset += llen == 0u ? 1u : 0u;
-#if 0
-        if (offset == 4u)
-        {
-            // case 1: if we have an actual offset (bit 31 is 0) -- we subtract a byte
-            // case 2: if the offset is "repeat offset" (bit 31 is 1, bits 29 and 30 encode previous "repeat offset")
-            //         which depending on previous block. We keep subtracting bytes
-            encodedOffset = offset1 - 1u;
-        }
-        else
-        {
-            encodedOffset = (offset == 3u) ? offset3 : ((offset == 2u) ? offset2 : offset1);
-        }
-#else
-        encodedOffset = (offset < 3u) ? (offset < 2u ? offset1 : offset2) : (offset < 4u ? offset3 : (offset1 - 1u));
-#endif
-    }
-
-    offset3 = offset >= 3u ? offset2 : offset3;
-    offset2 = offset >= 2u ? offset1 : offset2;
-    offset1 = encodedOffset;
-    return encodedOffset;
 }
 
 static zstdgpu_SeqStreamInfo zstdgpu_LoadSeqStreamInfo(ZSTDGPU_PARAM_INOUT(zstdgpu_DecompressSequences_SRT) srt, uint32_t seqStreamIdx)
@@ -3372,18 +3254,20 @@ static void zstdgpu_ReadSeqBitsAndDecompress(ZSTDGPU_PARAM_INOUT(zstdgpu_Backwar
 
     ZSTDGPU_ASSERT(symbolLLen < 36);
     ZSTDGPU_ASSERT(symbolMLen < 53);
+    ZSTDGPU_ASSERT(symbolOffs <= (kzstdgpu_SeqOffset_Encoded_BitBase - 1));
+    const uint32_t symbolOffs_Clamped = zstdgpu_MinU32(symbolOffs, kzstdgpu_SeqOffset_Encoded_BitBase - 1);
 
     const uint32_t llenInfo = SEQ_LITERAL_LENGTH_EXTRA_BITS_AND_BASELINES[symbolLLen];
     const uint32_t mlenInfo = SEQ_MATCH_LENGTH_EXTRA_BITS_AND_BASELINES[symbolMLen];
     const uint32_t bitcntLLen = llenInfo & 31;
-    const uint32_t bitcntOffs = symbolOffs;
+    const uint32_t bitcntOffs = symbolOffs_Clamped;
     const uint32_t bitcntMLen = mlenInfo & 31;
 
     const uint32_t bitsOffs = zstdgpu_Backward_BitBuffer_V0_Get(bitBuffer, bitcntOffs);
     const uint32_t bitsMLen = zstdgpu_Backward_BitBuffer_V0_Get(bitBuffer, bitcntMLen);
     const uint32_t bitsLLen = zstdgpu_Backward_BitBuffer_V0_Get(bitBuffer, bitcntLLen);
 
-    outOffs = (1u << symbolOffs) + bitsOffs;
+    outOffs = (1u << symbolOffs_Clamped) + bitsOffs;
     outMLen = (mlenInfo >> 5) + bitsMLen;
     outLLen = (llenInfo >> 5) + bitsLLen;
 }
@@ -3490,7 +3374,7 @@ static void zstdgpu_ShaderEntry_DecompressSequences_MultiStream(ZSTDGPU_PARAM_IN
                 zstdgpu_FseElem_Symbol(fseElemMLen),
                 llen, offs, mlen
             );
-            offs = zstdgpu_SequenceOffsets_Update2(offset1, offset2, offset3, offs, llen);
+            offs = zstdgpu_UpdatePreviousAndRecomputeIncoming(offset1, offset2, offset3, offs, llen);
 
             // TODO: output totalSize per iteration to automatically compute prefix
             totalSize += llen + mlen;
@@ -3639,7 +3523,7 @@ static void zstdgpu_ShaderEntry_DecompressSequences_SingleStream(ZSTDGPU_PARAM_I
             zstdgpu_FseElem_Symbol(packedFseElemOffs),
             zstdgpu_FseElem_Symbol(packedFseElemMLen),
             llen, offs, mlen);
-        offs = zstdgpu_SequenceOffsets_Update2(offset1, offset2, offset3, offs, llen);
+        offs = zstdgpu_UpdatePreviousAndRecomputeIncoming(offset1, offset2, offset3, offs, llen);
 
         /*totalSize += llen + mlen;*/
         totalMLen += mlen;
@@ -3788,7 +3672,7 @@ static void zstdgpu_ShaderEntry_DecompressSequences_MultiStream_LdsOutCache(ZSTD
                     zstdgpu_FseElem_Symbol(fseElemMLen),
                     llen, offs, mlen
                 );
-                offs = zstdgpu_SequenceOffsets_Update2(offset1, offset2, offset3, offs, llen);
+                offs = zstdgpu_UpdatePreviousAndRecomputeIncoming(offset1, offset2, offset3, offs, llen);
 
                 totalMLen += mlen;
 

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -1054,15 +1054,14 @@ static void zstdgpu_ShaderEntry_ParseCompressedBlocks(ZSTDGPU_PARAM_INOUT(zstdgp
         if (literalBlockType == 0)
         {
             outBlockData.literal.offs = zstdgpu_Forward_BitBuffer_GetByteOffset(buffer);
-            outBlockData.literal.offs = zstdgpu_EncodeRawLitOffset(outBlockData.literal.offs);
+            outBlockData.literal.size = zstdgpu_EncodeRawLitTypeIntoLitSize(regeneratedSize);
             zstdgpu_Forward_BitBuffer_Skip(buffer, regeneratedSize);
         }
         else
         {
             outBlockData.literal.offs = zstdgpu_Forward_BitBuffer_Get(buffer, 8);
-            outBlockData.literal.offs = zstdgpu_EncodeRleLitOffset(outBlockData.literal.offs);
+            outBlockData.literal.size = zstdgpu_EncodeRleLitTypeIntoLitSize(regeneratedSize);
         }
-        outBlockData.literal.size = regeneratedSize;
 
         const uint32_t rawStreamCountPerWave = WaveActiveCountBits(literalBlockType == 0);
         const uint32_t rleStreamCountPerWave = WaveActiveCountBits(literalBlockType == 1);
@@ -1128,8 +1127,8 @@ static void zstdgpu_ShaderEntry_ParseCompressedBlocks(ZSTDGPU_PARAM_INOUT(zstdgp
         }
         const uint32_t regeneratedOffset = WaveReadLaneFirst(regeneratedOffsetPerWave) + WavePrefixSum(regeneratedSize);
 
-        outBlockData.literal.offs = zstdgpu_EncodeCmpLitOffset(regeneratedOffset);
-        outBlockData.literal.size = regeneratedSize;
+        outBlockData.literal.offs = regeneratedOffset;
+        outBlockData.literal.size = zstdgpu_EncodeCmpLitTypeIntoLitSize(regeneratedSize);
         outBlockData.litStreamIndex = hufLitStreamStart;
 
         //  Note: `Compressed_Size` includes the size of the Huffman Tree description when it is present.
@@ -1314,7 +1313,7 @@ static void zstdgpu_ShaderEntry_ParseCompressedBlocks(ZSTDGPU_PARAM_INOUT(zstdgp
     //         of the remaining portion of literals not copied via sequence execution.
     const uint32_t blockIndexInFrame = srt.inGlobalBlockIndexPerCmpBlock[threadId];
 
-    srt.inoutBlockSizePrefix[blockIndexInFrame] = outBlockData.literal.size;
+    srt.inoutBlockSizePrefix[blockIndexInFrame] = zstdgpu_DecodeLitSize(outBlockData.literal.size);
 
     // A "HufLit" is a literal block that carries a Huffman Table (literalBlockType == 2, i.e. FullTree).
     // Its hufLitId (compacted, in cmpLit-encounter order) keys the per-HT literal stream range.
@@ -4139,19 +4138,19 @@ static void zstdgpu_ShaderEntry_ExecuteSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_Exe
             }
         }
 
-        const uint32_t litType = WaveReadLaneFirst(zstdgpu_DecodeLitOffsetType(literal.offs));
-        const uint32_t litOffs = zstdgpu_DecodeLitOffset(literal.offs);
-        const uint32_t litSize = literal.size;
+        const uint32_t litType = WaveReadLaneFirst(zstdgpu_DecodeLitType(literal.size));
+        const uint32_t litSize = zstdgpu_DecodeLitSize(literal.size);
+        const uint32_t litOffs = literal.offs;
 
-        if (zstdgpu_CheckLitOffsetTypeCmp(litType))
+        if (zstdgpu_IsLitTypeCmp(litType))
         {
             zstdgpu_ExecuteSequences_Lit(srt, srt.inDecompressedLiterals, litOffs, litOffs + litSize, blockByteBeg, blockByteEnd, seqOfs, seqEnd);
         }
-        else if (zstdgpu_CheckLitOffsetTypeRaw(litType))
+        else if (zstdgpu_IsLitTypeRaw(litType))
         {
             zstdgpu_ExecuteSequences_Lit(srt, srt.inCompressedData, litOffs, litOffs + litSize, blockByteBeg, blockByteEnd, seqOfs, seqEnd);
         }
-        else if (zstdgpu_CheckLitOffsetTypeRle(litType))
+        else if (zstdgpu_IsLitTypeRle(litType))
         {
             // NOTE(pamartis): RLE literals contain actual symbol instead of offset, so we set the offsets to zero.
             const uint32_t symbol = litOffs;

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -453,6 +453,13 @@ static inline uint32_t zstdgpu_AlignUp(uint32_t offset, uint32_t alignment)
     return (offset + alignmentBits) & ~alignmentBits;
 }
 
+static inline uint64_t zstdgpu_AlignUp64(uint64_t offset, uint64_t alignment)
+{
+    ZSTDGPU_ASSERT(0 == (alignment & (alignment - 1)));
+    const uint64_t alignmentBits = alignment - 1;
+    return (offset + alignmentBits) & ~alignmentBits;
+}
+
 #ifdef __hlsl_dx_compiler
 #   define ZSTDGPU_FOR_WORK_ITEMS(workItemId, workItemCount, groupThreadId, groupThreadCount)   \
         for (ZSTDGPU_WARN_DISABLE_DXC(-Wfor-redefinition, uint32_t workItemId = groupThreadId); workItemId < workItemCount; workItemId += groupThreadCount)

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -767,6 +767,7 @@ static inline uint32_t zstdgpu_IsLitTypeCmp(uint32_t x)
 
 static inline uint32_t zstdgpu_EncodeSeqRepeatOffset(uint32_t x)
 {
+    ZSTDGPU_ASSERT(x >= 1 && x <= 3);
     // NOTE(pamartis):
     //      - we set bit 29 to mark this uint32_t as "encoded"
     //      - we set bits [28:27] to the "repeated offset"
@@ -774,19 +775,32 @@ static inline uint32_t zstdgpu_EncodeSeqRepeatOffset(uint32_t x)
     return (x << 27u) | 0x27ffffffu;
 }
 
+
+static const uint32_t kzstdgpu_SeqOffset_RepType_BitBase = 27u;
+static const uint32_t kzstdgpu_SeqOffset_RepType_BitMask = 3u << kzstdgpu_SeqOffset_RepType_BitBase;
+
+static const uint32_t kzstdgpu_SeqOffset_Encoded_BitBase = 29u;
+static const uint32_t kzstdgpu_SeqOffset_Encoded_BitMask = 1u << kzstdgpu_SeqOffset_Encoded_BitBase;
+
+static const uint32_t kzstdgpu_SeqOffset_Lookback_BitBase = 30u;
+static const uint32_t kzstdgpu_SeqOffset_Lookback_BitMask = 3u << kzstdgpu_SeqOffset_Lookback_BitBase;
+
+
+static inline uint32_t zstdgpu_DecodeSeqRepeatOffsetEncoded(uint32_t x)
+{
+    return x & kzstdgpu_SeqOffset_Encoded_BitMask;
+}
+
 static inline uint32_t zstdgpu_DecodeSeqRepeatOffset(uint32_t x)
 {
-    return (x >> 27u) & 3u;
+    ZSTDGPU_ASSERT_MSG(zstdgpu_DecodeSeqRepeatOffsetEncoded(x) > 0, "offset(0x%08x) is NOT REPEAT-encoded while the function expects so.", x);
+    return (x & kzstdgpu_SeqOffset_RepType_BitMask) >> kzstdgpu_SeqOffset_RepType_BitBase;
 }
 
 static inline uint32_t zstdgpu_DecodeSeqRepeatOffsetSubtractedBytes(uint32_t x)
 {
+    ZSTDGPU_ASSERT_MSG(zstdgpu_DecodeSeqRepeatOffsetEncoded(x) > 0, "offset(0x%08x) is NOT REPEAT-encoded while the function expects so.", x);
     return ~(x | 0xf8000000u);
-}
-
-static inline uint32_t zstdgpu_DecodeSeqRepeatOffsetEncoded(uint32_t x)
-{
-    return x & 0x20000000;
 }
 
 static inline uint32_t zstdgpu_DecodeSeqRepeatOffsetAndApplyPreviousOffsets(uint32_t offset, uint32_t prevOffs1, uint32_t prevOffs2, uint32_t prevOffs3)
@@ -795,6 +809,49 @@ static inline uint32_t zstdgpu_DecodeSeqRepeatOffsetAndApplyPreviousOffsets(uint
     const uint32_t cnt = zstdgpu_DecodeSeqRepeatOffsetSubtractedBytes(offset);
     offset = (idx == 3u) ? prevOffs3 : ((idx == 2u) ? prevOffs2 : prevOffs1);
     return offset - cnt;
+}
+
+static inline uint32_t zstdgpu_SubtractByteFromSeqOffset(uint32_t x)
+{
+    // NOTE(pamartis): Because the offset can be either "encoded" or normal, we have to check underflows differently
+    uint32_t bit = zstdgpu_DecodeSeqRepeatOffsetEncoded(x);
+    ZSTDGPU_ASSERT((0 == bit && x >= 4 && x < kzstdgpu_SeqOffset_Encoded_BitMask) || (0 != bit && zstdgpu_DecodeSeqRepeatOffsetSubtractedBytes(x) < ((1u << kzstdgpu_SeqOffset_RepType_BitBase) - 1)));
+
+    // case 1: if we have an actual offset (bit 29 is 0) -- we subtract a byte
+    // case 2: if the offset is "repeat offset" (bit 29 is 1, bits 28 and 27 encode previous "repeat offset")
+    //         which depending on previous block. We keep subtracting bytes
+    return x - 1;
+}
+
+static uint32_t zstdgpu_UpdatePreviousAndRecomputeIncoming(ZSTDGPU_PARAM_INOUT(uint32_t) offset1,
+                                                           ZSTDGPU_PARAM_INOUT(uint32_t) offset2,
+                                                           ZSTDGPU_PARAM_INOUT(uint32_t) offset3,
+                                                           uint32_t offset,
+                                                           uint32_t llen)
+{
+    ZSTDGPU_ASSERT_MSG(offset < 0x20000000, "Incoming 'offset'(0x%08x) overflow into 'repeat' offset bit", offset);
+    uint32_t encodedOffset = offset;
+    if (offset <= 3u)
+    {
+        offset += llen == 0u ? 1u : 0u;
+#if 0
+        if (offset == 4u)
+        {
+            encodedOffset = zstdgpu_SubtractByteFromSeqOffset(offset1);
+        }
+        else
+        {
+            encodedOffset = (offset == 3u) ? offset3 : ((offset == 2u) ? offset2 : offset1);
+        }
+#else
+        encodedOffset = (offset < 3u) ? (offset < 2u ? offset1 : offset2) : (offset < 4u ? offset3 : zstdgpu_SubtractByteFromSeqOffset(offset1));
+#endif
+    }
+
+    offset3 = offset >= 3u ? offset2 : offset3;
+    offset2 = offset >= 2u ? offset1 : offset2;
+    offset1 = encodedOffset;
+    return encodedOffset;
 }
 
 static inline void zstdgpu_DecodeSeqRepeatOffsetsAndApplyPreviousOffsets(ZSTDGPU_PARAM_INOUT(uint32_t) offset1,

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -706,49 +706,54 @@ static inline uint32_t zstdgpu_Decode31BitLookbackFlags(uint32_t x)
     return x & 0x80000000u;
 }
 
-static inline uint32_t zstdgpu_EncodeRawLitOffset(uint32_t x)
+/**
+ * NOTE(pamartis): The 2-bit literal type (Raw/Rle/Cmp) is packed into the top 2 bits of the literal
+ * `size` field because it is within `kzstdgpu_MaxCount_LiteralBytes` (128 KiB) range, so the
+ * top 2 bits are always available.
+ */
+static inline uint32_t zstdgpu_EncodeRawLitTypeIntoLitSize(uint32_t x)
 {
     ZSTDGPU_ASSERT(x <= ~0xc0000000u);
     return (x & ~0xc0000000u) | 0x40000000u;
 }
 
-static inline uint32_t zstdgpu_EncodeRleLitOffset(uint32_t x)
+static inline uint32_t zstdgpu_EncodeRleLitTypeIntoLitSize(uint32_t x)
 {
-    ZSTDGPU_ASSERT(x <= 0x000000ffu);
+    ZSTDGPU_ASSERT(x <= ~0xc0000000u);
     return (x & ~0xc0000000u) | 0x80000000u;
 }
 
-static inline uint32_t zstdgpu_EncodeCmpLitOffset(uint32_t x)
+static inline uint32_t zstdgpu_EncodeCmpLitTypeIntoLitSize(uint32_t x)
 {
     ZSTDGPU_ASSERT(x <= ~0xc0000000u);
     return (x & ~0xc0000000u) | 0xc0000000u;
 }
 
-static inline uint32_t zstdgpu_DecodeLitOffsetType(uint32_t x)
+static inline uint32_t zstdgpu_DecodeLitType(uint32_t x)
 {
     const uint32_t type = x & 0xc0000000u;
     ZSTDGPU_ASSERT(type != 0);
     return type;
 }
 
-static inline uint32_t zstdgpu_DecodeLitOffset(uint32_t x)
+static inline uint32_t zstdgpu_DecodeLitSize(uint32_t x)
 {
-    const uint32_t offset = x & ~0xc0000000u;
+    const uint32_t size = x & ~0xc0000000u;
     ZSTDGPU_ASSERT((x & 0xc0000000u) != 0);
-    return offset;
+    return size;
 }
 
-static inline uint32_t zstdgpu_CheckLitOffsetTypeRaw(uint32_t x)
+static inline uint32_t zstdgpu_IsLitTypeRaw(uint32_t x)
 {
     return x == 0x40000000u ? 1u : 0u;
 }
 
-static inline uint32_t zstdgpu_CheckLitOffsetTypeRle(uint32_t x)
+static inline uint32_t zstdgpu_IsLitTypeRle(uint32_t x)
 {
     return x == 0x80000000u ? 1u : 0u;
 }
 
-static inline uint32_t zstdgpu_CheckLitOffsetTypeCmp(uint32_t x)
+static inline uint32_t zstdgpu_IsLitTypeCmp(uint32_t x)
 {
     return x == 0xc0000000u ? 1u : 0u;
 }

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -434,7 +434,7 @@ static void zstdgpu_Test_DecompressSequences(zstdgpu_ResourceDataCpu & cpuRes, z
             // we need to setup it properly
             for (uint32_t i = 0; i < cpuRes.Counters->Blocks_CMP; ++i)
             {
-                const uint32_t literalSize = cpuRes.CompressedBlocks[i].literal.size;
+                const uint32_t literalSize = zstdgpu_DecodeLitSize(cpuRes.CompressedBlocks[i].literal.size);
                 const uint32_t dstBlockIndex = cpuRes.GlobalBlockIndexPerCmpBlock[i];
                 cpuRes.BlockSizePrefix[dstBlockIndex] = literalSize;
             }

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -1529,9 +1529,9 @@ static int demoRun(void *demoCtx)
     }
     zstdgpu_SetupOutputs(perRequestContext, zstdUnCompressedFramesMemory.bufGpu, zstdUnCompressedFramesMemorySizeInBytes, zstdUnCompressedFramesRefs.bufGpu, fbInfo.frameCount);
 
-    uint32_t readbackHeapSize[3] = { 0, 0, 0 };
-    uint32_t uploadHeapSize[3] = {0, 0, 0 };
-    uint32_t defaultHeapSize[3] = {0, 0, 0};
+    uint64_t readbackHeapSize[3] = { 0, 0, 0 };
+    uint64_t uploadHeapSize[3] = {0, 0, 0 };
+    uint64_t defaultHeapSize[3] = {0, 0, 0};
     uint32_t descriptorCount[3] = { 0, 0, 0 };
 
     for (uint32_t frameIndex = 0; frameIndex < repCount; ++frameIndex)
@@ -1604,9 +1604,9 @@ static int demoRun(void *demoCtx)
                 {
                     if (extMem /** a scenario with supplying external memory */)
                     {
-                        uint32_t defaultHeapSizeReq = 0;
-                        uint32_t uploadHeapSizeReq = 0;
-                        uint32_t readbackHeapSizeReq = 0;
+                        uint64_t defaultHeapSizeReq = 0;
+                        uint64_t uploadHeapSizeReq = 0;
+                        uint64_t readbackHeapSizeReq = 0;
                         uint32_t descriptorCountReq = 0;
 
                         zstdgpu_GetAllStageGpuMemoryRequirement(&defaultHeapSizeReq, &uploadHeapSizeReq, &readbackHeapSizeReq, &descriptorCountReq, perRequestContext);
@@ -1636,9 +1636,9 @@ static int demoRun(void *demoCtx)
                     {
                         if (extMem /** a scenario with supplying external memory */)
                         {
-                            uint32_t defaultHeapSizeReq = 0;
-                            uint32_t uploadHeapSizeReq = 0;
-                            uint32_t readbackHeapSizeReq = 0;
+                            uint64_t defaultHeapSizeReq = 0;
+                            uint64_t uploadHeapSizeReq = 0;
+                            uint64_t readbackHeapSizeReq = 0;
                             uint32_t descriptorCountReq = 0;
 
                             zstdgpu_GetGpuMemoryRequirement(&defaultHeapSizeReq, &uploadHeapSizeReq, &readbackHeapSizeReq, &descriptorCountReq, perRequestContext, stageIndex);


### PR DESCRIPTION
This PR 
- moves 2-bit literal type being packed into `offset` field to `size` field of `zstdgpu_OffsetAndSize` to mainly support "raw" literals in input buffers `>1 GiB`.
- switches to `uint64_t` type for heap offsets and sizes to support temporal memory `>4 GiB`
- validates supported sequence offsets and frame window sizes are `<512 MiB`.