### PR TITLE
Add manifest-driven scenario/GPU/file skips to Zstd GPU CI

### DIFF
--- a/zstd/zstdgpu_ci_tests/adversarial_manifest.cpp
+++ b/zstd/zstdgpu_ci_tests/adversarial_manifest.cpp
@@ -261,7 +261,8 @@ static bool ParseEntry(Parser& p, AdversarialEntry& entry, std::string& errorOut
 }
 
 // Parses one scenario_skip object. scenario_glob and gpu_name_glob are
-// required; reason and tracking_bug are optional; unknown fields are skipped.
+// required; path_glob, reason, and tracking_bug are optional; unknown fields
+// are skipped.
 static bool ParseScenarioSkip(Parser& p, ScenarioSkip& skip, std::string& errorOut)
 {
     if (!p.SkipWs() || !p.Expect('{')) { errorOut = p.error; return false; }
@@ -285,6 +286,10 @@ static bool ParseScenarioSkip(Parser& p, ScenarioSkip& skip, std::string& errorO
         {
             skip.gpuNameGlob = p.ReadString();
             haveGpu = true;
+        }
+        else if (key == "path_glob")
+        {
+            skip.pathGlob = p.ReadString();
         }
         else if (key == "reason")
         {
@@ -534,19 +539,36 @@ const AdversarialEntry* AdversarialManifest::Match(const std::string& zstFullPat
 }
 
 const ScenarioSkip* AdversarialManifest::MatchScenarioSkip(const std::string& scenarioName,
-                                                           const std::string& gpuName) const
+                                                           const std::string& gpuName,
+                                                           const std::string& zstFullPath,
+                                                           const std::filesystem::path& contentPath) const
 {
     // Returns nullptr unless the manifest is loaded and both names are
     // non-empty. scenario_glob and gpu_name_glob use the same anchored glob
-    // syntax as path globs.
+    // syntax as path globs. An empty path_glob matches every file; a non-empty
+    // path_glob is matched against the file path relative to contentPath so a
+    // skip can target a single file (or subtree) within the scenario.
     if (!m_loaded || scenarioName.empty() || gpuName.empty())
         return nullptr;
+    std::string rel;
+    bool haveRel = false;
     for (const auto& s : m_scenarioSkips)
     {
         if (s.scenarioGlob.empty() || s.gpuNameGlob.empty())
             continue;
-        if (GlobMatch(s.scenarioGlob, scenarioName) && GlobMatch(s.gpuNameGlob, gpuName))
-            return &s;
+        if (!GlobMatch(s.scenarioGlob, scenarioName) || !GlobMatch(s.gpuNameGlob, gpuName))
+            continue;
+        if (!s.pathGlob.empty())
+        {
+            if (!haveRel)
+            {
+                rel = RelativeAndNormalize(zstFullPath, contentPath);
+                haveRel = true;
+            }
+            if (!GlobMatchSuffix(s.pathGlob, rel))
+                continue;
+        }
+        return &s;
     }
     return nullptr;
 }

--- a/zstd/zstdgpu_ci_tests/adversarial_manifest.cpp
+++ b/zstd/zstdgpu_ci_tests/adversarial_manifest.cpp
@@ -9,15 +9,15 @@
 
 // AdversarialManifest implementation.
 //
-// This file contains a minimal, purpose-built JSON parser scoped to the schema
-// documented in adversarial_manifest.json — NOT a general-purpose JSON parser.
-// It handles the subset our manifest uses: top-level object with a "notes"
-// string field and an "entries" array of objects. Each entry has string /
-// integer / boolean / string-array fields. Basic backslash escapes in strings
-// (\", \\, \/, \n, \r, \t) are supported. Unicode escapes and nested objects
-// are NOT supported (the manifest schema doesn't use them). Any deviation from
-// the expected shape produces a clear error via the errorOut parameter and
-// leaves the manifest empty rather than throwing.
+// This file contains a minimal, purpose-built JSON parser scoped to this
+// manifest's schema — NOT a general-purpose JSON parser. It handles a top-level
+// object with a "notes" string field, an "entries" array of file objects, and
+// an optional "scenario_skips" array of scenario objects. Each object has
+// string / integer / boolean / string-array fields. Basic backslash escapes in
+// strings (\", \\, \/, \n, \r, \t) are supported. Unicode escapes and nested
+// objects are NOT supported. Any deviation from the expected shape produces a
+// clear error via the errorOut parameter and leaves the manifest empty rather
+// than throwing.
 //
 // A hand-rolled parser avoids adding a third-party JSON dependency for what is
 // a small, controlled data file. If the schema grows to need general JSON
@@ -260,6 +260,56 @@ static bool ParseEntry(Parser& p, AdversarialEntry& entry, std::string& errorOut
     return true;
 }
 
+// Parses one scenario_skip object. scenario_glob and gpu_name_glob are
+// required; reason and tracking_bug are optional; unknown fields are skipped.
+static bool ParseScenarioSkip(Parser& p, ScenarioSkip& skip, std::string& errorOut)
+{
+    if (!p.SkipWs() || !p.Expect('{')) { errorOut = p.error; return false; }
+
+    bool haveScenario = false, haveGpu = false;
+    while (true)
+    {
+        if (!p.SkipWs()) { p.Fail("unexpected eof in scenario_skip"); errorOut = p.error; return false; }
+        if (p.text[p.pos] == '}') { ++p.pos; break; }
+
+        std::string key = p.ReadString();
+        if (p.Failed()) { errorOut = p.error; return false; }
+        if (!p.SkipWs() || !p.Expect(':')) { errorOut = p.error; return false; }
+
+        if (key == "scenario_glob")
+        {
+            skip.scenarioGlob = p.ReadString();
+            haveScenario = true;
+        }
+        else if (key == "gpu_name_glob")
+        {
+            skip.gpuNameGlob = p.ReadString();
+            haveGpu = true;
+        }
+        else if (key == "reason")
+        {
+            skip.reason = p.ReadString();
+        }
+        else if (key == "tracking_bug")
+        {
+            skip.trackingBug = p.ReadString();
+        }
+        else
+        {
+            p.SkipValue();
+        }
+        if (p.Failed()) { errorOut = p.error; return false; }
+
+        if (!p.SkipWs()) { p.Fail("unexpected eof in scenario_skip"); errorOut = p.error; return false; }
+        if (p.text[p.pos] == ',') { ++p.pos; continue; }
+        if (p.text[p.pos] == '}') { ++p.pos; break; }
+        p.Fail("expected ',' or '}' in scenario_skip"); errorOut = p.error; return false;
+    }
+    if (!haveScenario) { errorOut = "scenario_skip missing required 'scenario_glob' field"; return false; }
+    if (!haveGpu)      { errorOut = "scenario_skip missing required 'gpu_name_glob' field"; return false; }
+    return true;
+}
+
 // Glob matcher supporting '*' wildcards and '[a-b]' character ranges.
 // Case-sensitive. Not general-purpose — no '?', no '**', no negation.
 // Fully anchored: the pattern must consume the entire `path`. O(N*M) worst case
@@ -434,6 +484,25 @@ bool AdversarialManifest::LoadFromFile(const std::filesystem::path& jsonPath, st
                 }
             }
         }
+        else if (key == "scenario_skips")
+        {
+            if (!p.SkipWs() || !p.Expect('[')) { errorOut = p.error; return false; }
+            if (!p.SkipWs()) { p.Fail("unexpected eof in scenario_skips"); errorOut = p.error; return false; }
+            if (p.text[p.pos] == ']') { ++p.pos; }
+            else
+            {
+                while (true)
+                {
+                    ScenarioSkip skip;
+                    if (!ParseScenarioSkip(p, skip, errorOut)) return false;
+                    m_scenarioSkips.push_back(std::move(skip));
+                    if (!p.SkipWs()) { p.Fail("unexpected eof in scenario_skips"); errorOut = p.error; return false; }
+                    if (p.text[p.pos] == ',') { ++p.pos; continue; }
+                    if (p.text[p.pos] == ']') { ++p.pos; break; }
+                    p.Fail("expected ',' or ']' in scenario_skips"); errorOut = p.error; return false;
+                }
+            }
+        }
         else
         {
             // Unknown top-level field — skip for forward compat.
@@ -460,6 +529,24 @@ const AdversarialEntry* AdversarialManifest::Match(const std::string& zstFullPat
     {
         if (GlobMatchSuffix(e.pathGlob, rel))
             return &e;
+    }
+    return nullptr;
+}
+
+const ScenarioSkip* AdversarialManifest::MatchScenarioSkip(const std::string& scenarioName,
+                                                           const std::string& gpuName) const
+{
+    // Returns nullptr unless the manifest is loaded and both names are
+    // non-empty. scenario_glob and gpu_name_glob use the same anchored glob
+    // syntax as path globs.
+    if (!m_loaded || scenarioName.empty() || gpuName.empty())
+        return nullptr;
+    for (const auto& s : m_scenarioSkips)
+    {
+        if (s.scenarioGlob.empty() || s.gpuNameGlob.empty())
+            continue;
+        if (GlobMatch(s.scenarioGlob, scenarioName) && GlobMatch(s.gpuNameGlob, gpuName))
+            return &s;
     }
     return nullptr;
 }

--- a/zstd/zstdgpu_ci_tests/adversarial_manifest.h
+++ b/zstd/zstdgpu_ci_tests/adversarial_manifest.h
@@ -11,13 +11,18 @@
 // demo exit code. When a matching file is exercised by the wrapper, the
 // correctness test expects exit_code == manifest value rather than success.
 //
-// Perf tests do NOT consult the manifest; they skip fuzz content by path (see
-// IsFuzzContent in zstdgpu_ci_tests.cpp).
+// The manifest also carries an optional "scenario_skips" list. Each entry
+// matches a scenario by name and the machine by --gpu-name, causing matching
+// scenarios to GTEST_SKIP before the demo runs.
+//
+// Perf tests do NOT consult the per-file entries; they skip fuzz content by
+// path (see IsFuzzContent in zstdgpu_ci_tests.cpp). Scenario skips apply to any
+// matching scenario, correctness or performance.
 //
 // If the manifest is not loaded (--adversarial-manifest not passed OR file
 // missing), the wrapper falls back to legacy behavior: every file expected to
-// succeed. This is intentionally additive — no test starts failing just
-// because the manifest isn't wired up yet.
+// succeed and no scenario skips. This is intentionally additive — no test
+// starts failing just because the manifest isn't wired up yet.
 
 #pragma once
 
@@ -26,13 +31,22 @@
 #include <vector>
 
 // One entry describes an expected outcome for a set of files matched by
-// path_glob (relative to --content-path). See adversarial_manifest.json for
-// the shipping schema and field semantics.
+// path_glob (relative to --content-path).
 struct AdversarialEntry
 {
     std::string pathGlob;                          // e.g. "public/fuzz/generated/gen_bitflip_off0[0-3]_*.zst"
     std::string reason;                            // Human-readable description of what's wrong with the file(s) (JSON key "reason")
     int expectedExitCode = 1;                      // Expected demo process exit code (always 1 today; field exists for future flexibility)
+};
+
+// One scenario skip. Matches a GTest scenario by name and the machine by
+// --gpu-name; matching scenarios GTEST_SKIP before the demo is spawned.
+struct ScenarioSkip
+{
+    std::string scenarioGlob;                      // Glob over the GTest scenario name (JSON key "scenario_glob")
+    std::string gpuNameGlob;                       // Glob over the --gpu-name value (JSON key "gpu_name_glob")
+    std::string reason;                            // Explanation shown in the skip message (JSON key "reason")
+    std::string trackingBug;                       // Reference for the skip, e.g. a bug ID (JSON key "tracking_bug")
 };
 
 // Loads and matches the manifest. Loaded once at startup, then read-only from
@@ -54,7 +68,14 @@ public:
     const AdversarialEntry* Match(const std::string& zstFullPath,
                                   const std::filesystem::path& contentPath) const;
 
+    // Returns the first scenario_skip whose scenario_glob matches scenarioName
+    // and whose gpu_name_glob matches gpuName, or nullptr. Also returns nullptr
+    // when the manifest isn't loaded or either argument is empty.
+    const ScenarioSkip* MatchScenarioSkip(const std::string& scenarioName,
+                                          const std::string& gpuName) const;
+
     size_t Size() const { return m_entries.size(); }
+    size_t ScenarioSkipCount() const { return m_scenarioSkips.size(); }
     bool Loaded() const { return m_loaded; }
     const std::filesystem::path& SourcePath() const { return m_sourcePath; }
 
@@ -67,6 +88,7 @@ public:
 
 private:
     std::vector<AdversarialEntry> m_entries;
+    std::vector<ScenarioSkip> m_scenarioSkips;
     std::filesystem::path m_sourcePath;
     bool m_loaded = false;
 };

--- a/zstd/zstdgpu_ci_tests/adversarial_manifest.h
+++ b/zstd/zstdgpu_ci_tests/adversarial_manifest.h
@@ -45,6 +45,7 @@ struct ScenarioSkip
 {
     std::string scenarioGlob;                      // Glob over the GTest scenario name (JSON key "scenario_glob")
     std::string gpuNameGlob;                       // Glob over the --gpu-name value (JSON key "gpu_name_glob")
+    std::string pathGlob;                          // Optional glob over the file path relative to --content-path (JSON key "path_glob"); empty matches every file in the scenario
     std::string reason;                            // Explanation shown in the skip message (JSON key "reason")
     std::string trackingBug;                       // Reference for the skip, e.g. a bug ID (JSON key "tracking_bug")
 };
@@ -68,11 +69,15 @@ public:
     const AdversarialEntry* Match(const std::string& zstFullPath,
                                   const std::filesystem::path& contentPath) const;
 
-    // Returns the first scenario_skip whose scenario_glob matches scenarioName
-    // and whose gpu_name_glob matches gpuName, or nullptr. Also returns nullptr
-    // when the manifest isn't loaded or either argument is empty.
+    // Returns the first scenario_skip whose scenario_glob matches scenarioName,
+    // gpu_name_glob matches gpuName, and (when set) path_glob matches the file
+    // path relative to contentPath. Returns nullptr on no match, when the
+    // manifest isn't loaded, or when scenarioName/gpuName is empty. A skip with
+    // an empty path_glob matches every file in the scenario.
     const ScenarioSkip* MatchScenarioSkip(const std::string& scenarioName,
-                                          const std::string& gpuName) const;
+                                          const std::string& gpuName,
+                                          const std::string& zstFullPath,
+                                          const std::filesystem::path& contentPath) const;
 
     size_t Size() const { return m_entries.size(); }
     size_t ScenarioSkipCount() const { return m_scenarioSkips.size(); }

--- a/zstd/zstdgpu_ci_tests/adversarial_manifest.sample.json
+++ b/zstd/zstdgpu_ci_tests/adversarial_manifest.sample.json
@@ -32,6 +32,13 @@
       "gpu_name_glob": "*Fabrikam GPU 9000*",
       "reason": "Example: quarantine a single named scenario on one specific device model.",
       "tracking_bug": "Replace with a tracking reference."
+    },
+    {
+      "scenario_glob": "Gbv*",
+      "gpu_name_glob": "*Contoso*",
+      "path_glob": "<path>/example_single_file.zst",
+      "reason": "Example: optional path_glob narrows the skip to one file (or a glob subtree) within the scenario/GPU match. Omit path_glob to skip every file in the scenario.",
+      "tracking_bug": "Replace with a tracking reference."
     }
   ]
 }

--- a/zstd/zstdgpu_ci_tests/adversarial_manifest.sample.json
+++ b/zstd/zstdgpu_ci_tests/adversarial_manifest.sample.json
@@ -1,0 +1,37 @@
+{
+  "$schema_version": 1,
+  "notes": "SAMPLE / REFERENCE manifest for the Zstd GPU CI wrapper. The entries below are placeholders that exist only to document the schema — do not ship it as-is. At runtime the wrapper loads a real manifest either from --adversarial-manifest <path> or, if that flag is absent, by auto-discovering <content-path>/adversarial_manifest.json.",
+
+  "entries": [
+    {
+      "path_glob": "<path>/example_single_file.zst",
+      "reason": "A single named file the demo must reject; replace <path> and the file name with your own.",
+      "expected_exit_code": 1
+    },
+    {
+      "path_glob": "<path>/example_family_[0-9][0-9][0-9].zst",
+      "reason": "A family of files matched with a bracket range. '[0-9]' matches one digit.",
+      "expected_exit_code": 1
+    },
+    {
+      "path_glob": "<path>/example_dir/*.zst",
+      "reason": "Every .zst directly under a directory. '*' matches any characters within a path segment.",
+      "expected_exit_code": 1
+    }
+  ],
+
+  "scenario_skips": [
+    {
+      "scenario_glob": "Gbv*",
+      "gpu_name_glob": "*Contoso*",
+      "reason": "Example: quarantine every GBV scenario (Gbv, GbvSeq) on any adapter whose --gpu-name contains 'Contoso'.",
+      "tracking_bug": "Replace with a bug ID, driver note, or TSG link describing why the scenario is disabled on this device class."
+    },
+    {
+      "scenario_glob": "PerStageTiming",
+      "gpu_name_glob": "*Fabrikam GPU 9000*",
+      "reason": "Example: quarantine a single named scenario on one specific device model.",
+      "tracking_bug": "Replace with a tracking reference."
+    }
+  ]
+}

--- a/zstd/zstdgpu_ci_tests/main.cpp
+++ b/zstd/zstdgpu_ci_tests/main.cpp
@@ -113,6 +113,8 @@ static void PrintUsage(const char* exe)
               << "                          Smaller files skip perf; individually-compressed textures are not representative of throughput.\n"
               << "  --gbv-sample-count <N>  Number of files the GBV scenarios run on, sampled by an even stride\n"
               << "                          across the sorted corpus (default: 10). A value <= 0 runs GBV on all files.\n"
+              << "  --gpu-name <name>       Adapter name of this machine. Consumed only by the manifest's\n"
+              << "                          scenario_skips; if omitted, no scenario is skipped by GPU name.\n"
               << "  --adversarial-manifest <path>   Optional JSON manifest of known-adversarial fuzz files.\n"
               << "                                  If NOT specified, the wrapper auto-discovers the manifest at\n"
               << "                                  <content-path>/adversarial_manifest.json. If found (either way),\n"
@@ -173,6 +175,10 @@ static bool ParseArgs(int argc, char** argv, TestConfig& config, bool& shouldExi
         else if (std::strcmp(argv[i], "--adversarial-manifest") == 0 && i + 1 < argc)
         {
             config.adversarialManifestPath = argv[++i];
+        }
+        else if (std::strcmp(argv[i], "--gpu-name") == 0 && i + 1 < argc)
+        {
+            config.gpuName = argv[++i];
         }
         else if (std::strcmp(argv[i], "--perf-min-mb") == 0 && i + 1 < argc)
         {

--- a/zstd/zstdgpu_ci_tests/zstdgpu_ci_tests.cpp
+++ b/zstd/zstdgpu_ci_tests/zstdgpu_ci_tests.cpp
@@ -256,6 +256,36 @@ static bool CheckAdversarialOrLegacy(const std::string& zstFile, const DemoResul
     return true;
 }
 
+// Returns the current GTest scenario (test method) name. For parameterized
+// tests current_test_info()->name() is "<Scenario>/<param>", so we take the
+// portion before the first '/'. Returns empty outside a test.
+static std::string CurrentScenarioName()
+{
+    const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+    if (!info || !info->name())
+        return {};
+    std::string name = info->name();
+    const size_t slash = name.find('/');
+    return slash == std::string::npos ? name : name.substr(0, slash);
+}
+
+// If the manifest marks the current scenario as skipped for this machine's
+// --gpu-name, returns the message to pass to GTEST_SKIP; otherwise returns
+// empty. GTEST_SKIP must stay in the caller (the Run*Test helpers) so control
+// returns from the test after the skip is recorded.
+static std::string ScenarioSkipReason()
+{
+    const ScenarioSkip* s = g_testConfig.adversarialManifest.MatchScenarioSkip(
+        CurrentScenarioName(), g_testConfig.gpuName);
+    if (!s)
+        return {};
+    std::string msg = "Scenario '" + CurrentScenarioName() + "' skipped on GPU '" +
+                      g_testConfig.gpuName + "': " + s->reason;
+    if (!s->trackingBug.empty())
+        msg += " (tracking: " + s->trackingBug + ")";
+    return msg;
+}
+
 // Run a correctness scenario. Spawns zstdgpu_demo.exe with the given .zst file and scenario flags, then asserts exit code == 0.
 // main() has already validated the demo path exists, so we don't re-check here.
 // stdout is printed via the unconditional [DEMO OUT] block below and does NOT
@@ -263,6 +293,14 @@ static bool CheckAdversarialOrLegacy(const std::string& zstFile, const DemoResul
 // the same text in the log.
 static void RunCorrectnessTest(const std::string& zstFile, const std::vector<std::string>& scenarioFlags)
 {
+    // If the manifest marks this scenario as skipped for this GPU, skip before
+    // spawning the demo.
+    if (std::string skip = ScenarioSkipReason(); !skip.empty())
+    {
+        GTEST_SKIP() << skip;
+        return;
+    }
+
     auto args = BuildCorrectnessArgs(zstFile, scenarioFlags);
     auto result = RunDemo(g_testConfig.demoPath, args, g_testConfig.timeoutSeconds);
 
@@ -311,6 +349,14 @@ static void RunCorrectnessTest(const std::string& zstFile, const std::vector<std
 static void RunPerformanceTest(const std::string& zstFile, int profilingLevel,
                                 const std::vector<std::string>& extraFlags)
 {
+    // Skip if the manifest marks this scenario as skipped for this GPU; this
+    // takes precedence over the fuzz/size skips below.
+    if (std::string skip = ScenarioSkipReason(); !skip.empty())
+    {
+        GTEST_SKIP() << skip;
+        return;
+    }
+
     // Fuzzing content mixes clean and corrupt inputs with varying code paths,
     // so its timing isn't meaningful perf data — skip it before running the demo.
     if (IsFuzzContent(zstFile))

--- a/zstd/zstdgpu_ci_tests/zstdgpu_ci_tests.cpp
+++ b/zstd/zstdgpu_ci_tests/zstdgpu_ci_tests.cpp
@@ -273,10 +273,10 @@ static std::string CurrentScenarioName()
 // --gpu-name, returns the message to pass to GTEST_SKIP; otherwise returns
 // empty. GTEST_SKIP must stay in the caller (the Run*Test helpers) so control
 // returns from the test after the skip is recorded.
-static std::string ScenarioSkipReason()
+static std::string ScenarioSkipReason(const std::string& zstFile)
 {
     const ScenarioSkip* s = g_testConfig.adversarialManifest.MatchScenarioSkip(
-        CurrentScenarioName(), g_testConfig.gpuName);
+        CurrentScenarioName(), g_testConfig.gpuName, zstFile, g_testConfig.contentPath);
     if (!s)
         return {};
     std::string msg = "Scenario '" + CurrentScenarioName() + "' skipped on GPU '" +
@@ -295,7 +295,7 @@ static void RunCorrectnessTest(const std::string& zstFile, const std::vector<std
 {
     // If the manifest marks this scenario as skipped for this GPU, skip before
     // spawning the demo.
-    if (std::string skip = ScenarioSkipReason(); !skip.empty())
+    if (std::string skip = ScenarioSkipReason(zstFile); !skip.empty())
     {
         GTEST_SKIP() << skip;
         return;
@@ -351,7 +351,7 @@ static void RunPerformanceTest(const std::string& zstFile, int profilingLevel,
 {
     // Skip if the manifest marks this scenario as skipped for this GPU; this
     // takes precedence over the fuzz/size skips below.
-    if (std::string skip = ScenarioSkipReason(); !skip.empty())
+    if (std::string skip = ScenarioSkipReason(zstFile); !skip.empty())
     {
         GTEST_SKIP() << skip;
         return;

--- a/zstd/zstdgpu_ci_tests/zstdgpu_ci_tests.h
+++ b/zstd/zstdgpu_ci_tests/zstdgpu_ci_tests.h
@@ -29,6 +29,8 @@ struct TestConfig
     std::string logDir;                         // Directory for logs, CSVs, and GTest XML output
     std::string logFile;                        // Consolidated text log file path (--log-file)
     std::string adversarialManifestPath;        // Optional path to adversarial_manifest.json (--adversarial-manifest)
+    std::string gpuName;                        // Adapter name of the machine under test (--gpu-name). Used only for the
+                                                // manifest's scenario skips.
     int runCount = 40;                          // Number of iterations for performance tests
     int timeoutSeconds = 0;                     // Max seconds before killing a demo process (0 = no timeout)
     int perfMinMB = 4;                          // Min .zst size (MB) required for perf tests. Smaller files skip perf (individually-compressed textures are not representative).


### PR DESCRIPTION
Adds a `scenario_skips` list to the adversarial manifest so specific test scenarios can be quarantined per machine without code changes.

- Each skip matches on scenario_glob × gpu_name_glob (`--gpu-name`), GTEST_SKIP-ing before the demo spawns.
- Optional `path_glob` narrows a skip to a single file (or subtree) within the scenario; omit it to skip every file.

Additive and backward-compatible: with no manifest (or no matching skip), behavior is unchanged. Includes a documented sample manifest.