### PR TITLE
Fix A/V and validation errors that occur when clamping the frame ranges used in the demo app with --idx-min and --idx-max 

### DIFF
--- a/zstd/zstdgpu/zstdgpu_reference_store.cpp
+++ b/zstd/zstdgpu/zstdgpu_reference_store.cpp
@@ -1110,8 +1110,8 @@ ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_DecompressedSequen
             // NOTE: dst.offs can't be the same due to non-deterministic allocation
             //izstdgpu_ReferenceStore_Validate_OffsetAndSize(&refSeqRefs[refSeqSteamIndex].dst, &tstSeqRefs[tstSeqSteamIndex].dst);
             {
-                const uint32_t refSeqOffsNext = (i == GBlockCountCMP - 1u) ? GSequenceCount                                                     : refData->PerSeqStreamSeqStart[refSeqSteamIndex + 1];
-                const uint32_t tstSeqOffsNext = (i == GBlockCountCMP - 1u) ? tstData->Counters->Seq_Streams_DecodedItems  : tstData->PerSeqStreamSeqStart[tstSeqSteamIndex + 1];
+                const uint32_t refSeqOffsNext = (refSeqSteamIndex + 1u == GSequenceStreamCount)           ? GSequenceCount                                    : refData->PerSeqStreamSeqStart[refSeqSteamIndex + 1];
+                const uint32_t tstSeqOffsNext = (tstSeqSteamIndex + 1u == tstData->Counters->Seq_Streams) ? tstData->Counters->Seq_Streams_DecodedItems       : tstData->PerSeqStreamSeqStart[tstSeqSteamIndex + 1];
                 const uint32_t refSeqCount = refSeqOffsNext - refSeqOffs;
                 const uint32_t tstSeqCount = tstSeqOffsNext - tstSeqOffs;
 

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -1090,7 +1090,7 @@ static int demoRun(void *demoCtx)
     wchar_t  **argv = ctx->argv;
 #endif
 
-    void                  *&zstdData                       = ctx->zstdData;
+    void                  *&zstdDataBase                   = ctx->zstdData;
     zstdgpu_FrameInfo     *&zstdFrameInfo                  = ctx->zstdFrameInfo;
     zstdgpu_OffsetAndSize *&zstdInFrameRefs                = ctx->zstdInFrameRefs;
     zstdgpu_OffsetAndSize *&zstdOutFrameRefs               = ctx->zstdOutFrameRefs;
@@ -1114,6 +1114,8 @@ static int demoRun(void *demoCtx)
     zstdgpu_ResourceDataCpu    &zstdCpu                      = ctx->zstdCpu;
     uint64_t                   &freqGpuClocks                = ctx->freqGpuClocks;
     FILE                      *&csvFile                      = ctx->csvFile;
+
+    void *zstdData = NULL;
 
     bool extMem = false;
     bool blkCnt = false;
@@ -1322,7 +1324,10 @@ static int demoRun(void *demoCtx)
     uint32_t zstdCompressedFramesMemorySizeInBytes = 0;
     uint32_t zstdUnCompressedFramesMemorySizeInBytes = 0;
 
-    loadFileAligned(&zstdData, &zstdDataSize, &zstdCompressedFramesMemorySizeInBytes, 2u, zstFilePath);
+    // Load into zstdDataBase which is the base pointer that will be freed.  Copy into the working pointer zstdData (which may move) 
+    loadFileAligned(&zstdDataBase, &zstdDataSize, &zstdCompressedFramesMemorySizeInBytes, 2u, zstFilePath);
+    zstdData = zstdDataBase;
+
     if (NULL == zstdData)
     {
         debugPrint(L"[FAIL] Couldn't load '%s'. Early Out.\n", zstFilePath);
@@ -1342,11 +1347,12 @@ static int demoRun(void *demoCtx)
     zstdOutFrameRefs = (zstdgpu_OffsetAndSize *)malloc(sizeof(zstdgpu_OffsetAndSize) * fbInfo.frameCount);
     zstdgpu_CollectFrames(zstdInFrameRefs, zstdFrameInfo, fbInfo.frameCount, zstdData, zstdCompressedFramesMemorySizeInBytes, zstdDataSize);
 
-    // An invalid file can parse to 0 frames; clamp to 0 to avoid unsigned underflow of endFrame.
+    // Ensure that the user-specified frame range (--idx-min/max) is clamped to the available frames
     const uint32_t endFrame = fbInfo.frameCount == 0 ? 0 : fbInfo.frameCount - 1;
+    const uint32_t startFrame = minFrame < endFrame ? minFrame : endFrame;
 
     // NOTE(pamartis): Support the option to choose a range of frame in the input package/data
-    if (minFrame > 0 || maxFrame < endFrame)
+    if (startFrame > 0 || maxFrame < endFrame)
     {
         maxFrame = maxFrame < endFrame
                  ? maxFrame : endFrame;


### PR DESCRIPTION
Fix 2 additional issues that surface with frame range clamping.

--idx-min > 0 needs to be within the range of frames.  The base pointer that is allocated needs to be preserved so that it can be freed at the end.

--idx-max may not decompress all blocks.  Fix an incorrect calculation in validation code of which sequences have been decoded so validation covers the correct ranges.