### PR TITLE
ZstdGpuDemo: Prefer high-performance GPU

### DIFF
--- a/zstd/platform/x64/zstdgpu_demo_platform.cpp
+++ b/zstd/platform/x64/zstdgpu_demo_platform.cpp
@@ -138,7 +138,12 @@ ID3D12Device *zstdgpu_Demo_PlatformInit(uint32_t gpuVenId, uint32_t gpuDevId, bo
     IDXGIAdapter *adapter = NULL;
     ID3D12Device *device = NULL;
     D3D12AID_CHECK(CreateDXGIFactory2(0, D3D12AID_IID_PPV_ARGS(&factory)));
-    for (unsigned i = 0; DXGI_ERROR_NOT_FOUND != factory->EnumAdapters(i, &adapter); ++i)
+    for (unsigned i = 0;
+         DXGI_ERROR_NOT_FOUND != factory->EnumAdapterByGpuPreference(
+                                     i,
+                                     DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE,
+                                     D3D12AID_IID_PPV_ARGS(&adapter));
+         ++i)
     {
         DXGI_ADAPTER_DESC desc;
         D3D12AID_CHECK(adapter->GetDesc(&desc));


### PR DESCRIPTION
Summary

Prefer the highest-performance GPU when the Zstd demo selects an adapter.

Updates adapter enumeration to use `EnumAdapterByGpuPreference` with `DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE`. This prioritizes discrete GPUs on hybrid systems while preserving existing vendor filtering and device capability checks.

Validated on pipeline, including Windows 10 machine