### PR TITLE
zstdgpu_demo/imp: adds support for .zst files with zero valid frames 

### DIFF
--- a/zstd/zstdgpu/zstdgpu_reference_store.cpp
+++ b/zstd/zstdgpu/zstdgpu_reference_store.cpp
@@ -1110,8 +1110,8 @@ ZSTDGPU_ENUM(Validate_Result) zstdgpu_ReferenceStore_Validate_DecompressedSequen
             // NOTE: dst.offs can't be the same due to non-deterministic allocation
             //izstdgpu_ReferenceStore_Validate_OffsetAndSize(&refSeqRefs[refSeqSteamIndex].dst, &tstSeqRefs[tstSeqSteamIndex].dst);
             {
-                const uint32_t refSeqOffsNext = (refSeqSteamIndex + 1u == GSequenceStreamCount)           ? GSequenceCount                                    : refData->PerSeqStreamSeqStart[refSeqSteamIndex + 1];
-                const uint32_t tstSeqOffsNext = (tstSeqSteamIndex + 1u == tstData->Counters->Seq_Streams) ? tstData->Counters->Seq_Streams_DecodedItems       : tstData->PerSeqStreamSeqStart[tstSeqSteamIndex + 1];
+                const uint32_t refSeqOffsNext = (i == GBlockCountCMP - 1u) ? GSequenceCount                                                     : refData->PerSeqStreamSeqStart[refSeqSteamIndex + 1];
+                const uint32_t tstSeqOffsNext = (i == GBlockCountCMP - 1u) ? tstData->Counters->Seq_Streams_DecodedItems  : tstData->PerSeqStreamSeqStart[tstSeqSteamIndex + 1];
                 const uint32_t refSeqCount = refSeqOffsNext - refSeqOffs;
                 const uint32_t tstSeqCount = tstSeqOffsNext - tstSeqOffs;
 

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -1090,7 +1090,7 @@ static int demoRun(void *demoCtx)
     wchar_t  **argv = ctx->argv;
 #endif
 
-    void                  *&zstdDataBase                   = ctx->zstdData;
+    void                  *&zstdDataMemory                 = ctx->zstdData;
     zstdgpu_FrameInfo     *&zstdFrameInfo                  = ctx->zstdFrameInfo;
     zstdgpu_OffsetAndSize *&zstdInFrameRefs                = ctx->zstdInFrameRefs;
     zstdgpu_OffsetAndSize *&zstdOutFrameRefs               = ctx->zstdOutFrameRefs;
@@ -1322,7 +1322,11 @@ static int demoRun(void *demoCtx)
     uint32_t zstdCompressedFramesMemorySizeInBytes = 0;
     uint32_t zstdUnCompressedFramesMemorySizeInBytes = 0;
 
-    loadFileAligned(&zstdData, &zstdDataSize, &zstdCompressedFramesMemorySizeInBytes, 2u, zstFilePath);
+    loadFileAligned(&zstdDataMemory, &zstdDataSize, &zstdCompressedFramesMemorySizeInBytes, 2u, zstFilePath);
+    // NOTE(pamartis): `zstdDataMemory` is the reference to a pointer to a memory block that is going to be freed.
+    // `zstdData` pointer can hold an address of the start of ANY frame. See `if (minFrame > 0 || maxFrame < endFrame)` branch.
+    void *zstdData = zstdDataMemory;
+
     if (NULL == zstdData)
     {
         debugPrint(L"[FAIL] Couldn't load '%s'. Early Out.\n", zstFilePath);

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -1346,8 +1346,7 @@ static int demoRun(void *demoCtx)
     zstdOutFrameRefs = (zstdgpu_OffsetAndSize *)malloc(sizeof(zstdgpu_OffsetAndSize) * fbInfo.frameCount);
     zstdgpu_CollectFrames(zstdInFrameRefs, zstdFrameInfo, fbInfo.frameCount, zstdData, zstdCompressedFramesMemorySizeInBytes, zstdDataSize);
 
-    // An invalid file can parse to 0 frames; clamp to 0 to avoid unsigned underflow of endFrame.
-    const uint32_t endFrame = fbInfo.frameCount == 0 ? 0 : fbInfo.frameCount - 1;
+    const uint32_t endFrame = fbInfo.frameCount - 1;
 
     // NOTE(pamartis): Support the option to choose a range of frame in the input package/data
     if (minFrame > 0 || maxFrame < endFrame)

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -1341,6 +1341,13 @@ static int demoRun(void *demoCtx)
     zstdgpu_CountFramesAndBlocksInfo fbInfo;
     zstdgpu_CountFramesAndBlocks(&fbInfo, zstdData, zstdCompressedFramesMemorySizeInBytes, zstdDataSize);
 
+    if (fbInfo.frameCount == 0)
+    {
+        debugPrint(L"[FAIL] No valid ZSTD frames was discovered in '%s'. Early Out.\n", zstFilePath);
+        ctx->retv = 1;
+        return 0;
+    }
+
     zstdFrameInfo = (zstdgpu_FrameInfo *)malloc(sizeof(zstdgpu_FrameInfo) * fbInfo.frameCount);
     zstdInFrameRefs = (zstdgpu_OffsetAndSize *)malloc(sizeof(zstdgpu_OffsetAndSize) * fbInfo.frameCount);
     zstdOutFrameRefs = (zstdgpu_OffsetAndSize *)malloc(sizeof(zstdgpu_OffsetAndSize) * fbInfo.frameCount);

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -1115,8 +1115,6 @@ static int demoRun(void *demoCtx)
     uint64_t                   &freqGpuClocks                = ctx->freqGpuClocks;
     FILE                      *&csvFile                      = ctx->csvFile;
 
-    void *zstdData = NULL;
-
     bool extMem = false;
     bool blkCnt = false;
     bool seqCnt = false;
@@ -1324,10 +1322,7 @@ static int demoRun(void *demoCtx)
     uint32_t zstdCompressedFramesMemorySizeInBytes = 0;
     uint32_t zstdUnCompressedFramesMemorySizeInBytes = 0;
 
-    // Load into zstdDataBase which is the base pointer that will be freed.  Copy into the working pointer zstdData (which may move) 
-    loadFileAligned(&zstdDataBase, &zstdDataSize, &zstdCompressedFramesMemorySizeInBytes, 2u, zstFilePath);
-    zstdData = zstdDataBase;
-
+    loadFileAligned(&zstdData, &zstdDataSize, &zstdCompressedFramesMemorySizeInBytes, 2u, zstFilePath);
     if (NULL == zstdData)
     {
         debugPrint(L"[FAIL] Couldn't load '%s'. Early Out.\n", zstFilePath);
@@ -1347,12 +1342,11 @@ static int demoRun(void *demoCtx)
     zstdOutFrameRefs = (zstdgpu_OffsetAndSize *)malloc(sizeof(zstdgpu_OffsetAndSize) * fbInfo.frameCount);
     zstdgpu_CollectFrames(zstdInFrameRefs, zstdFrameInfo, fbInfo.frameCount, zstdData, zstdCompressedFramesMemorySizeInBytes, zstdDataSize);
 
-    // Ensure that the user-specified frame range (--idx-min/max) is clamped to the available frames
+    // An invalid file can parse to 0 frames; clamp to 0 to avoid unsigned underflow of endFrame.
     const uint32_t endFrame = fbInfo.frameCount == 0 ? 0 : fbInfo.frameCount - 1;
-    const uint32_t startFrame = minFrame < endFrame ? minFrame : endFrame;
 
     // NOTE(pamartis): Support the option to choose a range of frame in the input package/data
-    if (startFrame > 0 || maxFrame < endFrame)
+    if (minFrame > 0 || maxFrame < endFrame)
     {
         maxFrame = maxFrame < endFrame
                  ? maxFrame : endFrame;


### PR DESCRIPTION
This PR mostly reverts changes from the following PRs that didn't pass the review but were submitted:

- https://github.com/microsoft/DirectStorage/pull/133
- https://github.com/microsoft/DirectStorage/pull/134

and instead makes zstdgpu_demo correctly handle .zst files with zero valid frames which it never supposed to do previously.