### PR TITLE
zstdgpu_demo: fix math error with frame count for invalid/fuzzed files when --idx-max is supplied.

### DIFF
--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -1342,7 +1342,8 @@ static int demoRun(void *demoCtx)
     zstdOutFrameRefs = (zstdgpu_OffsetAndSize *)malloc(sizeof(zstdgpu_OffsetAndSize) * fbInfo.frameCount);
     zstdgpu_CollectFrames(zstdInFrameRefs, zstdFrameInfo, fbInfo.frameCount, zstdData, zstdCompressedFramesMemorySizeInBytes, zstdDataSize);
 
-    const uint32_t endFrame = fbInfo.frameCount - 1;
+    // An invalid file can parse to 0 frames; clamp to 0 to avoid unsigned underflow of endFrame.
+    const uint32_t endFrame = fbInfo.frameCount == 0 ? 0 : fbInfo.frameCount - 1;
 
     // NOTE(pamartis): Support the option to choose a range of frame in the input package/data
     if (minFrame > 0 || maxFrame < endFrame)


### PR DESCRIPTION
Some fuzzing content can parse to 0 frames. In that case endFrame = fbInfo.frameCount - 1 underflows.  This problem only shows up with a frame-range clamp (--idx-max) set.

Clamp endFrame to 0 when frameCount == 0 so the slice is skipped and the invalid input is rejected similarly to when --idx-max is not provided.