### PR TITLE
zstdgpu/simplify: enables multi-stream sequence decompression/pulls up block destination computation into a separate pass

### DIFF
--- a/zstd/platform/x64/zstdgpu_demo_platform.cpp
+++ b/zstd/platform/x64/zstdgpu_demo_platform.cpp
@@ -74,7 +74,7 @@ static void CALLBACK zstdgpu_Demo_D3D12MessageCallback(D3D12_MESSAGE_CATEGORY ca
     wprintf(L"[%ls] %hs\n", zstdgpu_Demo_D3D12SeverityToWide(severity), pDescription);
 }
 
-ID3D12Device *zstdgpu_Demo_PlatformInit(uint32_t gpuVenId, uint32_t gpuDevId, bool d3dDbg)
+ID3D12Device *zstdgpu_Demo_PlatformInit(uint32_t gpuVenId, uint32_t gpuDevId, bool d3dDbg, bool d3dGbv)
 {
     // Default main thread to CPU 0
     SetThreadAffinityMask(GetCurrentThread(), 0x1);
@@ -102,7 +102,10 @@ ID3D12Device *zstdgpu_Demo_PlatformInit(uint32_t gpuVenId, uint32_t gpuDevId, bo
             ID3D12Debug1 *d3d12Debug1 = NULL;
             D3D12AID_CHECK(fnD3D12GetDebugInterface(D3D12AID_IID_PPV_ARGS(&d3d12Debug1)));
             d3d12Debug1->EnableDebugLayer();
-            d3d12Debug1->SetEnableGPUBasedValidation(TRUE);
+            if (d3dGbv)
+            {
+                d3d12Debug1->SetEnableGPUBasedValidation(TRUE);
+            }
             //d3d12Debug1->SetEnableSynchronizedCommandQueueValidation(FALSE /* otherwise enabled by default */);
             D3D12AID_SAFE_RELEASE(d3d12Debug1);
         }

--- a/zstd/platform/zstdgpu_demo_platform.h
+++ b/zstd/platform/zstdgpu_demo_platform.h
@@ -17,7 +17,7 @@ extern "C"
 {
 #endif
 
-struct ID3D12Device *zstdgpu_Demo_PlatformInit(uint32_t gpuVenId, uint32_t gpuDevId, bool d3dDbg);
+struct ID3D12Device *zstdgpu_Demo_PlatformInit(uint32_t gpuVenId, uint32_t gpuDevId, bool d3dDbg, bool d3dGbv);
 
 void zstdgpu_Demo_PlatformTerm(struct ID3D12Device *device);
 

--- a/zstd/zstdgpu/Shaders/ZstdGpuComputeDestBlockOffsets.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuComputeDestBlockOffsets.hlsl
@@ -1,0 +1,66 @@
+/**
+ * ZstdGpuComputeDestBlockOffsets.hlsl
+ *
+ * Computes the absolute destination offset of every uncompressed block.
+ *
+ * Copyright (c) Microsoft. All rights reserved.
+ * This code is licensed under the MIT License (MIT).
+ * THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+ * ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+ * IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+ *
+ * Advanced Technology Group (ATG)
+ * Author(s):   Pavel Martishevsky (pamartis@microsoft.com)
+ */
+
+#include "../zstdgpu_shaders.h"
+
+struct Consts
+{
+    uint32_t tgOffset;
+    uint32_t workItemCount;
+    uint32_t frameCount;
+};
+
+ConstantBuffer<Consts> Constants : register(b0);
+
+#include "../zstdgpu_srt_decl_bind.h"
+ZSTDGPU_COMPUTE_DEST_BLOCK_OFFSETS_SRT()
+#include "../zstdgpu_srt_decl_undef.h"
+
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=3), UAV(u0, numDescriptors=1)), RootConstants(b0, num32BitConstants=3)")]
+[numthreads(kzstdgpu_TgSizeX_ComputeDestBlockOffset, 1, 1)]
+void main(uint2 groupId : SV_GroupId, uint threadId : SV_GroupThreadId)
+{
+    const uint32_t blockIdx = zstdgpu_ConvertTo32BitGroupId(groupId, Constants.tgOffset) * kzstdgpu_TgSizeX_ComputeDestBlockOffset + threadId;
+    if (blockIdx >= Constants.workItemCount)
+    {
+        return;
+    }
+
+    zstdgpu_ComputeDestBlockOffsets_SRT srt;
+
+    #include "../zstdgpu_srt_decl_copy.h"
+    ZSTDGPU_COMPUTE_DEST_BLOCK_OFFSETS_SRT()
+    #include "../zstdgpu_srt_decl_undef.h"
+
+    const uint32_t frameIdx = zstdgpu_BinarySearch(srt.inPerFrameBlockCountAll, 0, Constants.frameCount, blockIdx);
+    const uint32_t firstFrameBlockIdx = srt.inPerFrameBlockCountAll[frameIdx];
+
+    uint32_t firstFrameBlockOffset = 0;
+    ZSTDGPU_BRANCH if (firstFrameBlockIdx > 0)
+    {
+        firstFrameBlockOffset = srt.inBlockSizePrefix[firstFrameBlockIdx - 1];
+    }
+
+    uint32_t blockOffset = 0;
+    ZSTDGPU_BRANCH if (blockIdx > 0)
+    {
+        blockOffset = srt.inBlockSizePrefix[blockIdx - 1];
+    }
+
+    srt.inoutBlockDestOffs[blockIdx] = srt.inUnCompressedFramesRefs[frameIdx].offs
+                                     + blockOffset
+                                     - firstFrameBlockOffset;
+}

--- a/zstd/zstdgpu/Shaders/ZstdGpuComputeDestSequenceOffsets.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuComputeDestSequenceOffsets.hlsl
@@ -30,7 +30,7 @@ ZSTDGPU_COMPUTE_DEST_SEQUENCE_OFFSETS_SRT()
 
 #define NUM_THREADS 256
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=7), UAV(u0, numDescriptors=1)), RootConstants(b0, num32BitConstants=2)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=5), UAV(u0, numDescriptors=1)), RootConstants(b0, num32BitConstants=2)")]
 [numthreads(NUM_THREADS, 1, 1)]
 void main(uint2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
 {
@@ -61,30 +61,7 @@ void main(uint2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
     seqSize -= seqOffs;
 
     const uint32_t blockIdx = srt.inSeqStreamToBlockId[seqStreamIdx];
-
-    const uint32_t frameCnt = srt.inCounters[0].Frames;
-    const uint32_t frameIdx = zstdgpu_BinarySearch(srt.inPerFrameBlockCountAll, 0, frameCnt, blockIdx);
-
-    const zstdgpu_OffsetAndSize dstFrameOffsAndSize = srt.inUnCompressedFramesRefs[frameIdx];
-
-    const uint32_t firstFrameBlockIdx = srt.inPerFrameBlockCountAll[frameIdx];
-
-    uint32_t firstFrameBlockOfs = 0;
-    // NOTE(pamartis): Without `ZSTDGPU_BRANCH`, there's out-of-bounds `ZstdInBlockSizePrefix` access detected by validation layer when
-    // DXC used: "Version: dxcompiler.dll: 1.6 - 1.6.2112.16 (e8295973c); dxil.dll: 1.6(101.6.2112.13)"
-    ZSTDGPU_BRANCH if (firstFrameBlockIdx > 0)
-    {
-        firstFrameBlockOfs = srt.inBlockSizePrefix[firstFrameBlockIdx - 1];
-    }
-
-    uint32_t blockOfs = 0;
-    // NOTE(pamartis): Without `ZSTDGPU_BRANCH`, there's out-of-bounds `ZstdInBlockSizePrefix` access detected by validation layer when
-    // DXC used: "Version: dxcompiler.dll: 1.6 - 1.6.2112.16 (e8295973c); dxil.dll: 1.6(101.6.2112.13)"
-    ZSTDGPU_BRANCH if (blockIdx > 0)
-    {
-        blockOfs = srt.inBlockSizePrefix[blockIdx - 1];
-    }
-    const uint32_t blockByteBeg = dstFrameOffsAndSize.offs + (blockOfs - firstFrameBlockOfs) + seqOffs;
+    const uint32_t blockByteBeg = srt.inBlockDestOffs[blockIdx] + seqOffs;
 
     srt.inoutDestSequenceOffsets[i] = blockByteBeg;
 }

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_MultiStream_2_LdsOutCache_32.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_MultiStream_2_LdsOutCache_32.hlsl
@@ -1,5 +1,5 @@
 /**
- * ZstdGpuDecompressSequences_MultiStream_8_LdsOutCache_32.hlsl
+ * ZstdGpuDecompressSequences_MultiStream_2_LdsOutCache_32.hlsl
  *
  * A compute shader that decompresses multiple FSE-compressed sequences streams per TG by sampling
  * FSE tables from L0, but limiting the number of sequences streams per TG to avoid L0 cache thrashing
@@ -12,8 +12,8 @@
  * dwords for each of M streams, flushes them to memory by storing N sequential dwords per each of M
  * streams to help hardware coalescing.
  *
- * The variant accumulating M=32 sequences per sequences stream and processing N=8 sequences streams
- * per TG of 32 threads (some threads are inactive during decoding, and become active during memory writes).
+ * The variant accumulating M=32 sequences per sequences stream and processing N=`TgSizeX_DecompressSequences / 2` sequences streams
+ * per TG of `TgSizeX_DecompressSequences` threads (some threads are inactive during decoding, and become active during memory writes).
  *
  * Copyright (c) Microsoft. All rights reserved.
  * This code is licensed under the MIT License (MIT).
@@ -26,6 +26,6 @@
  * Author(s):   Pavel Martishevsky (pamartis@microsoft.com)
  */
 
-#define kzstdgpu_DecompressSequences_StreamsPerTG 8
+#define kzstdgpu_DecompressSequences_ThreadsPerStream 2
 #define kzstdgpu_DecompressSequences_LdsStoreCache_DwCount 32
 #include "ZstdGpuDecompressSequences_MultiStream_LdsOutCache.hlsli"

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_MultiStream_4_LdsOutCache_32.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_MultiStream_4_LdsOutCache_32.hlsl
@@ -1,5 +1,5 @@
 /**
- * ZstdGpuDecompressSequences_MultiStream_4_LdsOutCache_128.hlsl
+ * ZstdGpuDecompressSequences_MultiStream_4_LdsOutCache_32.hlsl
  *
  * A compute shader that decompresses multiple FSE-compressed sequences streams per TG by sampling
  * FSE tables from L0, but limiting the number of sequences streams per TG to avoid L0 cache thrashing
@@ -12,8 +12,8 @@
  * dwords for each of M streams, flushes them to memory by storing N sequential dwords per each of M
  * streams to help hardware coalescing.
  *
- * The variant accumulating M=128 sequences per sequences stream and processing N=4 sequences streams
- * per TG of 32 threads (some threads are inactive during decoding, and become active during memory writes).
+ * The variant accumulating M=32 sequences per sequences stream and processing N=`TgSizeX_DecompressSequences / 4` sequences streams
+ * per TG of `TgSizeX_DecompressSequences` threads (some threads are inactive during decoding, and become active during memory writes).
  *
  * Copyright (c) Microsoft. All rights reserved.
  * This code is licensed under the MIT License (MIT).
@@ -26,6 +26,6 @@
  * Author(s):   Pavel Martishevsky (pamartis@microsoft.com)
  */
 
-#define kzstdgpu_DecompressSequences_StreamsPerTG 4
-#define kzstdgpu_DecompressSequences_LdsStoreCache_DwCount 128
+#define kzstdgpu_DecompressSequences_ThreadsPerStream 4
+#define kzstdgpu_DecompressSequences_LdsStoreCache_DwCount 32
 #include "ZstdGpuDecompressSequences_MultiStream_LdsOutCache.hlsli"

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_MultiStream_4_LdsOutCache_64.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_MultiStream_4_LdsOutCache_64.hlsl
@@ -12,8 +12,8 @@
  * dwords for each of M streams, flushes them to memory by storing N sequential dwords per each of M
  * streams to help hardware coalescing.
  *
- * The variant accumulating M=64 sequences per sequences stream and processing N=4 sequences streams
- * per TG of 32 threads (some threads are inactive during decoding, and become active during memory writes).
+ * The variant accumulating M=64 sequences per sequences stream and processing N=`TgSizeX_DecompressSequences / 4` sequences streams
+ * per TG of `TgSizeX_DecompressSequences` threads (some threads are inactive during decoding, and become active during memory writes).
  *
  * Copyright (c) Microsoft. All rights reserved.
  * This code is licensed under the MIT License (MIT).
@@ -26,6 +26,6 @@
  * Author(s):   Pavel Martishevsky (pamartis@microsoft.com)
  */
 
-#define kzstdgpu_DecompressSequences_StreamsPerTG 4
+#define kzstdgpu_DecompressSequences_ThreadsPerStream 4
 #define kzstdgpu_DecompressSequences_LdsStoreCache_DwCount 64
 #include "ZstdGpuDecompressSequences_MultiStream_LdsOutCache.hlsli"

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_MultiStream_8_LdsOutCache_128.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_MultiStream_8_LdsOutCache_128.hlsl
@@ -1,5 +1,5 @@
 /**
- * ZstdGpuDecompressSequences_MultiStream_16_LdsOutCache_32.hlsl
+ * ZstdGpuDecompressSequences_MultiStream_8_LdsOutCache_128.hlsl
  *
  * A compute shader that decompresses multiple FSE-compressed sequences streams per TG by sampling
  * FSE tables from L0, but limiting the number of sequences streams per TG to avoid L0 cache thrashing
@@ -12,8 +12,8 @@
  * dwords for each of M streams, flushes them to memory by storing N sequential dwords per each of M
  * streams to help hardware coalescing.
  *
- * The variant accumulating M=32 sequences per sequences stream and processing N=16 sequences streams
- * per TG of 32 threads (some threads are inactive during decoding, and become active during memory writes).
+ * The variant accumulating M=128 sequences per sequences stream and processing N=`TgSizeX_DecompressSequences / 8` sequences streams
+ * per TG of `TgSizeX_DecompressSequences` threads (some threads are inactive during decoding, and become active during memory writes).
  *
  * Copyright (c) Microsoft. All rights reserved.
  * This code is licensed under the MIT License (MIT).
@@ -26,6 +26,6 @@
  * Author(s):   Pavel Martishevsky (pamartis@microsoft.com)
  */
 
-#define kzstdgpu_DecompressSequences_StreamsPerTG 16
-#define kzstdgpu_DecompressSequences_LdsStoreCache_DwCount 32
+#define kzstdgpu_DecompressSequences_ThreadsPerStream 8
+#define kzstdgpu_DecompressSequences_LdsStoreCache_DwCount 128
 #include "ZstdGpuDecompressSequences_MultiStream_LdsOutCache.hlsli"

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_MultiStream_8_LdsOutCache_64.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_MultiStream_8_LdsOutCache_64.hlsl
@@ -12,8 +12,8 @@
  * dwords for each of M streams, flushes them to memory by storing N sequential dwords per each of M
  * streams to help hardware coalescing.
  *
- * The variant accumulating M=64 sequences per sequences stream and processing N=8 sequences streams
- * per TG of 32 threads (some threads are inactive during decoding, and become active during memory writes).
+ * The variant accumulating M=64 sequences per sequences stream and processing N=`TgSizeX_DecompressSequences / 8` sequences streams
+ * per TG of `TgSizeX_DecompressSequences` threads (some threads are inactive during decoding, and become active during memory writes).
  *
  * Copyright (c) Microsoft. All rights reserved.
  * This code is licensed under the MIT License (MIT).
@@ -26,6 +26,6 @@
  * Author(s):   Pavel Martishevsky (pamartis@microsoft.com)
  */
 
-#define kzstdgpu_DecompressSequences_StreamsPerTG 8
+#define kzstdgpu_DecompressSequences_ThreadsPerStream 8
 #define kzstdgpu_DecompressSequences_LdsStoreCache_DwCount 64
 #include "ZstdGpuDecompressSequences_MultiStream_LdsOutCache.hlsli"

--- a/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_MultiStream_LdsOutCache.hlsli
+++ b/zstd/zstdgpu/Shaders/ZstdGpuDecompressSequences_MultiStream_LdsOutCache.hlsli
@@ -31,7 +31,17 @@
 #   error 'kzstdgpu_DecompressSequences_LdsStoreCache_DwCount' must be defined before including this '.hlsli'
 #endif
 
-#define NUM_THREADS 32
+#ifndef kzstdgpu_DecompressSequences_ThreadsPerStream
+#   error 'kzstdgpu_DecompressSequences_ThreadsPerStream' must be defined before including this '.hlsli'
+#endif
+
+#if kzstdgpu_DecompressSequences_ThreadsPerStream < 1 || kzstdgpu_DecompressSequences_ThreadsPerStream > 8
+#   error 'kzstdgpu_DecompressSequences_ThreadsPerStream' must be in range [1, 8]
+#endif
+
+#if (kzstdgpu_DecompressSequences_ThreadsPerStream & (kzstdgpu_DecompressSequences_ThreadsPerStream - 1)) != 0
+#   error 'kzstdgpu_DecompressSequences_ThreadsPerStream' must be a power of 2
+#endif
 
 #include "../zstdgpu_shaders.h"
 
@@ -52,7 +62,7 @@ groupshared uint32_t Lds[kzstdgpu_DecompressSequences_MultiStream_LdsOutCache_Ld
 #include "../zstdgpu_lds_hlsl.h"
 
 [RootSignature("DescriptorTable(SRV(t0, numDescriptors=10), UAV(u0, numDescriptors=7)), RootConstants(b0, num32BitConstants=2)")]
-[numthreads(NUM_THREADS, 1, 1)]
+[numthreads(kzstdgpu_TgSizeX_DecompressSequences, 1, 1)]
 void main(uint32_t2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
 {
     const uint32_t groupId = zstdgpu_ConvertTo32BitGroupId(groupId2, Constants.tgOffset);
@@ -62,5 +72,11 @@ void main(uint32_t2 groupId2 : SV_GroupId, uint i : SV_GroupThreadId)
     ZSTDGPU_DECOMPRESS_SEQUENCES_SRT()
     #include "../zstdgpu_srt_decl_undef.h"
 
-    zstdgpu_ShaderEntry_DecompressSequences_MultiStream_LdsOutCache(srt, groupId, i, NUM_THREADS, kzstdgpu_DecompressSequences_StreamsPerTG, kzstdgpu_DecompressSequences_LdsStoreCache_DwCount);
+    zstdgpu_ShaderEntry_DecompressSequences_MultiStream_LdsOutCache(
+        srt,
+        groupId,
+        i,
+        kzstdgpu_TgSizeX_DecompressSequences,
+        kzstdgpu_TgSizeX_DecompressSequences / kzstdgpu_DecompressSequences_ThreadsPerStream,
+        kzstdgpu_DecompressSequences_LdsStoreCache_DwCount);
 }

--- a/zstd/zstdgpu/Shaders/ZstdGpuExecuteSequences.hlsli
+++ b/zstd/zstdgpu/Shaders/ZstdGpuExecuteSequences.hlsli
@@ -20,7 +20,7 @@
 ZSTDGPU_EXECUTE_SEQUENCES_SRT()
 #include "../zstdgpu_srt_decl_undef.h"
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=12), UAV(u0, numDescriptors=2))")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=11), UAV(u0, numDescriptors=2))")]
 [numthreads(MAX_COPY_SIZE, 1, 1)]
 void main(uint groupId : SV_GroupId, uint i : SV_GroupThreadId)
 {

--- a/zstd/zstdgpu/Shaders/ZstdGpuMemsetMemcpy.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuMemsetMemcpy.hlsl
@@ -20,8 +20,6 @@ struct Consts
 {
     uint32_t tgOffset;
     uint32_t workItemCount;
-    uint32_t blockCount;
-    uint32_t frameCount;
     uint32_t flags;
 };
 
@@ -31,22 +29,22 @@ ConstantBuffer<Consts>                  Constants                           : re
 ZSTDGPU_MEMSET_MEMCPY_SRT()
 #include "../zstdgpu_srt_decl_undef.h"
 
-StructuredBuffer<uint32_t>              ZstdInBlockSizePrefixTyped          : register(t5);
+StructuredBuffer<uint32_t>              ZstdInBlockSizePrefixTyped          : register(t3);
 
-StructuredBuffer<uint32_t>              ZstdInPerFrameBlockSizePrefixTyped  : register(t6);
+StructuredBuffer<zstdgpu_OffsetAndSize> ZstdInBlocksRefsTyped               : register(t4);
 
-StructuredBuffer<zstdgpu_OffsetAndSize> ZstdInBlocksRefsTyped               : register(t7);
+StructuredBuffer<uint32_t>              ZstdInGlobalBlockIndexTyped         : register(t5);
 
-StructuredBuffer<uint32_t>              ZstdInGlobalBlockIndexTyped         : register(t8);
-
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=5), UAV(u0, numDescriptors=1)), SRV(t5), SRV(t6), SRV(t7), SRV(t8), RootConstants(b0, num32BitConstants=5)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=3), UAV(u0, numDescriptors=1)), SRV(t3), SRV(t4), SRV(t5), RootConstants(b0, num32BitConstants=3)")]
 [numthreads(kzstdgpu_TgSizeX_MemsetMemcpy, 1, 1)]
 void main(uint2 groupId : SV_GroupId, uint i : SV_GroupThreadId)
 {
     i += zstdgpu_ConvertTo32BitGroupId(groupId, Constants.tgOffset) * kzstdgpu_TgSizeX_MemsetMemcpy;
 
     if (i >= Constants.workItemCount)
+    {
         return;
+    }
 
     const uint32_t blockCnt = (Constants.flags & 0x1u) ? ZstdInCounters[0].Blocks_RAW : ZstdInCounters[0].Blocks_RLE;
     const uint32_t blockIdx = zstdgpu_BinarySearch(ZstdInBlockSizePrefixTyped, 0, blockCnt, i);
@@ -57,30 +55,12 @@ void main(uint2 groupId : SV_GroupId, uint i : SV_GroupThreadId)
 
     const uint32_t globalBlockIdx = ZstdInGlobalBlockIndexTyped[blockIdx];
 
-    uint32_t globalBlockGlobalOffset = 0;
-    [branch] if (globalBlockIdx > 0)
+    const uint32_t dstBlockOffset = ZstdInBlockDestOffs[globalBlockIdx];
+
+    if (byteIdx >= blockRef.size)
     {
-        globalBlockGlobalOffset = ZstdInBlockSizePrefix[globalBlockIdx - 1];
-    }
-
-    const uint32_t frameIdx = zstdgpu_BinarySearch(ZstdInPerFrameBlockCountAll, 0, Constants.frameCount, globalBlockIdx);
-
-    const uint32_t frameFirstGlobalBlockIdx = ZstdInPerFrameBlockCountAll[frameIdx];
-
-    uint32_t frameFirstBlockGlobalOffset = 0;
-    [branch] if (frameFirstGlobalBlockIdx > 0)
-    {
-        frameFirstBlockGlobalOffset = ZstdInBlockSizePrefix[frameFirstGlobalBlockIdx - 1];
-    }
-
-    const uint32_t frameRelativeBlockOffset = globalBlockGlobalOffset - frameFirstBlockGlobalOffset;
-
-    const zstdgpu_OffsetAndSize dstFrameOffsetAndSize = ZstdInUnCompressedFramesRefs[frameIdx];
-
-    const uint32_t dstBlockOffset = dstFrameOffsetAndSize.offs + frameRelativeBlockOffset;
-
-    if (byteIdx >= dstFrameOffsetAndSize.size)
         return;
+    }
 
     [branch] if (Constants.flags & 0x1u)
     {

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -63,11 +63,11 @@
 #include "ZstdGpuDecompressLiterals_LdsStoreCache32_8.h"
 #include "ZstdGpuDecompressSequences_MultiStream_4.h"
 #include "ZstdGpuDecompressSequences_MultiStream_8.h"
-#include "ZstdGpuDecompressSequences_MultiStream_4_LdsOutCache_128.h"
-#include "ZstdGpuDecompressSequences_MultiStream_4_LdsOutCache_64.h"
+#include "ZstdGpuDecompressSequences_MultiStream_8_LdsOutCache_128.h"
 #include "ZstdGpuDecompressSequences_MultiStream_8_LdsOutCache_64.h"
-#include "ZstdGpuDecompressSequences_MultiStream_8_LdsOutCache_32.h"
-#include "ZstdGpuDecompressSequences_MultiStream_16_LdsOutCache_32.h"
+#include "ZstdGpuDecompressSequences_MultiStream_4_LdsOutCache_64.h"
+#include "ZstdGpuDecompressSequences_MultiStream_4_LdsOutCache_32.h"
+#include "ZstdGpuDecompressSequences_MultiStream_2_LdsOutCache_32.h"
 #include "ZstdGpuDecompressSequences_SingleStream_LdsFseCache128.h"
 #include "ZstdGpuDecompressSequences_SingleStream_LdsFseCache64.h"
 #include "ZstdGpuDecompressSequences_SingleStream_LdsFseCache32.h"
@@ -733,11 +733,11 @@ static void zstdgpu_ReCreate_SRTs(zstdgpu_SRTs & srts, ID3D12Device *device, con
     ZSTDGPU_KERNEL(DecompressSequences_SingleStream_ScalarFseLoad32 ,   L"Decompress Sequences (Single-Stream, Scalar FSE Load, TG Size= 32)")  \
     ZSTDGPU_KERNEL(DecompressSequences_MultiStream_4                ,   L"Decompress Sequences (Multi-Stream, Streams= 4)")                     \
     ZSTDGPU_KERNEL(DecompressSequences_MultiStream_8                ,   L"Decompress Sequences (Multi-Stream, Streams= 8)")                     \
-    ZSTDGPU_KERNEL(DecompressSequences_MultiStream_4_LdsOutCache_128,   L"Decompress Sequences (Multi-Stream, Streams= 4, LDS Out Cache=128 Sequences)")    \
-    ZSTDGPU_KERNEL(DecompressSequences_MultiStream_4_LdsOutCache_64 ,   L"Decompress Sequences (Multi-Stream, Streams= 4, LDS Out Cache= 64 Sequences)")    \
-    ZSTDGPU_KERNEL(DecompressSequences_MultiStream_8_LdsOutCache_64 ,   L"Decompress Sequences (Multi-Stream, Streams= 8, LDS Out Cache= 64 Sequences)")    \
-    ZSTDGPU_KERNEL(DecompressSequences_MultiStream_8_LdsOutCache_32 ,   L"Decompress Sequences (Multi-Stream, Streams= 8, LDS Out Cache= 32 Sequences)")    \
-    ZSTDGPU_KERNEL(DecompressSequences_MultiStream_16_LdsOutCache_32,   L"Decompress Sequences (Multi-Stream, Streams=16, LDS Out Cache= 32 Sequences)")    \
+    ZSTDGPU_KERNEL(DecompressSequences_MultiStream_8_LdsOutCache_128,   L"Decompress Sequences (Multi-Stream, Threads Per Stream=8, LDS Out Cache=128 Sequences)")    \
+    ZSTDGPU_KERNEL(DecompressSequences_MultiStream_8_LdsOutCache_64 ,   L"Decompress Sequences (Multi-Stream, Threads Per Stream=8, LDS Out Cache= 64 Sequences)")    \
+    ZSTDGPU_KERNEL(DecompressSequences_MultiStream_4_LdsOutCache_64 ,   L"Decompress Sequences (Multi-Stream, Threads Per Stream=4, LDS Out Cache= 64 Sequences)")    \
+    ZSTDGPU_KERNEL(DecompressSequences_MultiStream_4_LdsOutCache_32 ,   L"Decompress Sequences (Multi-Stream, Threads Per Stream=4, LDS Out Cache= 32 Sequences)")    \
+    ZSTDGPU_KERNEL(DecompressSequences_MultiStream_2_LdsOutCache_32 ,   L"Decompress Sequences (Multi-Stream, Threads Per Stream=2, LDS Out Cache= 32 Sequences)")    \
     ZSTDGPU_KERNEL(ExecuteSequences128                              ,   L"Execute Sequences 128")                                               \
     ZSTDGPU_KERNEL(ExecuteSequences64                               ,   L"Execute Sequences 64")                                                \
     ZSTDGPU_KERNEL(ExecuteSequences32                               ,   L"Execute Sequences 32")                                                \
@@ -1076,8 +1076,17 @@ ZSTDGPU_ENUM(Status) zstdgpu_CreatePersistentContext(zstdgpu_PersistentContext *
             // Nvidia
             ZSTDGPU_KERNEL_MAP(DecompressLiterals, DecompressLiterals_LdsStoreCache32_16);
             context->DecompressLiterals_LdsStoreCache_StreamsPerGroup = 16;
-            ZSTDGPU_KERNEL_MAP(DecompressSequences, DecompressSequences_SingleStream_LdsFseCache32);
-            context->DecompressSequences_StreamsPerGroup = 1;
+
+            // NOTE(pamartis): Enable multi-stream variant by default. This variant outperforms single-stream
+            // variant in cases when the number of sequence streams large enough so GPU becomes fully saturated
+            // with threadgroups/waves running single-stream shader. On the other side, because single-stream
+            // variant waves/threadgroups are shorter individually, workloads not saturating GPU would perform
+            // faster with single-stream variant and multi-stream version would be a pessimisation.
+            //
+            // But we choose "throughput" maximising kernel.
+            ZSTDGPU_KERNEL_MAP(DecompressSequences, DecompressSequences_MultiStream_4_LdsOutCache_32);
+            context->DecompressSequences_StreamsPerGroup = kzstdgpu_TgSizeX_DecompressSequences / 4u;
+
             ZSTDGPU_KERNEL_MAP(ExecuteSequences, ExecuteSequences64);
         }
         else if (featureOptions1.WaveLaneCountMax == 128)

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -49,6 +49,7 @@
 
 #include "zstdgpu_resources.h"
 
+#include "ZstdGpuComputeDestBlockOffsets.h"
 #include "ZstdGpuComputeDestSequenceOffsets.h"
 #include "ZstdGpuComputePrefixSum.h"
 #include "ZstdGpuDecodeHuffmanWeights.h"
@@ -712,6 +713,7 @@ static void zstdgpu_ReCreate_SRTs(zstdgpu_SRTs & srts, ID3D12Device *device, con
 }
 
 #define ZSTDGPU_KERNEL_LIST()                                                                                                           \
+    ZSTDGPU_KERNEL(ComputeDestBlockOffsets                          ,   L"Compute Destination Block Offsets")                                   \
     ZSTDGPU_KERNEL(ComputeDestSequenceOffsets                       ,   L"Compute Destination Sequence Offsets")                                \
     ZSTDGPU_KERNEL(ComputePrefixSum                                 ,   L"Compute Prefix of Literal and TG Count for Literal Decompression")    \
     ZSTDGPU_KERNEL(DecodeHuffmanWeights                             ,   L"Decode (from nibbles) Uncompressed Huffman Weights")                  \
@@ -777,6 +779,7 @@ static const zstdgpu_CompiledShader kzstdgpu_CompiledShaders [] =
 };
 
 #define ZSTDGPU_DISPATCH32_CMD_SIG_LIST()                       \
+    ZSTDGPU_DISPATCH32_CMD_SIG(ComputeDestBlockOffsets  , 1)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(DecodeHuffmanWeights     , 1)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(DecompressHuffmanWeights , 1)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(DecompressLiterals       , 1)    \
@@ -785,7 +788,7 @@ static const zstdgpu_CompiledShader kzstdgpu_CompiledShaders [] =
     ZSTDGPU_DISPATCH32_CMD_SIG(InitFseTable             , 1)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(InitHuffmanTable         , 1)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(Memset                   , 1)    \
-    ZSTDGPU_DISPATCH32_CMD_SIG(MemsetMemcpy             , 5)    \
+    ZSTDGPU_DISPATCH32_CMD_SIG(MemsetMemcpy             , 4)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(PrefixSequenceOffsets    , 10)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(PrefixSum                , 2)    \
     ZSTDGPU_DISPATCH32_CMD_SIG(ComputePrefixSum         , 5)    \
@@ -793,6 +796,7 @@ static const zstdgpu_CompiledShader kzstdgpu_CompiledShaders [] =
     ZSTDGPU_DISPATCH32_CMD_SIG(PropagateFseIndex        , 0)
 
 #define ZSTDGPU_RUNTIME_KERNEL_LIST_SHARED()        \
+    ZSTDGPU_KERNEL(ComputeDestBlockOffsets)         \
     ZSTDGPU_KERNEL(ComputeDestSequenceOffsets)      \
     ZSTDGPU_KERNEL(ComputePrefixSum)                \
     ZSTDGPU_KERNEL(DecodeHuffmanWeights)            \
@@ -843,6 +847,7 @@ static const zstdgpu_CompiledShader kzstdgpu_CompiledShaders [] =
     ZSTDGPU_KERNEL_SCOPE_X(DecompressSequences                  , L"Decompress Sequences"       )   \
     ZSTDGPU_KERNEL_SCOPE_X(PrefixSequenceOffsets                , L"Propagate Sequence Offsets" )   \
     ZSTDGPU_KERNEL_SCOPE_X(FinaliseSequenceOffsets              , L"Finalise Sequence Offsets"  )   \
+    ZSTDGPU_KERNEL_SCOPE_X(ComputeDestBlockOffsets              , L"Compute Dest Block Offsets" )   \
     ZSTDGPU_KERNEL_SCOPE_X(ExecuteSequences                     , L"ExecuteSequences"           )   \
     ZSTDGPU_KERNEL_SCOPE_X(MemcpyRAW_MemsetRLE                  , L"Memcpy Raw/Memset RLE Blocks")  \
     ZSTDGPU_KERNEL_SCOPE_X(PrefixBlockSizes                     , L"Prefix Block Sizes"         )
@@ -3249,10 +3254,23 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         }
 
         // last written by [Prefix Block Sizes]
-        // next read by [Memcpy RAW blocks, Memset RLE blocks] and [Execute Sequences]
+        // next read by [Compute Dest Block Offsets], [Memcpy RAW blocks, Memset RLE blocks], and [Execute Sequences]
         setResourceUavToSrvSync(barriers, bc + 0, req->resData.gpuOnly.BlockSizePrefix);
         bc += 1;
         cmdList->ResourceBarrier(bc, barriers);
+        PIXEndEvent(cmdList);
+    }
+
+    {
+        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Compute Dest Block Offsets]");
+        BIND_RS_PS_SRT(ComputeDestBlockOffsets);
+        // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
+        cmdList->SetComputeRoot32BitConstant(1, req->zstdFrameCount, 2);
+
+        ZSTDGPU_KERNEL_SCOPE(ComputeDestBlockOffsets, cmdList,
+            zstdgpu_DispatchIndirect(cmdList, ComputeDestBlockOffsets, PrefixBlockSizes);
+        );
+
         PIXEndEvent(cmdList);
     }
 
@@ -3270,10 +3288,13 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier with Resources for [Memcpy RAW blocks, Memset RLE blocks] and [Execute Sequences]");
-        D3D12_RESOURCE_BARRIER barriers[1];
+        D3D12_RESOURCE_BARRIER barriers[2];
         // last written/updated by [Finalise Sequence Offsets]
         // next read by [Execute Sequences]
         setResourceUavToSrvSync(barriers, 0, req->resData.gpuOnly.DecompressedSequenceOffs);
+        // last written by [Compute Dest Block Offsets]
+        // next read by [Memcpy RAW blocks, Memset RLE blocks], [Execute Sequences], and [Compute Dest Sequence Offsets]
+        setResourceUavToSrvSync(barriers, 1, req->resData.gpuOnly.BlockDestOffs);
         cmdList->ResourceBarrier(_countof(barriers), barriers);
         PIXEndEvent(cmdList);
     }
@@ -3287,25 +3308,19 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         {
             {
                 cmdList->SetComputeRootShaderResourceView(1, req->resData.gpuOnly.RawBlockSizePrefix->GetGPUVirtualAddress());
-                cmdList->SetComputeRootShaderResourceView(2, req->resData.gpuOnly.PerFrameBlockSizesRAW->GetGPUVirtualAddress());
-                cmdList->SetComputeRootShaderResourceView(3, req->resData.gpuOnly.BlocksRAWRefs->GetGPUVirtualAddress());
-                cmdList->SetComputeRootShaderResourceView(4, req->resData.gpuOnly.GlobalBlockIndexPerRawBlock->GetGPUVirtualAddress());
+                cmdList->SetComputeRootShaderResourceView(2, req->resData.gpuOnly.BlocksRAWRefs->GetGPUVirtualAddress());
+                cmdList->SetComputeRootShaderResourceView(3, req->resData.gpuOnly.GlobalBlockIndexPerRawBlock->GetGPUVirtualAddress());
                 // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
-                cmdList->SetComputeRoot32BitConstant(5, req->zstdRawBlockCountMax, 2);
-                cmdList->SetComputeRoot32BitConstant(5, req->zstdFrameCount, 3);
-                cmdList->SetComputeRoot32BitConstant(5, 1 /* flags */, 4);
+                cmdList->SetComputeRoot32BitConstant(4, 1 /* flags */, 2);
                 zstdgpu_DispatchIndirect(cmdList, MemsetMemcpy, MemcpyRAW);
             }
 
             {
                 cmdList->SetComputeRootShaderResourceView(1, req->resData.gpuOnly.RleBlockSizePrefix->GetGPUVirtualAddress());
-                cmdList->SetComputeRootShaderResourceView(2, req->resData.gpuOnly.PerFrameBlockSizesRLE->GetGPUVirtualAddress());
-                cmdList->SetComputeRootShaderResourceView(3, req->resData.gpuOnly.BlocksRLERefs->GetGPUVirtualAddress());
-                cmdList->SetComputeRootShaderResourceView(4, req->resData.gpuOnly.GlobalBlockIndexPerRleBlock->GetGPUVirtualAddress());
+                cmdList->SetComputeRootShaderResourceView(2, req->resData.gpuOnly.BlocksRLERefs->GetGPUVirtualAddress());
+                cmdList->SetComputeRootShaderResourceView(3, req->resData.gpuOnly.GlobalBlockIndexPerRleBlock->GetGPUVirtualAddress());
                 // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
-                cmdList->SetComputeRoot32BitConstant(5, req->zstdRleBlockCountMax, 2);
-                cmdList->SetComputeRoot32BitConstant(5, req->zstdFrameCount, 3);
-                cmdList->SetComputeRoot32BitConstant(5, 0 /* flags */, 4);
+                cmdList->SetComputeRoot32BitConstant(4, 0 /* flags */, 2);
                 zstdgpu_DispatchIndirect(cmdList, MemsetMemcpy, MemsetRLE);
             }
         });

--- a/zstd/zstdgpu/zstdgpu_resources.h
+++ b/zstd/zstdgpu/zstdgpu_resources.h
@@ -108,6 +108,7 @@
     ZSTDGPU_BUFFER(zstdgpu_OffsetAndSize                    , BlocksCMPRefs                 )
 
 #define ZSTDGPU_BUFFERS_LIST_STAGE_1() \
+    ZSTDGPU_BUFFER(uint32_t                                 , BlockDestOffs                 )   \
     ZSTDGPU_BUFFER(uint32_t                                 , HuffmanTableCodeAndSymbol     )   \
     ZSTDGPU_BUFFER(uint32_t                                 , HuffmanTableRankIndex         )   \
     ZSTDGPU_BUFFER(uint32_t                                 , HuffmanTableInfo              )
@@ -297,6 +298,7 @@ static void zstdgpu_ResourceInfo_Stage_1_InitSize(zstdgpu_ResourceInfo *outInfo,
 
     // TODO: this must a total of all blocks (including RLE and RAW)
     const uint32_t BlockSizePrefix_Count = allBlockCount + zstdgpu_GetLookbackBlockCount(allBlockCount);
+    const uint32_t BlockDestOffs_Count = allBlockCount;
     const uint32_t GlobalBlockIndexPerRawBlock_Count = rawBlockCount;
     const uint32_t GlobalBlockIndexPerRleBlock_Count = rleBlockCount;
     const uint32_t GlobalBlockIndexPerCmpBlock_Count = cmpBlockCount;

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -3570,8 +3570,13 @@ static void zstdgpu_ShaderEntry_DecompressSequences_SingleStream(ZSTDGPU_PARAM_I
 #endif
 
 #ifndef kzstdgpu_DecompressSequences_StreamsPerTG
-#define kzstdgpu_DecompressSequences_StreamsPerTG 8
+#define kzstdgpu_DecompressSequences_StreamsPerTG (kzstdgpu_TgSizeX_DecompressSequences / kzstdgpu_DecompressSequences_ThreadsPerStream)
 #define kzstdgpu_DecompressSequences_StreamsPerTG_UNDEF 1
+#endif
+
+#ifndef kzstdgpu_DecompressSequences_ThreadsPerStream
+#define kzstdgpu_DecompressSequences_ThreadsPerStream 4
+#define kzstdgpu_DecompressSequences_ThreadsPerStream_UNDEF 1
 #endif
 
 #include "zstdgpu_lds_decl_size.h"
@@ -3589,7 +3594,20 @@ static void zstdgpu_ShaderEntry_DecompressSequences_MultiStream_LdsOutCache(ZSTD
     const uint32_t seqStreamBeg = groupId * streamsPerGroup;
 
     const uint32_t seqStreamCntInGroup = zstdgpu_MinU32(seqStreamCnt - seqStreamBeg, streamsPerGroup);
-    const uint32_t seqStreamIdxInGroup = zstdgpu_MinU32(threadId, seqStreamCntInGroup - 1u);
+
+    // NOTE(pamartis): distribute the group's streams equally across the TG's waves (wave-size agnostic).
+    // Each wave owns `streamsPerWave` consecutive streams
+    const uint32_t laneCnt = zstdgpu_MinU32(WaveGetLaneCount(), tgSize);
+    const uint32_t waveCnt = tgSize / laneCnt;
+    const uint32_t waveIdx = WaveReadLaneFirst(threadId / laneCnt);
+    const uint32_t laneIdx = WaveGetLaneIndex();
+    const uint32_t streamsPerWave = streamsPerGroup / waveCnt;
+    const uint32_t waveStreamBase = waveIdx * streamsPerWave;
+    const uint32_t waveStreamEnd = zstdgpu_MinU32(waveStreamBase + streamsPerWave, seqStreamCntInGroup);
+    const uint32_t laneStreamIdxInGroup = waveStreamBase + laneIdx;
+    const bool seqStreamActive = laneStreamIdxInGroup < waveStreamEnd;
+
+    const uint32_t seqStreamIdxInGroup = zstdgpu_MinU32(laneStreamIdxInGroup, seqStreamCntInGroup - 1u);
     const uint32_t seqStreamIdx = seqStreamBeg + seqStreamIdxInGroup;
 
     const uint32_t cmpBlockCnt = srt.inCounters[0].Blocks_CMP;
@@ -3639,14 +3657,11 @@ static void zstdgpu_ShaderEntry_DecompressSequences_MultiStream_LdsOutCache(ZSTD
 
         const uint32_t storeCacheThreadOffset = seqStreamIdxInGroup * cacheDwordsPerStream;
 
-        const uint32_t laneCnt = zstdgpu_MinU32(WaveGetLaneCount(), tgSize);
-        const uint32_t streamBeg = WaveReadLaneFirst(threadId);
-
         uint32_t seqIdx = seqRefDst.offs;
 
         // WARN(pamartis): The condition here is important even if size and offset are correct to make sure no work is done by
         // threads that get replicated data
-        const uint32_t seqIdxEnd = seqRefDst.offs + ((threadId < seqStreamCntInGroup) ? seqRefDst.size : 0);
+        const uint32_t seqIdxEnd = seqRefDst.offs + (seqStreamActive ? seqRefDst.size : 0);
 
         do
         {
@@ -3679,7 +3694,7 @@ static void zstdgpu_ShaderEntry_DecompressSequences_MultiStream_LdsOutCache(ZSTD
                 const uint32_t seqIdxInBatch = seqIdx - seqIdxBatchBeg;
 
                 //
-                const uint32_t seqIdxInCache = (seqIdxInBatch & ~kStoreCacheBankMask) + ((seqIdxInBatch + threadId) & kStoreCacheBankMask);
+                const uint32_t seqIdxInCache = (seqIdxInBatch & ~kStoreCacheBankMask) + ((seqIdxInBatch + seqStreamIdxInGroup) & kStoreCacheBankMask);
                 zstdgpu_LdsStoreU32(GS_LLenCache + storeCacheThreadOffset + seqIdxInCache, llen);
                 zstdgpu_LdsStoreU32(GS_MLenCache + storeCacheThreadOffset + seqIdxInCache, mlen);
                 zstdgpu_LdsStoreU32(GS_OffsCache + storeCacheThreadOffset + seqIdxInCache, offs);
@@ -3691,13 +3706,12 @@ static void zstdgpu_ShaderEntry_DecompressSequences_MultiStream_LdsOutCache(ZSTD
             }
 
             // Cooperative flush phase: all threads flush each stream's LDS cache to UAV memory
-            uint32_t i = streamBeg;
-            const uint32_t streamEnd = zstdgpu_MinU32(i + laneCnt, seqStreamCntInGroup);
+            uint32_t i = waveStreamBase;
 
-            ZSTDGPU_LOOP for (; i < streamEnd; ++i)
+            ZSTDGPU_LOOP for (; i < waveStreamEnd; ++i)
             {
-                const uint32_t seqCntInBatch = WaveReadLaneAt(seqIdxBatchEnd - seqIdxBatchBeg, i - streamBeg);
-                const uint32_t dstSeqIdx = WaveReadLaneAt(seqIdxBatchBeg, i - streamBeg);
+                const uint32_t seqCntInBatch = WaveReadLaneAt(seqIdxBatchEnd - seqIdxBatchBeg, i - waveStreamBase);
+                const uint32_t dstSeqIdx = WaveReadLaneAt(seqIdxBatchBeg, i - waveStreamBase);
 
                 ZSTDGPU_FOR_WORK_ITEMS(seqIdxToStore, seqCntInBatch, WaveGetLaneIndex(), laneCnt)
                 {
@@ -3718,7 +3732,7 @@ static void zstdgpu_ShaderEntry_DecompressSequences_MultiStream_LdsOutCache(ZSTD
         while (WaveActiveAnyTrue(seqIdx < seqIdxEnd));
     }
 
-    if (threadId < seqStreamCntInGroup)
+    if (seqStreamActive)
     {
         // NOTE(pamartis): update block size adding `totalMLen` bytes on top
         srt.inoutBlockSizePrefix[seqRef.blockId] = totalMLen + literalSize;
@@ -3740,6 +3754,11 @@ static void zstdgpu_ShaderEntry_DecompressSequences_MultiStream_LdsOutCache(ZSTD
 #ifdef kzstdgpu_DecompressSequences_StreamsPerTG_UNDEF
 #undef kzstdgpu_DecompressSequences_StreamsPerTG_UNDEF
 #undef kzstdgpu_DecompressSequences_StreamsPerTG
+#endif
+
+#ifdef kzstdgpu_DecompressSequences_ThreadsPerStream_UNDEF
+#undef kzstdgpu_DecompressSequences_ThreadsPerStream_UNDEF
+#undef kzstdgpu_DecompressSequences_ThreadsPerStream
 #endif
 
 static void zstdgpu_ShaderEntry_FinaliseSequenceOffsets(ZSTDGPU_PARAM_INOUT(zstdgpu_FinaliseSequenceOffsets_SRT) srt, uint32_t threadId)

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -3964,18 +3964,6 @@ static void zstdgpu_ShaderEntry_ExecuteSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_Exe
                                ? srt.inPerFrameBlockCountCMP[frameIdx + 1u]
                                : srt.inoutCounters[0].Blocks_CMP;
 
-    const uint32_t firstFrameBlockIdx = srt.inPerFrameBlockCountAll[frameIdx];
-
-    uint32_t firstFrameBlockOfs = 0;
-    // NOTE(pamartis): Without `ZSTDGPU_BRANCH`, there's out-of-bounds `ZstdInBlockSizePrefix` access detected by validation layer when
-    // DXC used: "Version: dxcompiler.dll: 1.6 - 1.6.2112.16 (e8295973c); dxil.dll: 1.6(101.6.2112.13)"
-    ZSTDGPU_BRANCH if (firstFrameBlockIdx > 0)
-    {
-        firstFrameBlockOfs = srt.inBlockSizePrefix[firstFrameBlockIdx - 1];
-    }
-
-    const zstdgpu_OffsetAndSize dstFrameOffsAndSize = srt.inUnCompressedFramesRefs[frameIdx];
-
     for (uint32_t cmpBlockIdx = cmpBlockBeg; cmpBlockIdx < cmpBlockEnd; ++cmpBlockIdx)
     {
         const uint32_t blockIdx = srt.inGlobalBlockIndexPerCmpBlock[cmpBlockIdx];
@@ -3988,8 +3976,9 @@ static void zstdgpu_ShaderEntry_ExecuteSequences(ZSTDGPU_PARAM_INOUT(zstdgpu_Exe
             blockOfs = srt.inBlockSizePrefix[blockIdx - 1];
         }
 
-        const uint32_t blockByteBeg = dstFrameOffsAndSize.offs + (blockOfs - firstFrameBlockOfs);
-        const uint32_t blockByteEnd = dstFrameOffsAndSize.offs + (srt.inBlockSizePrefix[blockIdx] - firstFrameBlockOfs);
+        const uint32_t blockSize = srt.inBlockSizePrefix[blockIdx] - blockOfs;
+        const uint32_t blockByteBeg = srt.inBlockDestOffs[blockIdx];
+        const uint32_t blockByteEnd = blockByteBeg + blockSize;
 
 #if 0
         for (uint32_t blockByteIdx = blockByteBeg + i; blockByteIdx < blockByteEnd; blockByteIdx += maxCopySize)

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -422,6 +422,8 @@ static const uint32_t kzstdgpu_TgSizeX_DecompressHuffmanWeights = 8;
 
 static const uint32_t kzstdgpu_TgSizeX_DecodeHuffmanWeights = 32;
 
+static const uint32_t kzstdgpu_TgSizeX_DecompressSequences = 128;
+
 // NOTE(pamartis): Decompressing Literals should be as small as possible (divergent workload)
 // but not too small to make sure Huffman table initialisation isn't repeated too often
 // TODO(pamartis) Try threadgroup sizes that less than wave size to see whether reducing

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -444,6 +444,12 @@ static const uint32_t kzstdgpu_TgSizeX_MemsetMemcpy = 64;
 static const uint32_t kzstdgpu_TgSizeX_MemsetMemcpy = 32;
 #endif
 
+#if defined(_GAMING_XBOX) || defined(__XBOX_SCARLETT) || defined(__XBOX_ONE)
+static const uint32_t kzstdgpu_TgSizeX_ComputeDestBlockOffset = 64;
+#else
+static const uint32_t kzstdgpu_TgSizeX_ComputeDestBlockOffset = 128;
+#endif
+
 #define ZSTDGPU_TG_COUNT(elemCount, tgSize) (((elemCount) + (tgSize) - 1) / (tgSize))
 
 static inline uint32_t zstdgpu_AlignUp(uint32_t offset, uint32_t alignment)
@@ -1754,43 +1760,44 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t initResou
     \
     ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , DecompressedSequenceOffs      , 0)
 
+#define ZSTDGPU_COMPUTE_DEST_BLOCK_OFFSETS_SRT()                                                       \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , BlockSizePrefix               , 0)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , PerFrameBlockCountAll         , 1)    \
+    ZSTDGPU_RO_BUFFER_DECL(zstdgpu_OffsetAndSize                , UnCompressedFramesRefs        , 2)    \
+    \
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , BlockDestOffs                 , 0)
+
 #define ZSTDGPU_EXECUTE_SEQUENCES_SRT()                                                                 \
     ZSTDGPU_RO_TYPED_BUFFER_DECL(uint32_t, uint8_t              , CompressedData                , 0)    \
     \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , PerFrameBlockCountCMP         , 1)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , PerFrameBlockCountAll         , 2)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , BlockSizePrefix               , 3)    \
-    ZSTDGPU_RO_BUFFER_DECL(zstdgpu_OffsetAndSize                , UnCompressedFramesRefs        , 4)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , DecompressedSequenceLLen      , 5)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , DecompressedSequenceMLen      , 6)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , DecompressedSequenceOffs      , 7)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , GlobalBlockIndexPerCmpBlock   , 8)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , PerSeqStreamSeqStart          , 9)    \
-    ZSTDGPU_RO_BUFFER_DECL(zstdgpu_CompressedBlockData          , CompressedBlocks              ,10)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , BlockSizePrefix               , 2)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , BlockDestOffs                 , 3)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , DecompressedSequenceLLen      , 4)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , DecompressedSequenceMLen      , 5)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , DecompressedSequenceOffs      , 6)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , GlobalBlockIndexPerCmpBlock   , 7)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , PerSeqStreamSeqStart          , 8)    \
+    ZSTDGPU_RO_BUFFER_DECL(zstdgpu_CompressedBlockData          , CompressedBlocks              , 9)    \
     \
-    ZSTDGPU_RO_TYPED_BUFFER_DECL(uint32_t, uint8_t              , DecompressedLiterals          ,11)    \
+    ZSTDGPU_RO_TYPED_BUFFER_DECL(uint32_t, uint8_t              , DecompressedLiterals          ,10)    \
     \
     ZSTDGPU_RW_TYPED_BUFFER_DECL(uint32_t, uint8_t              , UnCompressedFramesData        , 0)    \
     ZSTDGPU_RW_BUFFER_DECL(zstdgpu_Counters                     , Counters                      , 1)
 
 #define ZSTDGPU_COMPUTE_DEST_SEQUENCE_OFFSETS_SRT()                                                     \
     ZSTDGPU_RO_BUFFER_DECL(zstdgpu_Counters                     , Counters                      , 0)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , PerFrameBlockCountAll         , 1)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , BlockSizePrefix               , 2)    \
-    ZSTDGPU_RO_BUFFER_DECL(zstdgpu_OffsetAndSize                , UnCompressedFramesRefs        , 3)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , DecompressedSequenceMLen      , 4)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , PerSeqStreamSeqStart          , 5)    \
-    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , SeqStreamToBlockId            , 6)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , BlockDestOffs                 , 1)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , DecompressedSequenceMLen      , 2)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , PerSeqStreamSeqStart          , 3)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , SeqStreamToBlockId            , 4)    \
     \
     ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , DestSequenceOffsets           , 0)
 
 #define ZSTDGPU_MEMSET_MEMCPY_SRT()                                                                     \
     ZSTDGPU_RO_BUFFER_DECL(zstdgpu_Counters                     , Counters                      , 0)    \
     ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , CompressedData                , 1)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , BlockSizePrefix               , 2)    \
-    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , PerFrameBlockCountAll         , 3)    \
-    ZSTDGPU_RO_BUFFER_DECL(zstdgpu_OffsetAndSize                , UnCompressedFramesRefs        , 4)    \
+    ZSTDGPU_RO_BUFFER_DECL(uint32_t                             , BlockDestOffs                 , 2)    \
     \
     ZSTDGPU_RW_TYPED_BUFFER_DECL(uint32_t, uint8_t              , UnCompressedFramesData        , 0)
 
@@ -1812,6 +1819,7 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t initResou
     ZSTDGPU_SRT(DecompressLiterals                      , ZSTDGPU_DECOMPRESS_LITERALS_SRT())                        \
     ZSTDGPU_SRT(DecompressSequences                     , ZSTDGPU_DECOMPRESS_SEQUENCES_SRT())                       \
     ZSTDGPU_SRT(FinaliseSequenceOffsets                 , ZSTDGPU_FINALISE_SEQUENCE_OFFSETS_SRT())                  \
+    ZSTDGPU_SRT(ComputeDestBlockOffsets                 , ZSTDGPU_COMPUTE_DEST_BLOCK_OFFSETS_SRT())                 \
     ZSTDGPU_SRT(MemsetMemcpy                            , ZSTDGPU_MEMSET_MEMCPY_SRT())                              \
     ZSTDGPU_SRT(ExecuteSequences                        , ZSTDGPU_EXECUTE_SEQUENCES_SRT())                          \
     ZSTDGPU_SRT(ComputeDestSequenceOffsets              , ZSTDGPU_COMPUTE_DEST_SEQUENCE_OFFSETS_SRT())
@@ -1905,6 +1913,11 @@ typedef struct zstdgpu_FinaliseSequenceOffsets_SRT
 {
     ZSTDGPU_FINALISE_SEQUENCE_OFFSETS_SRT();
 } zstdgpu_FinaliseSequenceOffsets_SRT;
+
+typedef struct zstdgpu_ComputeDestBlockOffsets_SRT
+{
+    ZSTDGPU_COMPUTE_DEST_BLOCK_OFFSETS_SRT();
+} zstdgpu_ComputeDestBlockOffsets_SRT;
 
 typedef struct zstdgpu_ExecuteSequences_SRT
 {

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -1122,6 +1122,7 @@ static int demoRun(void *demoCtx)
     bool chkCpu = false;
     bool simGpu = false;
     bool d3dDbg = false;
+    bool d3dGbv = false;
     bool d3dGfx = false;
     bool outFrm = false;
     bool ssm = false;
@@ -1231,6 +1232,11 @@ static int demoRun(void *demoCtx)
                 {
                     d3dDbg = true;
                 }
+                else if (0 == wcscmp(argv[argi], L"--d3d-gbv"))
+                {
+                    d3dGbv = true;
+                    d3dDbg = true; // --d3d-gbv implies --d3d-dbg (GBV requires the debug layer)
+                }
                 else if (0 == wcscmp(argv[argi], L"--d3d-gfx"))
                 {
                     d3dGfx = true;
@@ -1287,7 +1293,8 @@ static int demoRun(void *demoCtx)
                 debugPrint(L"\t--sim-gpu                 [Optional] After running decompression on GPU, runs key GPU decompressor stages on CPU using intermediate inputs from GPU decompression and validates its outputs against the outputs from reference decompressor.\n");
                 debugPrint(L"\t--gpu-ven-id <id (hex)>   [Optional] VendorId (base16) to use when choosing GPU to run on.\n");
                 debugPrint(L"\t--gpu-dev-id <id (hex)>   [Optional] DeviceId (base16) to use when choosing GPU to run on.\n");
-                debugPrint(L"\t--d3d-dbg                 [Optional] Enables D3D12 debug layer.\n");
+                debugPrint(L"\t--d3d-dbg                 [Optional] Enables D3D12 debug layer (without GPU-Based Validation).\n");
+                debugPrint(L"\t--d3d-gbv                 [Optional] Enables D3D12 GPU-Based Validation (implies --d3d-dbg).\n");
                 debugPrint(L"\t--d3d-gfx                 [Optional] Enables D3D12 Graphics queue (DIRECT), otherwise COMPUTE (by default).\n");
                 debugPrint(L"\t--run-cnt <count>         [Optional] The number of times to repeat the experiment.\n");
                 debugPrint(L"\t--ext-mem                 [Optional] Enables external heaps so the library doesn't create them.\n");
@@ -1388,7 +1395,7 @@ static int demoRun(void *demoCtx)
     static const uint32_t kFrameInterval = 1;
 #endif
 
-    device = zstdgpu_Demo_PlatformInit(gpuVenId, gpuDevId, d3dDbg);
+    device = zstdgpu_Demo_PlatformInit(gpuVenId, gpuDevId, d3dDbg, d3dGbv);
     if (NULL == device)
     {
         debugPrint(L"[FAIL] Couldn't load create D3D12 device with venId=%u, devId=%u. Early Out.\n", gpuVenId, gpuDevId);


### PR DESCRIPTION
This PR brings several simplifications:
- D3D12 GPU-based validation gets its own command line parameter to decouple from D3D12 debug layer (mostly because some drivers have bugs with `ExecuteIndirect` with GBV enabled)
- Computation of destination block offsets was moved to separate pass to avoid doing this in multiple late stage shaders, sometimes at higher frequency.
- Multi-stream sequence decompression shader was made wave size agnostic with default threadgroup size set to 128 threads and `ThreadsPerStream` parameter controlling thread occupancy (ratio of all threads to active threads in the decoding phase). This multi-stream shader variant was enabled on NVIDIA after considerable volume of tests showing performance improvement of up to 3x comparing to single-stream shader variant. However, it's worth noting that performance loss (up to 2x) was also observed  mainly on workload not saturating GPU. The explanation why this happens is rather simple: while GPU is not saturated with threadgroups, decompressing only single stream per threadgroup (shader specialised for decompressing single stream) is always faster (while wasteful) than packing multiple streams into a single but more heavy threadgroup (shader specialised for decompressing multiple streams).