### PR TITLE
zstdgpu_tests: fix build against current zstdgpu.lib API + link surface

### DIFF
--- a/zstd/zstdgpu_tests/gpuwork.cpp
+++ b/zstd/zstdgpu_tests/gpuwork.cpp
@@ -103,11 +103,11 @@ Frames ZstdDecompressionWork::Decompress(std::vector<uint8_t>& compressedData, O
     struct DecompressionStageResources
     {
         com_ptr<ID3D12Heap> defaultHeap;
-        uint32_t defaultHeapSizeBytes = 0;
+        uint64_t defaultHeapSizeBytes = 0;
         com_ptr<ID3D12Heap> uploadHeap;
-        uint32_t uploadHeapSizeBytes = 0;
+        uint64_t uploadHeapSizeBytes = 0;
         com_ptr<ID3D12Heap> readbackHeap;
-        uint32_t readbackHeapSizeBytes = 0;
+        uint64_t readbackHeapSizeBytes = 0;
         com_ptr<ID3D12DescriptorHeap> shaderVisibleDescriptorHeap;
         uint32_t shaderVisibleDescriptorCount = 0;
     };

--- a/zstd/zstdgpu_tests/libzstdgpu.cpp
+++ b/zstd/zstdgpu_tests/libzstdgpu.cpp
@@ -138,9 +138,9 @@ namespace Decompression
     HRESULT _cdecl GetHeapMemorySizesForStage(
         void* perRequestContext,
         uint32_t stage,
-        uint32_t* defaultHeapSizeBytes,
-        uint32_t* uploadHeapSizeBytes,
-        uint32_t* readbackHeapSizeBytes,
+        uint64_t* defaultHeapSizeBytes,
+        uint64_t* uploadHeapSizeBytes,
+        uint64_t* readbackHeapSizeBytes,
         uint32_t* shaderVisibleDescriptorCount)
     {
         return hresult_from_status(zstdgpu_GetGpuMemoryRequirement(

--- a/zstd/zstdgpu_tests/libzstdgpu.cpp
+++ b/zstd/zstdgpu_tests/libzstdgpu.cpp
@@ -12,18 +12,6 @@
 
 #define TTA_ASSERT_IMPL
 
-#if defined(__clang__)
-#   ifndef __EXCEPTIONS
-#       define TTA_ASSERT_NOEXCEPT 1
-#   endif
-#elif defined(_MSC_VER)
-#   ifndef _CPPUNWIND
-#       define TTA_ASSERT_NOEXCEPT 1
-#   endif
-#else
-#   error Unknown compiler
-#endif
-
 #pragma warning(push)
 #pragma warning(disable: 4611) /* warning C4611: interaction between 'function' and C++ object destruction is non-portable */
 #include <tta_assert.h>

--- a/zstd/zstdgpu_tests/libzstdgpu.cpp
+++ b/zstd/zstdgpu_tests/libzstdgpu.cpp
@@ -6,6 +6,30 @@
 #include <windows.h>
 #include <winrt/base.h>
 
+// TTA_ASSERT_IMPL translation unit for zstdgpu_tests.exe.
+// zstdgpu.lib references tta_ symbols from tta_assert.h; every exe
+// linking it needs exactly one TU that defines TTA_ASSERT_IMPL first.
+
+#define TTA_ASSERT_IMPL
+
+#if defined(__clang__)
+#   ifndef __EXCEPTIONS
+#       define TTA_ASSERT_NOEXCEPT 1
+#   endif
+#elif defined(_MSC_VER)
+#   ifndef _CPPUNWIND
+#       define TTA_ASSERT_NOEXCEPT 1
+#   endif
+#else
+#   error Unknown compiler
+#endif
+
+#pragma warning(push)
+#pragma warning(disable: 4611) /* warning C4611: interaction between 'function' and C++ object destruction is non-portable */
+#include <tta_assert.h>
+#pragma warning(pop)
+
+
 namespace Decompression
 {
     HRESULT hresult_from_status(zstdgpu_Status status)

--- a/zstd/zstdgpu_tests/libzstdgpu.h
+++ b/zstd/zstdgpu_tests/libzstdgpu.h
@@ -52,9 +52,9 @@ namespace Decompression
     HRESULT _cdecl GetHeapMemorySizesForStage(
         void* perRequestContext,
         uint32_t stage, // 0-based stage index ( bounded by the totalStageCount returned by SetupDecompressionStages )
-        uint32_t* defaultHeapSizeBytes,
-        uint32_t* uploadHeapSizeBytes,
-        uint32_t* readbackHeapSizeBytes,
+        uint64_t* defaultHeapSizeBytes,
+        uint64_t* uploadHeapSizeBytes,
+        uint64_t* readbackHeapSizeBytes,
         uint32_t* shaderVisibleDescriptorCount);
 
     HRESULT _cdecl AddDecompressionStageToCommandlist(
@@ -143,9 +143,9 @@ namespace Decompression
         // Returns true if the the specified stage requires allocations, false if the stage was not required.
         bool TryGetHeapMemorySizes(
             uint32_t stage,
-            uint32_t* defaultHeapSizeBytes,
-            uint32_t* uploadHeapSizeBytes,
-            uint32_t* readbackHeapSizeBytes,
+            uint64_t* defaultHeapSizeBytes,
+            uint64_t* uploadHeapSizeBytes,
+            uint64_t* readbackHeapSizeBytes,
             uint32_t* shaderVisibleDescriptorCount)
         {
             HRESULT hr = GetHeapMemorySizesForStage(


### PR DESCRIPTION
Two build fixes for zstdgpu_tests.exe against current zstdgpu on development.

1. Widen libzstdgpu heap-size out-params to uint64_t

zstd/zstdgpu/zstdgpu.h's zstdgpu_GetGpuMemoryRequirement was widened in #123 to take uint64_t for the default/upload/readback heap-size out-params, but the libzstdgpu wrapper in zstd/zstdgpu_tests/ still declares them as uint32_t. Build fails with C2664 at libzstdgpu.cpp:146.

Fix — widen the wrapper chain to match: libzstdgpu.h, libzstdgpu.cpp, and the DecompressionStageResources fields in gpuwork.cpp on the caller side. shaderVisibleDescriptorCount stays uint32_t* (count, not byte size). CreateHeap already takes size_t, so no further caller changes needed.

2. Provide TTA_ASSERT_IMPL translation unit for zstdgpu_tests.exe

zstdgpu.lib (via zstd/zstdgpu/zstdgpu_assert.h) references tta_AssertAlways_0/1 and tta_AssertReport from zstd/ThirdParty/tta_assert.h — a single-header library that requires exactly one TU per exe to #define TTA_ASSERT_IMPL before including it. The demo does this at the end of zstdgpu_demo/main.cpp but zstdgpu_tests.exe was never wired up, so linking fails with LNK2001 for all three symbols on both x64 and ARM64.

Fix — add the same block near the top of libzstdgpu.cpp (same file we're already editing for fix #1). Uses raw #pragma warning(push/disable/pop) around the include instead of the ZSTDGPU_WARN_* macros the demo uses, because those macros are defined in zstdgpu_structs.h which isn't transitively included at this point in libzstdgpu.cpp. Semantically equivalent to the macro form.

Verification


Local build of zstd/zstdgpu_tests/zstdgpu_tests.vcxproj (x64, Release) compiles and links cleanly with both fixes applied.
Build on ADO in progress