### PR TITLE
Update Zstd CI Test Matrix

### DIFF
--- a/zstd/zstdgpu_ci_tests/main.cpp
+++ b/zstd/zstdgpu_ci_tests/main.cpp
@@ -178,7 +178,7 @@ static bool ParseArgs(int argc, char** argv, TestConfig& config, bool& shouldExi
         {
             config.perfMinMB = std::atoi(argv[++i]);
             if (config.perfMinMB < 0)
-                config.perfMinMB = 0;   // 0 = disable perf-size skip; sub-1MB files still skip via > 0 check
+                config.perfMinMB = 0;   // <= 0 disables the perf-size skip (all files eligible for perf)
         }
         else if (std::strcmp(argv[i], "--gbv-sample-count") == 0 && i + 1 < argc)
         {

--- a/zstd/zstdgpu_ci_tests/main.cpp
+++ b/zstd/zstdgpu_ci_tests/main.cpp
@@ -41,9 +41,8 @@ TestConfig g_testConfig;
 //
 // Uses the non-throwing overloads of recursive_directory_iterator so a single
 // unreadable subdirectory anywhere in the tree does not abort the entire walk
-// (which would take down the process before any test runs — see review
-// feedback on the throwing overload). Per-entry errors are logged as warnings
-// and the walk continues.
+// (the throwing overloads would terminate the process before any test runs).
+// Per-entry errors are logged as warnings and the walk continues.
 
 std::vector<std::string> DiscoverZstFiles(const std::string& contentPath)
 {
@@ -97,8 +96,8 @@ std::vector<std::string> DiscoverZstFiles(const std::string& contentPath)
 
 // CLI and entry point
 
-// QOL for diagnostics. For running manually
-// Activate with --help-ci to avoid conflicting with GTest's own --help output.
+// Prints CLI usage for manual and diagnostic runs. Activated with --help-ci to
+// avoid conflicting with GTest's own --help output.
 static void PrintUsage(const char* exe)
 {
     std::cout << "Usage: " << exe << " [gtest_options] [options]\n"
@@ -110,6 +109,10 @@ static void PrintUsage(const char* exe)
               << "  --log-file <path>       Consolidated text log file\n"
               << "  --run-count <N>         Perf test iteration count (default: 40)\n"
               << "  --timeout <seconds>     Per-test process timeout (default: no timeout)\n"
+              << "  --perf-min-mb <N>       Minimum .zst file size (MB) required for perf tests (default: 4).\n"
+              << "                          Smaller files skip perf; individually-compressed textures are not representative of throughput.\n"
+              << "  --gbv-sample-count <N>  Number of files the GBV scenarios run on, sampled by an even stride\n"
+              << "                          across the sorted corpus (default: 10). A value <= 0 runs GBV on all files.\n"
               << "  --adversarial-manifest <path>   Optional JSON manifest of known-adversarial fuzz files.\n"
               << "                                  If NOT specified, the wrapper auto-discovers the manifest at\n"
               << "                                  <content-path>/adversarial_manifest.json. If found (either way),\n"
@@ -170,6 +173,18 @@ static bool ParseArgs(int argc, char** argv, TestConfig& config, bool& shouldExi
         else if (std::strcmp(argv[i], "--adversarial-manifest") == 0 && i + 1 < argc)
         {
             config.adversarialManifestPath = argv[++i];
+        }
+        else if (std::strcmp(argv[i], "--perf-min-mb") == 0 && i + 1 < argc)
+        {
+            config.perfMinMB = std::atoi(argv[++i]);
+            if (config.perfMinMB < 0)
+                config.perfMinMB = 0;   // 0 = disable perf-size skip; sub-1MB files still skip via > 0 check
+        }
+        else if (std::strcmp(argv[i], "--gbv-sample-count") == 0 && i + 1 < argc)
+        {
+            config.gbvSampleCount = std::atoi(argv[++i]);
+            if (config.gbvSampleCount < 0)
+                config.gbvSampleCount = 0;   // <= 0 = no cap; GBV runs on every file
         }
         else if (std::strcmp(argv[i], "--help-ci") == 0)
         {

--- a/zstd/zstdgpu_ci_tests/zstdgpu_ci_tests.cpp
+++ b/zstd/zstdgpu_ci_tests/zstdgpu_ci_tests.cpp
@@ -10,17 +10,25 @@
 // Test definitions and demo runner for the Zstd GPU CI tests.
 //
 // Parameterized test suite (ZstdGpuDemoTests) instantiated once per .zst file
-// under the content path. Each file produces 6 scenarios:
+// under the content path. Each file produces the following scenarios:
 //
-//   Correctness (ASSERT — hard fail):
-//     - SimulationCheck  : --sim-gpu with CPU+GPU validation
-//     - D3D12DebugLayer  : --d3d-dbg
-//     - ExternalMemory   : --ext-mem
-//     - GraphicsQueue    : --d3d-gfx
+//   Correctness — "for all data" (ASSERT — hard fail):
+//     - GpuCheck           : --chk-gpu
+//     - GpuCheckSeq        : --chk-gpu --seq-cnt
+//     - ExternalMemory     : --chk-gpu --ext-mem
+//     - ExternalMemorySeq  : --chk-gpu --ext-mem --seq-cnt
+//     - D3D12DebugLayer    : --chk-gpu --d3d-dbg            (skipped on ARM)
+//     - D3D12DebugLayerSeq : --chk-gpu --d3d-dbg --seq-cnt  (skipped on ARM)
+//     - SimulationCheck    : --chk-gpu --chk-cpu --sim-gpu
+//     - SimulationCheckSeq : --chk-gpu --chk-cpu --sim-gpu --seq-cnt
+//
+//   Correctness — GBV (ASSERT; skipped on ARM; run only on the stride-selected
+//   subset of files chosen by --gbv-sample-count):
+//     - Gbv                : --chk-gpu --d3d-dbg --d3d-gbv
+//     - GbvSeq             : --chk-gpu --d3d-dbg --d3d-gbv --seq-cnt
 //
 //   Performance (EXPECT — soft fail, also verify CSV output was written):
-//     - OverallThroughput: --prf-lvl 0 → results/throughput_<stem>.csv
-//     - PerStageTiming   : --prf-lvl 2 → results/stages_<stem>.csv
+//     - PerStageTiming     : --prf-lvl 2 --d3d-gfx --seq-cnt → results/stages_<stem>.csv
 
 #include "zstdgpu_ci_tests.h"
 #include <gtest/gtest.h>
@@ -30,6 +38,7 @@
 #include <iostream>
 #include <sstream>
 #include <thread>
+#include <unordered_set>
 #include <Windows.h>
 
 // Internal types + forward declarations
@@ -63,7 +72,8 @@ namespace
         const std::string& zstFile,
         int profilingLevel,
         int runCount,
-        const std::string& csvOutputPath);
+        const std::string& csvOutputPath,
+        const std::vector<std::string>& extraFlags);
 }
 
 // Helpers
@@ -161,6 +171,62 @@ static bool IsFuzzContent(const std::string& zstFile)
     return false;
 }
 
+// Returns the set of files the Gbv/GbvSeq scenarios run on: an even, endpoint-
+// inclusive stride of g_testConfig.gbvSampleCount files across the sorted
+// discovered-file list. A count <= 0, or a corpus no larger than the count,
+// selects every file; a count of 1 selects the first file. Computed once.
+static const std::unordered_set<std::string>& GbvSampledFiles()
+{
+    static const std::unordered_set<std::string> selected = []
+    {
+        std::unordered_set<std::string> s;
+        const auto& files = g_testConfig.discoveredFiles;   // sorted full paths
+        const size_t n = files.size();
+        if (n == 0)
+            return s;
+        const int target = g_testConfig.gbvSampleCount;
+        if (target <= 0 || n <= static_cast<size_t>(target))
+        {
+            // count <= 0, or corpus no larger than the count: select every file.
+            s.insert(files.begin(), files.end());
+            return s;
+        }
+        if (target == 1)
+        {
+            s.insert(files.front());
+            return s;
+        }
+        const size_t t = static_cast<size_t>(target);
+        // Endpoint-inclusive stride: indices 0 .. n-1 taken in t steps so the
+        // sample spans the whole sorted list (first through last).
+        for (size_t i = 0; i < t; ++i)
+        {
+            const size_t idx = (i * (n - 1)) / (t - 1);
+            s.insert(files[idx]);
+        }
+        return s;
+    }();
+    return selected;
+}
+
+// True if this file is one of the stride-selected files the GBV scenarios run on.
+static bool IsSelectedForGbv(const std::string& zstFile)
+{
+    const auto& sel = GbvSampledFiles();
+    return sel.find(zstFile) != sel.end();
+}
+
+// True if the file is smaller than --perf-min-mb. Returns false when
+// --perf-min-mb <= 0 (disabled) or the file size cannot be read.
+static bool IsSmallForPerf(const std::string& zstFile)
+{
+    if (g_testConfig.perfMinMB <= 0) return false;
+    std::error_code ec;
+    auto size = std::filesystem::file_size(zstFile, ec);
+    if (ec) return false;
+    return size < static_cast<uintmax_t>(g_testConfig.perfMinMB) * 1024ULL * 1024ULL;
+}
+
 // If the adversarial manifest lists this file, verify that the demo rejected it
 // with the expected exit code. Returns true iff the outcome is a correct
 // rejection, or false if the file isn't in the manifest (in which case the
@@ -242,7 +308,8 @@ static void RunCorrectnessTest(const std::string& zstFile, const std::vector<std
 
 // Run a performance scenario. Spawns zstdgpu_demo.exe with profiling flags and requests CSV output. Uses EXPECT (not ASSERT) to verify the demo executed successfully and produced CSV output.
 // main() has already validated the demo path exists.
-static void RunPerformanceTest(const std::string& zstFile, int profilingLevel)
+static void RunPerformanceTest(const std::string& zstFile, int profilingLevel,
+                                const std::vector<std::string>& extraFlags)
 {
     // Fuzzing content mixes clean and corrupt inputs with varying code paths,
     // so its timing isn't meaningful perf data — skip it before running the demo.
@@ -254,19 +321,26 @@ static void RunPerformanceTest(const std::string& zstFile, int profilingLevel)
         return;
     }
 
-    // Build CSV output path matching spec convention:
-    //   prf-lvl 0 → results/throughput_<stem>.csv
-    //   prf-lvl 2 → results/stages_<stem>.csv
+    // Skip files smaller than --perf-min-mb.
+    if (IsSmallForPerf(zstFile))
+    {
+        GTEST_SKIP()
+            << "Perf test skipped: file is under --perf-min-mb ("
+            << g_testConfig.perfMinMB << " MB).\n"
+            << "File: " << zstFile;
+        return;
+    }
+
+    // Perf CSVs are written as stages_<stem>.csv under the results directory.
     std::string stem = std::filesystem::path(zstFile).stem().string();
-    std::string prefix = (profilingLevel == 0) ? "throughput" : "stages";
     std::filesystem::path resultsDir = std::filesystem::path(g_testConfig.logDir) / "results";
     if (!std::filesystem::exists(resultsDir))
     {
         std::filesystem::create_directories(resultsDir);
     }
-    std::string csvPath = (resultsDir / (prefix + "_" + stem + ".csv")).string();
+    std::string csvPath = (resultsDir / ("stages_" + stem + ".csv")).string();
 
-    auto args = BuildPerformanceArgs(zstFile, profilingLevel, g_testConfig.runCount, csvPath);
+    auto args = BuildPerformanceArgs(zstFile, profilingLevel, g_testConfig.runCount, csvPath, extraFlags);
     auto result = RunDemo(g_testConfig.demoPath, args, g_testConfig.timeoutSeconds);
 
     // Write to log file before assertions so logs are captured even if a check fails.
@@ -312,11 +386,28 @@ class ZstdGpuDemoTests : public ::testing::TestWithParam<std::string>
 {
 };
 
-// --- Correctness tests ---
+// --- Correctness tests — "for all data" matrix ---
 
-TEST_P(ZstdGpuDemoTests, SimulationCheck)
+// GPU correctness check (--chk-gpu only).
+TEST_P(ZstdGpuDemoTests, GpuCheck)
 {
-    RunCorrectnessTest(GetParam(), {"--chk-gpu", "--chk-cpu", "--sim-gpu"});
+    RunCorrectnessTest(GetParam(), {"--chk-gpu"});
+}
+
+// GpuCheck in single-submission mode (--seq-cnt).
+TEST_P(ZstdGpuDemoTests, GpuCheckSeq)
+{
+    RunCorrectnessTest(GetParam(), {"--chk-gpu", "--seq-cnt"});
+}
+
+TEST_P(ZstdGpuDemoTests, ExternalMemory)
+{
+    RunCorrectnessTest(GetParam(), {"--chk-gpu", "--ext-mem"});
+}
+
+TEST_P(ZstdGpuDemoTests, ExternalMemorySeq)
+{
+    RunCorrectnessTest(GetParam(), {"--chk-gpu", "--ext-mem", "--seq-cnt"});
 }
 
 TEST_P(ZstdGpuDemoTests, D3D12DebugLayer)
@@ -328,26 +419,64 @@ TEST_P(ZstdGpuDemoTests, D3D12DebugLayer)
 #endif
 }
 
-TEST_P(ZstdGpuDemoTests, ExternalMemory)
+TEST_P(ZstdGpuDemoTests, D3D12DebugLayerSeq)
 {
-    RunCorrectnessTest(GetParam(), {"--chk-gpu", "--ext-mem"});
+#if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_ARM64EC)
+    GTEST_SKIP() << "D3D12 debug layer tests are skipped on ARM platforms.";
+#else
+    RunCorrectnessTest(GetParam(), {"--chk-gpu", "--d3d-dbg", "--seq-cnt"});
+#endif
 }
 
-TEST_P(ZstdGpuDemoTests, GraphicsQueue)
+TEST_P(ZstdGpuDemoTests, SimulationCheck)
 {
-    RunCorrectnessTest(GetParam(), {"--chk-gpu", "--d3d-gfx"});
+    RunCorrectnessTest(GetParam(), {"--chk-gpu", "--chk-cpu", "--sim-gpu"});
+}
+
+TEST_P(ZstdGpuDemoTests, SimulationCheckSeq)
+{
+    RunCorrectnessTest(GetParam(), {"--chk-gpu", "--chk-cpu", "--sim-gpu", "--seq-cnt"});
+}
+
+// --- Correctness tests — GBV ---
+
+TEST_P(ZstdGpuDemoTests, Gbv)
+{
+#if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_ARM64EC)
+    GTEST_SKIP() << "D3D12 debug layer tests are skipped on ARM platforms.";
+#else
+    if (!IsSelectedForGbv(GetParam()))
+    {
+        GTEST_SKIP() << "GBV skipped: file is not in the stride-selected GBV sample ("
+                     << g_testConfig.gbvSampleCount << " files).";
+        return;
+    }
+    RunCorrectnessTest(GetParam(), {"--chk-gpu", "--d3d-dbg", "--d3d-gbv"});
+#endif
+}
+
+TEST_P(ZstdGpuDemoTests, GbvSeq)
+{
+#if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_ARM64EC)
+    GTEST_SKIP() << "D3D12 debug layer tests are skipped on ARM platforms.";
+#else
+    if (!IsSelectedForGbv(GetParam()))
+    {
+        GTEST_SKIP() << "GBV skipped: file is not in the stride-selected GBV sample ("
+                     << g_testConfig.gbvSampleCount << " files).";
+        return;
+    }
+    RunCorrectnessTest(GetParam(), {"--chk-gpu", "--d3d-dbg", "--d3d-gbv", "--seq-cnt"});
+#endif
 }
 
 // --- Performance tests ---
 
-TEST_P(ZstdGpuDemoTests, OverallThroughput)
-{
-    RunPerformanceTest(GetParam(), 0);
-}
-
+// Per-stage timings (--prf-lvl 2) on the DIRECT queue (--d3d-gfx) in single-
+// submission mode (--seq-cnt). Skips fuzz content and files under --perf-min-mb.
 TEST_P(ZstdGpuDemoTests, PerStageTiming)
 {
-    RunPerformanceTest(GetParam(), 2);
+    RunPerformanceTest(GetParam(), 2, {"--d3d-gfx", "--seq-cnt"});
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -510,12 +639,14 @@ std::vector<std::string> BuildCorrectnessArgs(
 }
 
 // Builds argument list for performance tests: run N iterations at the specified
-// profiling level, optionally writing per-run timing data to a CSV file.
+// profiling level, optionally writing per-run timing data to a CSV file. Any
+// scenario-specific demo flags are appended from `extraFlags`.
 std::vector<std::string> BuildPerformanceArgs(
     const std::string& zstFile,
     int profilingLevel,
     int runCount,
-    const std::string& csvOutputPath)
+    const std::string& csvOutputPath,
+    const std::vector<std::string>& extraFlags)
 {
     std::vector<std::string> args;
     args.push_back("--zst");
@@ -528,6 +659,10 @@ std::vector<std::string> BuildPerformanceArgs(
     {
         args.push_back("--out-csv");
         args.push_back(csvOutputPath);
+    }
+    for (const auto& flag : extraFlags)
+    {
+        args.push_back(flag);
     }
     return args;
 }

--- a/zstd/zstdgpu_ci_tests/zstdgpu_ci_tests.cpp
+++ b/zstd/zstdgpu_ci_tests/zstdgpu_ci_tests.cpp
@@ -443,7 +443,7 @@ TEST_P(ZstdGpuDemoTests, SimulationCheckSeq)
 TEST_P(ZstdGpuDemoTests, Gbv)
 {
 #if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_ARM64EC)
-    GTEST_SKIP() << "D3D12 debug layer tests are skipped on ARM platforms.";
+    GTEST_SKIP() << "GBV tests are skipped on ARM platforms.";
 #else
     if (!IsSelectedForGbv(GetParam()))
     {
@@ -458,7 +458,7 @@ TEST_P(ZstdGpuDemoTests, Gbv)
 TEST_P(ZstdGpuDemoTests, GbvSeq)
 {
 #if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_ARM64EC)
-    GTEST_SKIP() << "D3D12 debug layer tests are skipped on ARM platforms.";
+    GTEST_SKIP() << "GBV tests are skipped on ARM platforms.";
 #else
     if (!IsSelectedForGbv(GetParam()))
     {

--- a/zstd/zstdgpu_ci_tests/zstdgpu_ci_tests.h
+++ b/zstd/zstdgpu_ci_tests/zstdgpu_ci_tests.h
@@ -31,6 +31,8 @@ struct TestConfig
     std::string adversarialManifestPath;        // Optional path to adversarial_manifest.json (--adversarial-manifest)
     int runCount = 40;                          // Number of iterations for performance tests
     int timeoutSeconds = 0;                     // Max seconds before killing a demo process (0 = no timeout)
+    int perfMinMB = 4;                          // Min .zst size (MB) required for perf tests. Smaller files skip perf (individually-compressed textures are not representative).
+    int gbvSampleCount = 10;                    // Number of files the Gbv/GbvSeq scenarios run on, chosen by an even stride across the sorted corpus. <= 0 = no cap (run GBV on all files).
 
     // Cached list of .zst files discovered under contentPath. Populated once
     // in main() after validation; consumed by GetTestFiles() at fixture
@@ -45,9 +47,7 @@ struct TestConfig
 };
 
 // Global config, set once in main() before RUN_ALL_TESTS(), then read-only
-// from test bodies. A plain extern global instead of a getter/setter is enough
-// here — the "set once, then read" contract is enforced by the main() call
-// sequence and there is no benefit to hiding the storage.
+// from test bodies.
 extern TestConfig g_testConfig;
 
 // File discovery — scans a directory for *.zst files. Returns sorted full paths.


### PR DESCRIPTION
Adds two configurable CLI flags to the Zstd GPU CI test suite, `--perf-min-mb` (skip performance timing on `.zst` files below the given size, default 4 MB) and `--gbv-sample-count` (run the GBV/GbvSeq scenarios on an even stride-sampled subset of files rather than the whole corpus, default 10). Also trims the scenario matrix by removing the redundant GraphicsQueue and OverallThroughput throughput tests, leaving per-stage timing as the sole perf scenario (emitted as `stages_*.csv`).