### PR TITLE
zstdgpu_ci_tests: segment-anchored adversarial-manifest matching + zero-coverage fail-loud check

### DIFF
--- a/zstd/zstdgpu_ci_tests/adversarial_manifest.cpp
+++ b/zstd/zstdgpu_ci_tests/adversarial_manifest.cpp
@@ -262,7 +262,8 @@ static bool ParseEntry(Parser& p, AdversarialEntry& entry, std::string& errorOut
 
 // Glob matcher supporting '*' wildcards and '[a-b]' character ranges.
 // Case-sensitive. Not general-purpose — no '?', no '**', no negation.
-// O(N*M) worst case but N and M are small (paths are typically <256 chars).
+// Fully anchored: the pattern must consume the entire `path`. O(N*M) worst case
+// but N and M are small (paths are typically <256 chars).
 static bool GlobMatch(std::string_view pattern, std::string_view path)
 {
     size_t pi = 0, si = 0;
@@ -327,6 +328,24 @@ static bool GlobMatch(std::string_view pattern, std::string_view path)
     }
     while (pi < pattern.size() && pattern[pi] == '*') ++pi;
     return pi == pattern.size();
+}
+
+// Segment-anchored suffix match. Returns true if `pattern` matches the whole
+// `path`, OR a trailing portion of `path` that begins at a path-segment boundary
+// (position 0, or immediately after a '/'). This lets a glob authored relative
+// to a sub-tree still match when the caller supplies a deeper content root that
+// prepends extra leading path segments. Anchoring on '/' boundaries prevents
+// accidental mid-segment matches.
+static bool GlobMatchSuffix(std::string_view pattern, std::string_view path)
+{
+    if (GlobMatch(pattern, path))
+        return true;
+    for (size_t i = 0; i + 1 < path.size(); ++i)
+    {
+        if (path[i] == '/' && GlobMatch(pattern, path.substr(i + 1)))
+            return true;
+    }
+    return false;
 }
 
 // Normalizes a path for glob matching: relative to contentPath (if provided)
@@ -439,8 +458,31 @@ const AdversarialEntry* AdversarialManifest::Match(const std::string& zstFullPat
     const std::string rel = RelativeAndNormalize(zstFullPath, contentPath);
     for (const auto& e : m_entries)
     {
-        if (GlobMatch(e.pathGlob, rel))
+        if (GlobMatchSuffix(e.pathGlob, rel))
             return &e;
     }
     return nullptr;
+}
+
+size_t AdversarialManifest::CountCoverage(const std::vector<std::string>& files,
+                                          const std::filesystem::path& contentPath) const
+{
+    if (!m_loaded)
+        return 0;
+
+    size_t filesMatched = 0;
+    for (const auto& f : files)
+    {
+        const std::string rel = RelativeAndNormalize(f, contentPath);
+        for (const auto& e : m_entries)
+        {
+            if (GlobMatchSuffix(e.pathGlob, rel))
+            {
+                ++filesMatched;
+                break;
+            }
+        }
+    }
+
+    return filesMatched;
 }

--- a/zstd/zstdgpu_ci_tests/adversarial_manifest.h
+++ b/zstd/zstdgpu_ci_tests/adversarial_manifest.h
@@ -58,6 +58,13 @@ public:
     bool Loaded() const { return m_loaded; }
     const std::filesystem::path& SourcePath() const { return m_sourcePath; }
 
+    // Startup coverage self-check. Returns how many of `files` match at least
+    // one manifest entry. The wrapper uses this to fail loud when a loaded
+    // manifest matches nothing (an inert manifest is otherwise indistinguishable
+    // from a working one and silently disables the adversarial-rejection checks).
+    size_t CountCoverage(const std::vector<std::string>& files,
+                         const std::filesystem::path& contentPath) const;
+
 private:
     std::vector<AdversarialEntry> m_entries;
     std::filesystem::path m_sourcePath;

--- a/zstd/zstdgpu_ci_tests/main.cpp
+++ b/zstd/zstdgpu_ci_tests/main.cpp
@@ -31,6 +31,7 @@
 #include <iostream>
 #include <string>
 #include <system_error>
+#include <vector>
 
 // Global config, declared extern in zstdgpu_ci_tests.h. Set once in main(),
 // read from test bodies.
@@ -257,6 +258,26 @@ static int ValidateAndDiscover(TestConfig& config)
                   << " entries from '" << config.adversarialManifestPath << "'"
                   << (manifestFromExplicitFlag ? " (via --adversarial-manifest)." : " (auto-discovered in content-path).")
                   << "\n";
+
+        // Coverage self-check. A manifest that loads but matches NOTHING is
+        // almost always a content-path / glob-prefix misconfiguration (globs are
+        // authored relative to a sub-tree while --content-path points elsewhere).
+        // Left undetected this silently turns every correctly-rejected file into
+        // a spurious failure AND disables the rejection safety net, so fail loud
+        // rather than run with an inert manifest.
+        const size_t filesMatched = config.adversarialManifest.CountCoverage(
+            config.discoveredFiles, config.contentPath);
+        if (config.adversarialManifest.Size() > 0 && filesMatched == 0)
+        {
+            return Fail("adversarial manifest loaded " +
+                        std::to_string(config.adversarialManifest.Size()) +
+                        " entries but matched 0 of " +
+                        std::to_string(config.discoveredFiles.size()) +
+                        " discovered files. This is almost certainly a content-path/glob "
+                        "prefix mismatch: manifest globs are authored relative to a sub-tree. "
+                        "Verify --content-path '" +
+                        config.contentPath + "' points at or above that tree.");
+        }
     }
     else
     {


### PR DESCRIPTION
Two robustness fixes to the adversarial-manifest layer of the Zstd GPU CI harness, so manifest globs keep working regardless of where  --content-path  is rooted, and so a mis-scoped manifest fails loudly instead of silently.