### PR TITLE
zstdgpu/barrier-fixes-and-simplify: fixes barriers and replaces 3 buffers

### DIFF
--- a/zstd/zstdgpu/Shaders/ZstdGpuParseFrames.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuParseFrames.hlsl
@@ -34,7 +34,7 @@ ZSTDGPU_PARSE_FRAMES_SRT()
 #define __XBOX_ENABLE_WAVE32 1
 #endif
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=2), UAV(u0, numDescriptors=16)), RootConstants(b0, num32BitConstants=3)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=2), UAV(u0, numDescriptors=14)), RootConstants(b0, num32BitConstants=3)")]
 [numthreads(kzstdgpu_TgSizeX_ParseCompressedBlocks, 1, 1)]
 void main(uint i : SV_DispatchThreadId)
 {

--- a/zstd/zstdgpu/Shaders/ZstdGpuParseFrames.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuParseFrames.hlsl
@@ -34,7 +34,7 @@ ZSTDGPU_PARSE_FRAMES_SRT()
 #define __XBOX_ENABLE_WAVE32 1
 #endif
 
-[RootSignature("DescriptorTable(SRV(t0, numDescriptors=2), UAV(u0, numDescriptors=17)), RootConstants(b0, num32BitConstants=3)")]
+[RootSignature("DescriptorTable(SRV(t0, numDescriptors=2), UAV(u0, numDescriptors=16)), RootConstants(b0, num32BitConstants=3)")]
 [numthreads(kzstdgpu_TgSizeX_ParseCompressedBlocks, 1, 1)]
 void main(uint i : SV_DispatchThreadId)
 {

--- a/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
@@ -54,12 +54,16 @@ void main()
 
         // the arguments dependent on block counts/sizes -- these could be computed after ParseFrames
         zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_ComputePrefixSum,         cmpBlockCount,                            kzstdgpu_TgSizeX_PrefixSum_LiteralCount);
-        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_PrefixBlockSizes,         allBlockCount,                            kzstdgpu_TgSizeX_PrefixSum);
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_PrefixBlockSizesAll,      allBlockCount,                            kzstdgpu_TgSizeX_PrefixSum);
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_PrefixBlockSizesRLE,      rleBlockCount,                            kzstdgpu_TgSizeX_PrefixSum);
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_PrefixBlockSizesRAW,      rawBlockCount,                            kzstdgpu_TgSizeX_PrefixSum);
         zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_MemcpyRAW,                ZstdCounters[0].BlocksBytes_RAW,          kzstdgpu_TgSizeX_MemsetMemcpy);
         zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_MemsetRLE,                ZstdCounters[0].BlocksBytes_RLE,          kzstdgpu_TgSizeX_MemsetMemcpy);
         zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_ParseCompressedBlocks,    cmpBlockCount,                            kzstdgpu_TgSizeX_ParseCompressedBlocks);
 
         // Memset dispatch slots for InitResources Stage 1
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_Memset_RawBlockLookback,    zstdgpu_GetLookbackBlockCount(rawBlockCount),                    kzstdgpu_TgSizeX_Memset);
+        zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_Memset_RleBlockLookback,    zstdgpu_GetLookbackBlockCount(rleBlockCount),                    kzstdgpu_TgSizeX_Memset);
         zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_Memset_CmpBlockLookback,    zstdgpu_GetLookbackBlockCount(cmpBlockCount),                    kzstdgpu_TgSizeX_Memset);
         zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_Memset_AllBlockLookback,    zstdgpu_GetLookbackBlockCount(allBlockCount),                    kzstdgpu_TgSizeX_Memset);
         zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_Memset_CmpBlockCount,       cmpBlockCount,                                                   kzstdgpu_TgSizeX_Memset);

--- a/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
+++ b/zstd/zstdgpu/Shaders/ZstdGpuUpdateDispatchArgs.hlsl
@@ -96,9 +96,6 @@ void main()
         zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_PrefixSequenceOffsets,    ZstdCounters[0].Seq_Streams,              kzstdgpu_TgSizeX_PrefixSequenceOffsets);
         zstdgpu_EmitDispatch(ZstdDispatchArgs, ZstdDispatchCnts, kzstdgpu_DispatchSlot_PropagateFseIndex,        ZstdCounters[0].Seq_Streams,              kzstdgpu_TgSizeX_PropagateFseIndex);
 
-        // Update derived counter field in Counters (kept for shader bounds checks)
-        ZstdCounters[0].DecompressSequencesGroups = ZSTDGPU_TG_COUNT(ZstdCounters[0].Seq_Streams, Consts.decompressSequences_StreamsPerTG);
-
         const uint32_t predicateMask = 0
                                      | (litByteCount > Consts.litByteCountMax ? (1u << 3u) : 0u)
                                      | (seqElemCount > Consts.seqElemCountMax ? (1u << 4u) : 0u);

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -2520,7 +2520,7 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     }
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [Readback Counters :: After Block Count] and [Parse Compressed Blocks]");
-        D3D12_RESOURCE_BARRIER barriers[6];
+        D3D12_RESOURCE_BARRIER barriers[10];
         uint32_t bc = 0;
 
         if (zstdgpu_IsReadbackRequired(req, 0))
@@ -2545,9 +2545,13 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             setResourceState(barriers, bc ++, req->resData.gpuOnly.Predicate, UNORDERED_ACCESS, PREDICATION);
 
             // last written by [PrefixSum :: Block Counts]
-            // next bound to [Parse Compressed Blocks] as UAV
+            // next read by [Parse Frames :: Collect Blocks] as UAV
+            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountRAW);
+            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountRLE);
             setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountCMP);
             setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountAll);
+            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockSizesRAW);
+            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockSizesRLE);
         }
         ZSTDGPU_ASSERT(bc <= _countof(barriers));
         cmdList->ResourceBarrier(bc, barriers);

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -833,6 +833,7 @@ static const zstdgpu_CompiledShader kzstdgpu_CompiledShaders [] =
     ZSTDGPU_KERNEL_SCOPE_X(InitResources                        , L"Init Resources"             )   \
     ZSTDGPU_KERNEL_SCOPE_X(ParseFrames                          , L"Parse Frames"               )   \
     ZSTDGPU_KERNEL_SCOPE_X(ParseCompressedBlocks                , L"Parse Compressed Blocks"    )   \
+    ZSTDGPU_KERNEL_SCOPE_X(PrefixBlockSizesRAW_RLE              , L"Prefix Block Sizes (RAW/RLE)")  \
     ZSTDGPU_KERNEL_SCOPE_X(PropagateFseIndex                    , L"Propagate FSE Index"        )   \
     ZSTDGPU_KERNEL_SCOPE_X(UpdateDispatchArgs_Stage1            , L"UpdateDispatchArgs:: Stage1")
 
@@ -2388,17 +2389,13 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->Dispatch(tgCount, 1, 1);
         cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.PerFrameBlockCountAll->GetGPUVirtualAddress() + req->zstdFrameCount * sizeof(uint32_t));
         cmdList->Dispatch(tgCount, 1, 1);
-        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.PerFrameBlockSizesRAW->GetGPUVirtualAddress() + req->zstdFrameCount * sizeof(uint32_t));
-        cmdList->Dispatch(tgCount, 1, 1);
-        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.PerFrameBlockSizesRLE->GetGPUVirtualAddress() + req->zstdFrameCount * sizeof(uint32_t));
-        cmdList->Dispatch(tgCount, 1, 1);
 
         PIXEndEvent(cmdList);
     }
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [Parse Frames :: Count Blocks]");
 
-        D3D12_RESOURCE_BARRIER barriers[8];
+        D3D12_RESOURCE_BARRIER barriers[6];
         uint32_t bc = 0;
 
         // last written by [Init Resources :: Stage 0]
@@ -2417,8 +2414,6 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountRLE);
         setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountCMP);
         setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountAll);
-        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockSizesRAW);
-        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockSizesRLE);
 
         ZSTDGPU_ASSERT(bc <= _countof(barriers));
         cmdList->ResourceBarrier(bc, barriers);
@@ -2439,20 +2434,20 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [PrefixSum :: Block Counts]");
 
-        D3D12_RESOURCE_BARRIER barriers[7];
+        D3D12_RESOURCE_BARRIER barriers[5];
+        uint32_t bc = 0;
         // next written/atomically updated by [Parse Frames :: Count Blocks]
         // next written by [PrefixSum :: Block Counts] to store prefix sum instead of counts
-        setResourceUavSync(barriers, 0, req->resData.gpuOnly.PerFrameBlockCountRAW);
-        setResourceUavSync(barriers, 1, req->resData.gpuOnly.PerFrameBlockCountRLE);
-        setResourceUavSync(barriers, 2, req->resData.gpuOnly.PerFrameBlockCountCMP);
-        setResourceUavSync(barriers, 3, req->resData.gpuOnly.PerFrameBlockCountAll);
-        setResourceUavSync(barriers, 4, req->resData.gpuOnly.PerFrameBlockSizesRAW);
-        setResourceUavSync(barriers, 5, req->resData.gpuOnly.PerFrameBlockSizesRLE);
+        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountRAW);
+        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountRLE);
+        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountCMP);
+        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountAll);
         // last written by [Parse Frames :: Count Blocks]
         // next read by [Update Dispatch Args :: Stage 0] as RWStructuredBuffer (read-only)
         // NOTE: stays in UNORDERED_ACCESS because UpdateDispatchArgs binds Counters as UAV
-        setResourceUavSync(barriers, 6, req->resData.gpuOnly.Counters);
-        cmdList->ResourceBarrier(_countof(barriers), barriers);
+        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.Counters);
+        ZSTDGPU_ASSERT(bc <= _countof(barriers));
+        cmdList->ResourceBarrier(bc, barriers);
         PIXEndEvent(cmdList);
     }
     {
@@ -2486,14 +2481,6 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.PerFrameBlockCountAll->GetGPUVirtualAddress());
             cmdList->SetComputeRootUnorderedAccessView(1, req->resData.gpuOnly.PerFrameBlockCountAll->GetGPUVirtualAddress() + req->zstdFrameCount * sizeof(uint32_t));
             cmdList->Dispatch(tgCountX, 1, 1);
-
-            cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.PerFrameBlockSizesRAW->GetGPUVirtualAddress());
-            cmdList->SetComputeRootUnorderedAccessView(1, req->resData.gpuOnly.PerFrameBlockSizesRAW->GetGPUVirtualAddress() + req->zstdFrameCount * sizeof(uint32_t));
-            cmdList->Dispatch(tgCountX, 1, 1);
-
-            cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.PerFrameBlockSizesRLE->GetGPUVirtualAddress());
-            cmdList->SetComputeRootUnorderedAccessView(1, req->resData.gpuOnly.PerFrameBlockSizesRLE->GetGPUVirtualAddress() + req->zstdFrameCount * sizeof(uint32_t));
-            cmdList->Dispatch(tgCountX, 1, 1);
         });
 
         PIXEndEvent(cmdList);
@@ -2520,7 +2507,7 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     }
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [Readback Counters :: After Block Count] and [Parse Compressed Blocks]");
-        D3D12_RESOURCE_BARRIER barriers[10];
+        D3D12_RESOURCE_BARRIER barriers[8];
         uint32_t bc = 0;
 
         if (zstdgpu_IsReadbackRequired(req, 0))
@@ -2550,8 +2537,6 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountRLE);
             setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountCMP);
             setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountAll);
-            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockSizesRAW);
-            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockSizesRLE);
         }
         ZSTDGPU_ASSERT(bc <= _countof(barriers));
         cmdList->ResourceBarrier(bc, barriers);
@@ -2609,7 +2594,14 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
         cmdList->SetComputeRoot32BitConstant(1, 0 /* value */, 2);
 
-        // Group 1: CmpBlockLookback-sized regions (6 UAV rebinds, same dispatch slot)
+        // Group 1: {Raw,Rle}BlockLookback-sized regions
+        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.RawBlockSizePrefix->GetGPUVirtualAddress() + req->zstdRawBlockCountMax * sizeof(uint32_t));
+        zstdgpu_DispatchIndirect(cmdList, Memset, Memset_RawBlockLookback);
+
+        cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.RleBlockSizePrefix->GetGPUVirtualAddress() + req->zstdRleBlockCountMax * sizeof(uint32_t));
+        zstdgpu_DispatchIndirect(cmdList, Memset, Memset_RleBlockLookback);
+
+        // Group 2: CmpBlockLookback-sized regions (6 UAV rebinds, same dispatch slot)
         cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.LitGroupEndPerHuffmanTable->GetGPUVirtualAddress() + req->zstdCmpBlockCountMax * sizeof(uint32_t));
         zstdgpu_DispatchIndirect(cmdList, Memset, Memset_CmpBlockLookback);
         cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.PerSeqStreamFinalOffset1->GetGPUVirtualAddress() + req->zstdCmpBlockCountMax * sizeof(uint32_t));
@@ -2627,7 +2619,7 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.HufLitCompactionLookback->GetGPUVirtualAddress());
         zstdgpu_DispatchIndirect(cmdList, Memset, Memset_CmpBlockLookback);
 
-        // Group 2: FseIndexLookback{HufW,LLen,Offs,MLen} -- same shape as CmpBlockLookback (lookbackBlockCount uint32 each)
+        // Group 3: FseIndexLookback{HufW,LLen,Offs,MLen} -- same shape as CmpBlockLookback (lookbackBlockCount uint32 each)
         cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.FseIndexLookbackLLen->GetGPUVirtualAddress());
         zstdgpu_DispatchIndirect(cmdList, Memset, Memset_CmpBlockLookback);
         cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.FseIndexLookbackOffs->GetGPUVirtualAddress());
@@ -2635,7 +2627,7 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.FseIndexLookbackMLen->GetGPUVirtualAddress());
         zstdgpu_DispatchIndirect(cmdList, Memset, Memset_CmpBlockLookback);
 
-        // Group 3: HufWIdToHufLitId -- init to ~0 marking all potential Huffman table indices as unused. [Parse Compressed Blocks]
+        // Group 4: HufWIdToHufLitId -- init to ~0 marking all potential Huffman table indices as unused. [Parse Compressed Blocks]
         // would fill in this table with corresponding literal blocks.
         cmdList->SetComputeRoot32BitConstant(1, 0xFFFFFFFFu /* value */, 2);
         cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.HufWIdToHufLitId->GetGPUVirtualAddress());
@@ -2646,7 +2638,7 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[InitResources :: Memset :: Stage 1 :: BlockSize Lookback]");
-        // Group 4: BlockSizePrefix lookback (allBlockCount-sized)
+        // Group 5: BlockSizePrefix lookback (allBlockCount-sized)
         const uint32_t allBlockCount = req->zstdRawBlockCountMax
                                      + req->zstdRleBlockCountMax
                                      + req->zstdCmpBlockCountMax;
@@ -2684,7 +2676,7 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     }
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier with Resources for [Parse Compressed Blocks] and [Memcpy RAW blocks, Memset RLE blocks]");
-        D3D12_RESOURCE_BARRIER barriers[19];
+        D3D12_RESOURCE_BARRIER barriers[21];
 
         uint32_t bc = 0;
         {
@@ -2697,6 +2689,10 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             // so TODO: check if can remove
             setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.FseInfos);
             setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.FseProbs);
+            // last written by [InitResources :: Memset :: Stage 1] into Lookback and [Parse Frames :: Collect Blocks] into payload
+            // next written/updated by [Prefix RAW/RLE Block Sizes]
+            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.RawBlockSizePrefix);
+            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.RleBlockSizePrefix);
             // last written by [InitResources :: Memset :: Stage 1]
             // next written/updated by [Propagate FSE Index]
             setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.FseIndexLookbackLLen);
@@ -2751,8 +2747,30 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     }
 
     {
+        PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"[Prefix RAW/RLE Block Sizes]");
+        d3d12aid_ComputeRsPs_Set(&req->PrefixSum, cmdList);
+
+        // NOTE: Slots 0 (tgOffset) and 1 (workItemCount) are set by command signature via indirect dispatch
+        cmdList->SetComputeRoot32BitConstant(2, 0 /** outputInclusive */, 2);
+
+        ZSTDGPU_KERNEL_SCOPE(PrefixBlockSizesRAW_RLE, cmdList,
+            cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.RawBlockSizePrefix->GetGPUVirtualAddress());
+            cmdList->SetComputeRootUnorderedAccessView(1, req->resData.gpuOnly.RawBlockSizePrefix->GetGPUVirtualAddress() + req->zstdRawBlockCountMax * sizeof(uint32_t));
+
+            zstdgpu_DispatchIndirect(cmdList, PrefixSum, PrefixBlockSizesRAW);
+
+            cmdList->SetComputeRootUnorderedAccessView(0, req->resData.gpuOnly.RleBlockSizePrefix->GetGPUVirtualAddress());
+            cmdList->SetComputeRootUnorderedAccessView(1, req->resData.gpuOnly.RleBlockSizePrefix->GetGPUVirtualAddress() + req->zstdRleBlockCountMax * sizeof(uint32_t));
+
+            zstdgpu_DispatchIndirect(cmdList, PrefixSum, PrefixBlockSizesRLE);
+        );
+
+        PIXEndEvent(cmdList);
+    }
+
+    {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [Readback Counters :: After Block Parse] and [Update Dispatch Args] and [Compute `Per-Huffman Table` Literal Stream Count Prefix]");
-        D3D12_RESOURCE_BARRIER barriers[15];
+        D3D12_RESOURCE_BARRIER barriers[17];
         uint32_t bc = 0;
         {
             // last written by [Parse Compressed Blocks]
@@ -2771,6 +2789,10 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             // last written by [Parse Compressed Blocks]
             // next read by [Prefix Sequence Offsets]
             setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.PerFrameSeqStreamMinIdx);
+            // last written by [Prefix RAW/RLE Block Sizes]
+            // next read by [Memcpy RAW blocks, Memset RLE blocks]
+            setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.RawBlockSizePrefix);
+            setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.RleBlockSizePrefix);
 
             // last written by [Init Resources :: Stage 1] with zero values to lookback data
             // next written by [Decompress Sequences] with encoded "final" offsets per block
@@ -3228,7 +3250,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRoot32BitConstant(2, 1 /** outputInclusive */, 2);
 
         ZSTDGPU_KERNEL_SCOPE(PrefixBlockSizes, cmdList,
-            zstdgpu_DispatchIndirect(cmdList, PrefixSum, PrefixBlockSizes);
+            zstdgpu_DispatchIndirect(cmdList, PrefixSum, PrefixBlockSizesAll);
         );
 
         PIXEndEvent(cmdList);
@@ -3284,7 +3306,7 @@ void zstdgpu_SubmitStage2(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         cmdList->SetComputeRoot32BitConstant(1, req->zstdFrameCount, 2);
 
         ZSTDGPU_KERNEL_SCOPE(ComputeDestBlockOffsets, cmdList,
-            zstdgpu_DispatchIndirect(cmdList, ComputeDestBlockOffsets, PrefixBlockSizes);
+            zstdgpu_DispatchIndirect(cmdList, ComputeDestBlockOffsets, PrefixBlockSizesAll);
         );
 
         PIXEndEvent(cmdList);
@@ -3408,16 +3430,14 @@ ZSTDGPU_API void zstdgpu_ReadbackGpuResults(zstdgpu_PerRequestContext req, ID3D1
     // Read-only resource from the last stage (== 2) get a NON_PS_RESOURCE state as a result of promotion from COMMON state
     // (which happens in case if the stage prior to it (==1) is submitted in a separate CommandList/ExecuteCommandList)
     // and then used as COPY_SOURCE for debug readback
-    D3D12_RESOURCE_BARRIER barriers[13];
+    D3D12_RESOURCE_BARRIER barriers[11];
     uint32_t bc = 0;
     if (zstdgpu_IsReadbackRequired(req, 1))
     {
         setResourceState(barriers, 0, req->resData.gpuOnly.PerFrameBlockCountCMP, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
         setResourceState(barriers, 1, req->resData.gpuOnly.PerFrameBlockCountAll, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
-        setResourceState(barriers, 2, req->resData.gpuOnly.PerFrameBlockSizesRAW, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
-        setResourceState(barriers, 3, req->resData.gpuOnly.PerFrameBlockSizesRLE, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
-        setResourceState(barriers, 4, req->resData.gpuOnly.PerFrameSeqStreamMinIdx, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
-        bc += 5;
+        setResourceState(barriers, 2, req->resData.gpuOnly.PerFrameSeqStreamMinIdx, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
+        bc += 3;
         {
             setResourceState(barriers, bc + 0, req->resData.gpuOnly.GlobalBlockIndexPerCmpBlock, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
             setResourceState(barriers, bc + 1, req->resData.gpuOnly.PerSeqStreamSeqStart, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -2522,30 +2522,32 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [Readback Counters :: After Block Count] and [Parse Compressed Blocks]");
         D3D12_RESOURCE_BARRIER barriers[6];
         uint32_t bc = 0;
-        // last read by [Update Dispatch Args :: Stage 0]
-        // next read by [Readback Counters :: After Block Count] or [Init Resources :: Stage 1]
+
         if (zstdgpu_IsReadbackRequired(req, 0))
         {
+            // last read by [Update Dispatch Args :: Stage 0]
+            // next read by [Readback Counters :: After Block Count]
             setResourceState(barriers, bc ++, req->resData.gpuOnly.Counters, UNORDERED_ACCESS, COPY_SOURCE);
         }
         else
         {
+            // last read by [Update Dispatch Args :: Stage 0]
+            // next read by [Init Resources :: Stage 1]
             setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.Counters);
-        }
-        // last written by [PrefixSum :: Block Counts]
-        // next bound to [Parse Compressed Blocks] as UAV
-        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountCMP);
-        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountAll);
-        // last written by [Update Dispatch Args :: Stage 0]
-        // next read by ExecuteIndirect calls as argument/count buffers
-        setResourceState(barriers, bc ++, req->resData.gpuOnly.DispatchArgs, UNORDERED_ACCESS, INDIRECT_ARGUMENT);
-        setResourceState(barriers, bc ++, req->resData.gpuOnly.DispatchCnts, UNORDERED_ACCESS, INDIRECT_ARGUMENT);
 
-        if (0 == zstdgpu_IsReadbackRequired(req, 0))
-        {
+            // last written by [Update Dispatch Args :: Stage 0]
+            // next read by ExecuteIndirect calls as argument/count buffers
+            setResourceState(barriers, bc ++, req->resData.gpuOnly.DispatchArgs, UNORDERED_ACCESS, INDIRECT_ARGUMENT);
+            setResourceState(barriers, bc ++, req->resData.gpuOnly.DispatchCnts, UNORDERED_ACCESS, INDIRECT_ARGUMENT);
+
             // last written by [Update Dispatch Args :: Stage 0]
             // next read by Stage 1/2 predication
             setResourceState(barriers, bc ++, req->resData.gpuOnly.Predicate, UNORDERED_ACCESS, PREDICATION);
+
+            // last written by [PrefixSum :: Block Counts]
+            // next bound to [Parse Compressed Blocks] as UAV
+            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountCMP);
+            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountAll);
         }
         ZSTDGPU_ASSERT(bc <= _countof(barriers));
         cmdList->ResourceBarrier(bc, barriers);

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -2537,7 +2537,7 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         setResourceState(barriers, bc ++, req->resData.gpuOnly.DispatchArgs, UNORDERED_ACCESS, INDIRECT_ARGUMENT);
         setResourceState(barriers, bc ++, req->resData.gpuOnly.DispatchCnts, UNORDERED_ACCESS, INDIRECT_ARGUMENT);
 
-        if (zstdgpu_HasFlag(req->setupFlags, kzstdgpu_SetupFlags_HasFrameInfoConstants))
+        if (0 == zstdgpu_IsReadbackRequired(req, 0))
         {
             // last written by [Update Dispatch Args :: Stage 0]
             // next read by Stage 1/2 predication

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -2403,10 +2403,14 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
         // last written by [Init Resources :: Stage 0]
         // next written/atomically updated by [Parse Frames :: Count Blocks]
+        // triggers the barrier by immediate dependency between passes
         setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.Counters);
-        // last written by [InitResources :: Memset :: Stage 0]
-        // next written/updated by [Parse Compressed Blocks]
-        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameSeqStreamMinIdx);
+        if (0 == zstdgpu_IsReadbackRequired(req, 0))
+        {
+            // last written by [InitResources :: Memset :: Stage 0]
+            // next written/updated by [Parse Compressed Blocks]
+            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameSeqStreamMinIdx);
+        }
         // last written by [InitResources :: Memset :: Stage 0]
         // next written by [Parse Frames :: Block Counts]
         setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountRAW);
@@ -2416,7 +2420,7 @@ void zstdgpu_SubmitStage0(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockSizesRAW);
         setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockSizesRLE);
 
-        ZSTDGPU_ASSERT(bc == _countof(barriers));
+        ZSTDGPU_ASSERT(bc <= _countof(barriers));
         cmdList->ResourceBarrier(bc, barriers);
         PIXEndEvent(cmdList);
     }
@@ -2674,7 +2678,7 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     }
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier with Resources for [Parse Compressed Blocks] and [Memcpy RAW blocks, Memset RLE blocks]");
-        D3D12_RESOURCE_BARRIER barriers[20];
+        D3D12_RESOURCE_BARRIER barriers[19];
 
         uint32_t bc = 0;
         {
@@ -2695,9 +2699,6 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             // last written by [InitResources :: Memset :: Stage 1] to initialise "lookback" region.
             // next written/updated by [Compute `Per-Huffman Table` Literal Stream Count Prefix]
             setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.LitGroupEndPerHuffmanTable);
-            // last written by [InitResources :: Memset :: Stage 0]
-            // next written/updated by [Parse Compressed Blocks]
-            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.PerFrameSeqStreamMinIdx);
             // last written by [Parse Frames :: Collect Blocks]
             // next read by [Parse Compressed Blocks]
             setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.BlocksCMPRefs);

--- a/zstd/zstdgpu/zstdgpu.cpp
+++ b/zstd/zstdgpu/zstdgpu.cpp
@@ -2676,7 +2676,7 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
     }
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier with Resources for [Parse Compressed Blocks] and [Memcpy RAW blocks, Memset RLE blocks]");
-        D3D12_RESOURCE_BARRIER barriers[21];
+        D3D12_RESOURCE_BARRIER barriers[25];
 
         uint32_t bc = 0;
         {
@@ -2723,12 +2723,22 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             // last written by [Parse Frames :: Collect Blocks]
             // next written/updated by [Parse Compressed Blocks] - sets literal size to be uncompressed block size
             setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.BlockSizePrefix);
-            // last written by [Parse Frames :: Collect Blocks]
-            // next read by [Memcpy RAW blocks, Memset RLE blocks]
-            setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.BlocksRAWRefs);
-            setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.BlocksRLERefs);
+            if (0 == zstdgpu_IsReadbackRequired(req, 1))
+            {
+                // last written by [Parse Frames :: Collect Blocks]
+                // next read by [Memcpy RAW blocks, Memset RLE blocks]
+                setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.BlocksRAWRefs);
+                setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.BlocksRLERefs);
+                setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.GlobalBlockIndexPerRawBlock);
+                setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.GlobalBlockIndexPerRleBlock);
+                // last read by [Parse Frames :: Collect Blocks] as UAV
+                // next read by [Memcpy RAW blocks, Memset RLE blocks]
+                setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountRAW);
+                setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.PerFrameBlockCountRLE);
+            }
         }
 
+        ZSTDGPU_ASSERT(bc <= _countof(barriers));
         cmdList->ResourceBarrier(bc, barriers);
         PIXEndEvent(cmdList);
     }
@@ -2770,19 +2780,12 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
 
     {
         PIXBeginEvent(cmdList, PIX_COLOR_DEFAULT, L"Barrier for [Readback Counters :: After Block Parse] and [Update Dispatch Args] and [Compute `Per-Huffman Table` Literal Stream Count Prefix]");
-        D3D12_RESOURCE_BARRIER barriers[17];
+        D3D12_RESOURCE_BARRIER barriers[15];
         uint32_t bc = 0;
         {
             // last written by [Parse Compressed Blocks]
-            // next read by [Readback Counters :: After Block Parse] or [Update Dispatch Args]
-            if (zstdgpu_IsReadbackRequired(req, 1))
-            {
-                setResourceState(barriers, bc ++, req->resData.gpuOnly.Counters, UNORDERED_ACCESS, COPY_SOURCE);
-            }
-            else
-            {
-                setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.Counters);
-            }
+            // next read by [Update Dispatch Args :: Stage 1] as UAV
+            setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.Counters);
             // last written by [Parse Compressed Blocks]
             // next written/updated by [Decompress Sequences]
             setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.BlockSizePrefix);
@@ -2791,8 +2794,11 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
             setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.PerFrameSeqStreamMinIdx);
             // last written by [Prefix RAW/RLE Block Sizes]
             // next read by [Memcpy RAW blocks, Memset RLE blocks]
-            setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.RawBlockSizePrefix);
-            setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.RleBlockSizePrefix);
+            if (0 == zstdgpu_IsReadbackRequired(req, 1))
+            {
+                setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.RawBlockSizePrefix);
+                setResourceUavToSrvSync(barriers, bc ++, req->resData.gpuOnly.RleBlockSizePrefix);
+            }
 
             // last written by [Init Resources :: Stage 1] with zero values to lookback data
             // next written by [Decompress Sequences] with encoded "final" offsets per block
@@ -2859,15 +2865,18 @@ void zstdgpu_SubmitStage1(zstdgpu_PerRequestContext req, ID3D12GraphicsCommandLi
         // next read by [Propagate FSE Index] / [Compute `Per-Huffman Table` Literal Stream Count Prefix] via ExecuteIndirect
         setResourceState(barriers, bc ++, req->resData.gpuOnly.DispatchArgs, UNORDERED_ACCESS, INDIRECT_ARGUMENT);
         setResourceState(barriers, bc ++, req->resData.gpuOnly.DispatchCnts, UNORDERED_ACCESS, INDIRECT_ARGUMENT);
-        // last written by [Update Dispatch Args]
-        // next read/written by [Compute `Per-Huffman Table` Literal Stream Count Prefix]
-        setResourceUavSync(barriers, bc ++, req->resData.gpuOnly.Counters);
 
         if (0 == zstdgpu_IsReadbackRequired(req, 1))
         {
             // last written by [Update Dispatch Args :: Stage 1]
             // next read by SetPredication as PREDICATION
             setResourceState(barriers, bc ++, req->resData.gpuOnly.Predicate, UNORDERED_ACCESS, PREDICATION);
+        }
+        else
+        {
+            // last read by [Update Dispatch Args :: Stage 1] as UAV
+            // next read by [Readback Counters :: After Block Parse]
+            setResourceState(barriers, bc ++, req->resData.gpuOnly.Counters, UNORDERED_ACCESS, COPY_SOURCE);
         }
 
         ZSTDGPU_ASSERT(bc <= _countof(barriers));
@@ -3430,7 +3439,7 @@ ZSTDGPU_API void zstdgpu_ReadbackGpuResults(zstdgpu_PerRequestContext req, ID3D1
     // Read-only resource from the last stage (== 2) get a NON_PS_RESOURCE state as a result of promotion from COMMON state
     // (which happens in case if the stage prior to it (==1) is submitted in a separate CommandList/ExecuteCommandList)
     // and then used as COPY_SOURCE for debug readback
-    D3D12_RESOURCE_BARRIER barriers[11];
+    D3D12_RESOURCE_BARRIER barriers[13];
     uint32_t bc = 0;
     if (zstdgpu_IsReadbackRequired(req, 1))
     {
@@ -3455,6 +3464,9 @@ ZSTDGPU_API void zstdgpu_ReadbackGpuResults(zstdgpu_PerRequestContext req, ID3D1
             setResourceState(barriers, bc + 2, req->resData.gpuOnly.BlocksRLERefs, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
             bc += 3;
         }
+        setResourceState(barriers, bc + 0, req->resData.gpuOnly.HufWIdToHufLitId, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
+        setResourceState(barriers, bc + 1, req->resData.gpuOnly.HufLitIdToLitStreamId, NON_PIXEL_SHADER_RESOURCE, COPY_SOURCE);
+        bc += 2;
     }
 
     if (bc > 0)

--- a/zstd/zstdgpu/zstdgpu_resources.h
+++ b/zstd/zstdgpu/zstdgpu_resources.h
@@ -34,8 +34,6 @@
     ZSTDGPU_BUFFER(uint32_t                                 , PerFrameBlockCountRLE         )   \
     ZSTDGPU_BUFFER(uint32_t                                 , PerFrameBlockCountCMP         )   \
     ZSTDGPU_BUFFER(uint32_t                                 , PerFrameBlockCountAll         )   \
-    ZSTDGPU_BUFFER(uint32_t                                 , PerFrameBlockSizesRAW         )   \
-    ZSTDGPU_BUFFER(uint32_t                                 , PerFrameBlockSizesRLE         )   \
     ZSTDGPU_BUFFER(uint32_t                                 , PerFrameSeqStreamMinIdx       )
 
 #define ZSTDGPU_BUFFERS_LIST_STAGE_0() \
@@ -274,8 +272,6 @@ static void zstdgpu_ResourceInfo_Stage_0_InitSize(zstdgpu_ResourceInfo *outInfo,
     const uint32_t PerFrameBlockCountRLE_Count = PerFrameBlockCountRAW_Count;
     const uint32_t PerFrameBlockCountCMP_Count = PerFrameBlockCountRAW_Count;
     const uint32_t PerFrameBlockCountAll_Count = PerFrameBlockCountRAW_Count;
-    const uint32_t PerFrameBlockSizesRAW_Count = PerFrameBlockCountRAW_Count;
-    const uint32_t PerFrameBlockSizesRLE_Count = PerFrameBlockCountRLE_Count;
     const uint32_t PerFrameSeqStreamMinIdx_Count = frameCount;
     const uint32_t DispatchArgs_Count = kzstdgpu_DispatchSlot_Count * kzstdgpu_DispatchSlot_StrideInUInt32;
     const uint32_t DispatchCnts_Count = kzstdgpu_DispatchSlot_Count;
@@ -291,8 +287,8 @@ static void zstdgpu_ResourceInfo_Stage_1_InitSize(zstdgpu_ResourceInfo *outInfo,
     const uint32_t BlocksCMPRefs_Count = cmpBlockCount;
     const uint32_t allBlockCount = rawBlockCount + rleBlockCount + cmpBlockCount;
 
-    const uint32_t RawBlockSizePrefix_Count = rawBlockCount;
-    const uint32_t RleBlockSizePrefix_Count = rleBlockCount;
+    const uint32_t RawBlockSizePrefix_Count = rawBlockCount + zstdgpu_GetLookbackBlockCount(rawBlockCount);
+    const uint32_t RleBlockSizePrefix_Count = rleBlockCount + zstdgpu_GetLookbackBlockCount(rleBlockCount);
 
     // TODO: this must a total of all blocks (including RLE and RAW)
     const uint32_t BlockSizePrefix_Count = allBlockCount + zstdgpu_GetLookbackBlockCount(allBlockCount);

--- a/zstd/zstdgpu/zstdgpu_resources.h
+++ b/zstd/zstdgpu/zstdgpu_resources.h
@@ -36,8 +36,7 @@
     ZSTDGPU_BUFFER(uint32_t                                 , PerFrameBlockCountAll         )   \
     ZSTDGPU_BUFFER(uint32_t                                 , PerFrameBlockSizesRAW         )   \
     ZSTDGPU_BUFFER(uint32_t                                 , PerFrameBlockSizesRLE         )   \
-    ZSTDGPU_BUFFER(uint32_t                                 , PerFrameSeqStreamMinIdx       )   \
-    ZSTDGPU_BUFFER(zstdgpu_FrameInfo                        , Frames                        )
+    ZSTDGPU_BUFFER(uint32_t                                 , PerFrameSeqStreamMinIdx       )
 
 #define ZSTDGPU_BUFFERS_LIST_STAGE_0() \
     ZSTDGPU_BUFFER(uint32_t                                 , DispatchArgs                  )   \
@@ -268,7 +267,6 @@ static void zstdgpu_ResourceInfo_Stage_0_InitSize(zstdgpu_ResourceInfo *outInfo,
                                          + kzstdgpu_FseDefaultProbCount_Offs
                                          + kzstdgpu_FseDefaultProbCount_MLen;
 
-    const uint32_t Frames_Count = frameCount;
     const uint32_t FramesRefs_Count = frameCount;
     const uint32_t CompressedData_Count = (dataCount + 3) / 4; // because CompressedData is in uint32_t
     const uint32_t Counters_Count = 1;

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -567,7 +567,6 @@ static inline void zstdgpu_ShaderEntry_ParseFrames(ZSTDGPU_PARAM_INOUT(zstdgpu_P
                 bits,
                 srt.countBlocksOnly > 0 ? 0u : 1u
             );
-            srt.inoutFrames[threadId] = frameInfo;
 
             if (srt.countBlocksOnly > 0)
             {

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -467,7 +467,7 @@ static inline void zstdgpu_ShaderEntry_ParseFrame(ZSTDGPU_PARAM_INOUT(zstdgpu_Fr
                 outBlocksRAWRefs[outFrameInfo.rawBlockStart].offs = blockOffs;
                 outBlocksRAWRefs[outFrameInfo.rawBlockStart].size = blockSize;
 
-                outRawBlockSizes[outFrameInfo.rawBlockStart] = outFrameInfo.rawBlockBytesStart;
+                outRawBlockSizes[outFrameInfo.rawBlockStart] = blockSize;
                 outGlobalBlockIndexPerRawBlock[outFrameInfo.rawBlockStart] = blockIndex;
             }
 
@@ -476,7 +476,7 @@ static inline void zstdgpu_ShaderEntry_ParseFrame(ZSTDGPU_PARAM_INOUT(zstdgpu_Fr
                 outBlocksRLERefs[outFrameInfo.rleBlockStart].offs = blockOffs;
                 outBlocksRLERefs[outFrameInfo.rleBlockStart].size = blockSize;
 
-                outRleBlockSizes[outFrameInfo.rleBlockStart] = outFrameInfo.rleBlockBytesStart;
+                outRleBlockSizes[outFrameInfo.rleBlockStart] = blockSize;
                 outGlobalBlockIndexPerRleBlock[outFrameInfo.rleBlockStart] = blockIndex;
             }
 
@@ -548,9 +548,6 @@ static inline void zstdgpu_ShaderEntry_ParseFrames(ZSTDGPU_PARAM_INOUT(zstdgpu_P
                 frameInfo.rawBlockStart = srt.inoutPerFrameBlockCountRAW[threadId];
                 frameInfo.rleBlockStart = srt.inoutPerFrameBlockCountRLE[threadId];
                 frameInfo.cmpBlockStart = srt.inoutPerFrameBlockCountCMP[threadId];
-
-                frameInfo.rawBlockBytesStart = srt.inoutPerFrameBlockSizesRAW[threadId];
-                frameInfo.rleBlockBytesStart = srt.inoutPerFrameBlockSizesRLE[threadId];
             }
 
             zstdgpu_ShaderEntry_ParseFrame(
@@ -576,9 +573,6 @@ static inline void zstdgpu_ShaderEntry_ParseFrames(ZSTDGPU_PARAM_INOUT(zstdgpu_P
                 srt.inoutPerFrameBlockCountAll[threadId] = frameInfo.rawBlockStart
                                                          + frameInfo.rleBlockStart
                                                          + frameInfo.cmpBlockStart;
-
-                srt.inoutPerFrameBlockSizesRAW[threadId] = frameInfo.rawBlockBytesStart;
-                srt.inoutPerFrameBlockSizesRLE[threadId] = frameInfo.rleBlockBytesStart;
 
                 const uint32_t rawBlockCount = WaveActiveSum(frameInfo.rawBlockStart);
                 const uint32_t rleBlockCount = WaveActiveSum(frameInfo.rleBlockStart);

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -622,7 +622,6 @@ static void zstdgpu_ShaderEntry_InitResources(ZSTDGPU_PARAM_INOUT(zstdgpu_InitRe
             srt.inoutCounters[0].FseOffs                                     = 1;
             srt.inoutCounters[0].FseMLen                                     = 1;
             srt.inoutCounters[0].DecompressLiteralsGroups                    = 0;
-            srt.inoutCounters[0].DecompressSequencesGroups                   = 0;
             srt.inoutCounters[0].HUF_WgtStreams                              = 0;
             srt.inoutCounters[0].Seq_Streams_DecodedItems                    = 0;
             srt.inoutCounters[0].HUF_Streams_DecodedBytes                    = 0;

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -1597,23 +1597,22 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t initResou
     ZSTDGPU_RO_BUFFER_DECL(zstdgpu_OffsetAndSize                , FramesRefs                    , 1)    \
     \
     ZSTDGPU_RW_BUFFER_DECL(zstdgpu_Counters                     , Counters                      , 0)    \
-    ZSTDGPU_RW_BUFFER_DECL(zstdgpu_FrameInfo                    , Frames                        , 1)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameBlockCountRAW         , 2)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameBlockCountRLE         , 3)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameBlockCountCMP         , 4)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameBlockCountAll         , 5)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameBlockSizesRAW         , 6)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameBlockSizesRLE         , 7)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , RawBlockSizePrefix            , 8)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , RleBlockSizePrefix            , 9)    \
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameBlockCountRAW         , 1)    \
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameBlockCountRLE         , 2)    \
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameBlockCountCMP         , 3)    \
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameBlockCountAll         , 4)    \
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameBlockSizesRAW         , 5)    \
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameBlockSizesRLE         , 6)    \
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , RawBlockSizePrefix            , 7)    \
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , RleBlockSizePrefix            , 8)    \
     \
-    ZSTDGPU_RW_BUFFER_DECL(zstdgpu_OffsetAndSize                , BlocksRAWRefs                 ,10)    \
-    ZSTDGPU_RW_BUFFER_DECL(zstdgpu_OffsetAndSize                , BlocksRLERefs                 ,11)    \
-    ZSTDGPU_RW_BUFFER_DECL(zstdgpu_OffsetAndSize                , BlocksCMPRefs                 ,12)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , BlockSizePrefix               ,13)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , GlobalBlockIndexPerRawBlock   ,14)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , GlobalBlockIndexPerRleBlock   ,15)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , GlobalBlockIndexPerCmpBlock   ,16)
+    ZSTDGPU_RW_BUFFER_DECL(zstdgpu_OffsetAndSize                , BlocksRAWRefs                 , 9)    \
+    ZSTDGPU_RW_BUFFER_DECL(zstdgpu_OffsetAndSize                , BlocksRLERefs                 ,10)    \
+    ZSTDGPU_RW_BUFFER_DECL(zstdgpu_OffsetAndSize                , BlocksCMPRefs                 ,11)    \
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , BlockSizePrefix               ,12)    \
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , GlobalBlockIndexPerRawBlock   ,13)    \
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , GlobalBlockIndexPerRleBlock   ,14)    \
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , GlobalBlockIndexPerCmpBlock   ,15)
 
 #define ZSTDGPU_INIT_RESOURCES_SRT()                                                                    \
     ZSTDGPU_RO_TYPED_BUFFER_DECL(int32_t, int16_t               , FseProbsDefault               , 0)    \

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -325,15 +325,19 @@ static const uint32_t kzstdgpu_DispatchSlot_DecompressSequences          = 8;
 static const uint32_t kzstdgpu_DispatchSlot_FinaliseSequenceOffsets      = 9;
 static const uint32_t kzstdgpu_DispatchSlot_PrefixSequenceOffsets        = 10;
 static const uint32_t kzstdgpu_DispatchSlot_ComputePrefixSum             = 11;
-static const uint32_t kzstdgpu_DispatchSlot_PrefixBlockSizes             = 12;
-static const uint32_t kzstdgpu_DispatchSlot_MemcpyRAW                    = 13;
-static const uint32_t kzstdgpu_DispatchSlot_MemsetRLE                    = 14;
-static const uint32_t kzstdgpu_DispatchSlot_ParseCompressedBlocks        = 15;
-static const uint32_t kzstdgpu_DispatchSlot_Memset_CmpBlockLookback      = 16;
-static const uint32_t kzstdgpu_DispatchSlot_Memset_AllBlockLookback      = 17;
-static const uint32_t kzstdgpu_DispatchSlot_PropagateFseIndex            = 18;
-static const uint32_t kzstdgpu_DispatchSlot_Memset_CmpBlockCount         = 19;
-static const uint32_t kzstdgpu_DispatchSlot_Count                        = 20;
+static const uint32_t kzstdgpu_DispatchSlot_PrefixBlockSizesAll          = 12;
+static const uint32_t kzstdgpu_DispatchSlot_PrefixBlockSizesRAW          = 13;
+static const uint32_t kzstdgpu_DispatchSlot_PrefixBlockSizesRLE          = 14;
+static const uint32_t kzstdgpu_DispatchSlot_MemcpyRAW                    = 15;
+static const uint32_t kzstdgpu_DispatchSlot_MemsetRLE                    = 16;
+static const uint32_t kzstdgpu_DispatchSlot_ParseCompressedBlocks        = 17;
+static const uint32_t kzstdgpu_DispatchSlot_Memset_RawBlockLookback      = 18;
+static const uint32_t kzstdgpu_DispatchSlot_Memset_RleBlockLookback      = 19;
+static const uint32_t kzstdgpu_DispatchSlot_Memset_CmpBlockLookback      = 20;
+static const uint32_t kzstdgpu_DispatchSlot_Memset_AllBlockLookback      = 21;
+static const uint32_t kzstdgpu_DispatchSlot_PropagateFseIndex            = 22;
+static const uint32_t kzstdgpu_DispatchSlot_Memset_CmpBlockCount         = 23;
+static const uint32_t kzstdgpu_DispatchSlot_Count                        = 24;
 
 #if defined(_GAMING_XBOX) || defined(__XBOX_SCARLETT) || defined(__XBOX_ONE)
 static const uint32_t kzstdgpu_DispatchSlot_CmdsPerSlot                  = 1;
@@ -1601,18 +1605,16 @@ static inline uint32_t zstdgpu_InitResources_GetDispatchSizeX(uint32_t initResou
     ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameBlockCountRLE         , 2)    \
     ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameBlockCountCMP         , 3)    \
     ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameBlockCountAll         , 4)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameBlockSizesRAW         , 5)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , PerFrameBlockSizesRLE         , 6)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , RawBlockSizePrefix            , 7)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , RleBlockSizePrefix            , 8)    \
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , RawBlockSizePrefix            , 5)    \
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , RleBlockSizePrefix            , 6)    \
     \
-    ZSTDGPU_RW_BUFFER_DECL(zstdgpu_OffsetAndSize                , BlocksRAWRefs                 , 9)    \
-    ZSTDGPU_RW_BUFFER_DECL(zstdgpu_OffsetAndSize                , BlocksRLERefs                 ,10)    \
-    ZSTDGPU_RW_BUFFER_DECL(zstdgpu_OffsetAndSize                , BlocksCMPRefs                 ,11)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , BlockSizePrefix               ,12)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , GlobalBlockIndexPerRawBlock   ,13)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , GlobalBlockIndexPerRleBlock   ,14)    \
-    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , GlobalBlockIndexPerCmpBlock   ,15)
+    ZSTDGPU_RW_BUFFER_DECL(zstdgpu_OffsetAndSize                , BlocksRAWRefs                 , 7)    \
+    ZSTDGPU_RW_BUFFER_DECL(zstdgpu_OffsetAndSize                , BlocksRLERefs                 , 8)    \
+    ZSTDGPU_RW_BUFFER_DECL(zstdgpu_OffsetAndSize                , BlocksCMPRefs                 , 9)    \
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , BlockSizePrefix               ,10)    \
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , GlobalBlockIndexPerRawBlock   ,11)    \
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , GlobalBlockIndexPerRleBlock   ,12)    \
+    ZSTDGPU_RW_BUFFER_DECL(uint32_t                             , GlobalBlockIndexPerCmpBlock   ,13)
 
 #define ZSTDGPU_INIT_RESOURCES_SRT()                                                                    \
     ZSTDGPU_RO_TYPED_BUFFER_DECL(int32_t, int16_t               , FseProbsDefault               , 0)    \

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -294,7 +294,6 @@ typedef struct zstdgpu_Counters
     uint32_t FseOffs;
     uint32_t FseMLen;
     uint32_t DecompressLiteralsGroups;
-    uint32_t DecompressSequencesGroups;
 
     uint32_t HUF_WgtStreams;
     uint32_t Seq_Streams_DecodedItems;


### PR DESCRIPTION
This PR fixes resources transitions and replaces 3 buffers with existing buffers and prefix sum passes to decouple from implicit prefix sum calculation in during 2nd frame parsing.