### PR TITLE
Add option to constrain the size of content used for GBV testing

### DIFF
--- a/zstd/zstdgpu_ci_tests/main.cpp
+++ b/zstd/zstdgpu_ci_tests/main.cpp
@@ -113,6 +113,7 @@ static void PrintUsage(const char* exe)
               << "                          Smaller files skip perf; individually-compressed textures are not representative of throughput.\n"
               << "  --gbv-sample-count <N>  Number of files the GBV scenarios run on, sampled by an even stride\n"
               << "                          across the sorted corpus (default: 10). A value <= 0 runs GBV on all files.\n"
+              << "  --gbv-max-mb <N>        Max size of file to use for GBV tests in MB (default: 1)\n"
               << "  --adversarial-manifest <path>   Optional JSON manifest of known-adversarial fuzz files.\n"
               << "                                  If NOT specified, the wrapper auto-discovers the manifest at\n"
               << "                                  <content-path>/adversarial_manifest.json. If found (either way),\n"
@@ -185,6 +186,12 @@ static bool ParseArgs(int argc, char** argv, TestConfig& config, bool& shouldExi
             config.gbvSampleCount = std::atoi(argv[++i]);
             if (config.gbvSampleCount < 0)
                 config.gbvSampleCount = 0;   // <= 0 = no cap; GBV runs on every file
+        }
+        else if (std::strcmp(argv[i], "--gbv-max-mb") == 0 && i + 1 < argc)
+        {
+            config.gbvMaxMB = std::atoi(argv[++i]);
+            if (config.gbvMaxMB< 0)
+                config.gbvMaxMB = INT_MAX / (1024*1024); // <= 0 = no cap; GBV runs on any file size
         }
         else if (std::strcmp(argv[i], "--help-ci") == 0)
         {

--- a/zstd/zstdgpu_ci_tests/zstdgpu_ci_tests.cpp
+++ b/zstd/zstdgpu_ci_tests/zstdgpu_ci_tests.cpp
@@ -180,20 +180,38 @@ static const std::unordered_set<std::string>& GbvSampledFiles()
     static const std::unordered_set<std::string> selected = []
     {
         std::unordered_set<std::string> s;
-        const auto& files = g_testConfig.discoveredFiles;   // sorted full paths
-        const size_t n = files.size();
+        std::vector<std::string> smallFiles;
+        {
+            const auto& files = g_testConfig.discoveredFiles; // sorted full paths
+            std::copy_if(
+                files.begin(),
+                files.end(),
+                std::back_inserter(smallFiles),
+                [](const std::string& filename)
+                {
+                    try
+                    {
+                        return std::filesystem::file_size(filename) < g_testConfig.gbvMaxMB * (1024 * 1024);
+                    }
+                    catch (const std::filesystem::filesystem_error&)
+                    {
+                        return false; // skip missing/inaccessible files
+                    }
+                });
+        }
+        const size_t n = smallFiles.size();
         if (n == 0)
             return s;
         const int target = g_testConfig.gbvSampleCount;
         if (target <= 0 || n <= static_cast<size_t>(target))
         {
             // count <= 0, or corpus no larger than the count: select every file.
-            s.insert(files.begin(), files.end());
+            s.insert(smallFiles.begin(), smallFiles.end());
             return s;
         }
         if (target == 1)
         {
-            s.insert(files.front());
+            s.insert(smallFiles.front());
             return s;
         }
         const size_t t = static_cast<size_t>(target);
@@ -202,7 +220,7 @@ static const std::unordered_set<std::string>& GbvSampledFiles()
         for (size_t i = 0; i < t; ++i)
         {
             const size_t idx = (i * (n - 1)) / (t - 1);
-            s.insert(files[idx]);
+            s.insert(smallFiles[idx]);
         }
         return s;
     }();

--- a/zstd/zstdgpu_ci_tests/zstdgpu_ci_tests.h
+++ b/zstd/zstdgpu_ci_tests/zstdgpu_ci_tests.h
@@ -33,6 +33,7 @@ struct TestConfig
     int timeoutSeconds = 0;                     // Max seconds before killing a demo process (0 = no timeout)
     int perfMinMB = 4;                          // Min .zst size (MB) required for perf tests. Smaller files skip perf (individually-compressed textures are not representative).
     int gbvSampleCount = 10;                    // Number of files the Gbv/GbvSeq scenarios run on, chosen by an even stride across the sorted corpus. <= 0 = no cap (run GBV on all files).
+    int gbvMaxMB = 1;                           // Max .zst size (MB) for Gbv tests.  Larger files are skipped to avoid TDRs.
 
     // Cached list of .zst files discovered under contentPath. Populated once
     // in main() after validation; consumed by GetTestFiles() at fixture

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -1437,12 +1437,16 @@ static int demoRun(void *demoCtx)
         zstdReferenceUncompressedDataSize = (uint32_t)ZSTD_get_decompressed_size(zstdData, zstdDataSize);
         zstdReferenceUncompressedData = malloc(zstdReferenceUncompressedDataSize);
 
+        // Clear the buffer to a known zero state in case ZSTD_decompress writes less data than the frame header claims (this matches the GPU)
+        memset(zstdReferenceUncompressedData, 0x00, zstdReferenceUncompressedDataSize);
+
         // TODO: consider "per-file" or "per-frame" state (not just state internal) for validation layer
         zstdgpu_ReferenceStore_Report_ChunkBase(zstdData);
         zstdgpu_ReferenceStore_AllocateMemory();
 
         // NOTE(pamartis): this call to reference ZSTD decompressor populates zstdgpu_ReferenceStore with ground-truth data.
-        ZSTD_decompress(zstdReferenceUncompressedData, zstdReferenceUncompressedDataSize, zstdData, zstdDataSize);
+        int r = ZSTD_decompress(zstdReferenceUncompressedData, zstdReferenceUncompressedDataSize, zstdData, zstdDataSize);
+        debugPrint(L"[INFO] ZSTD_decompress  input size: %d  output size: %d   result: %d\n", zstdDataSize, zstdReferenceUncompressedDataSize, r); 
     }
 
     if (chkCpu)


### PR DESCRIPTION
Enabling GBV can cause TDRs on slower GPUs if the content size is too large.  Add an option to specify the maximum size (1MB by default) selected from the corpus to participate in GBV.