### PR TITLE
Optimize zstdgpu sequence decode: fused wave stores, branchless repcode, loop prefetching

### DIFF
--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -4009,7 +4009,7 @@ static void zstdgpu_ExecuteSequence_FusedCopy(ZSTDGPU_RW_TYPED_BUFFER(uint32_t, 
     const uint32_t total = seq.llen + seq.mlen;
 
     // Fast path: fused literal and match copy when the sequence fits within the wave.
-    ZSTDGPU_BRANCH if (seq.offs >= total && total <= laneCount)
+    ZSTDGPU_BRANCH if (seq.offs >= total && total <= laneCount && dstOfs + total <= dstEnd)
     {
         ZSTDGPU_BRANCH if (laneId < total)
         {
@@ -4050,7 +4050,8 @@ static void zstdgpu_ExecuteSequencePair_FusedCopy(ZSTDGPU_RW_TYPED_BUFFER(uint32
     // Fast path: attempt to coalesce the two sequences into a single wave-cooperative store.
     ZSTDGPU_BRANCH if (combined <= laneCount
                        && seq0.offs >= total0
-                       && seq1.offs >= combined)
+                       && seq1.offs >= combined
+                       && dstOfs + combined <= dstEnd)
     {
         ZSTDGPU_BRANCH if (laneId < combined)
         {
@@ -4070,7 +4071,8 @@ static void zstdgpu_ExecuteSequencePair_FusedCopy(ZSTDGPU_RW_TYPED_BUFFER(uint32
     // Second tier: attempt to coalesce the two sequences into a single wave-cooperative store when the combined span is up to twice the lane count.
     else if (combined <= (laneCount << 1u)
              && seq0.offs >= total0
-             && seq1.offs >= combined)
+             && seq1.offs >= combined
+             && dstOfs + combined <= dstEnd)
     {
         ZSTDGPU_LOOP for (uint32_t b = laneId; b < combined; b += laneCount)
         {

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -3958,6 +3958,105 @@ static void zstdgpu_MatchCopy(ZSTDGPU_RW_TYPED_BUFFER(uint32_t, uint8_t) dstData
     }
 }
 
+static void zstdgpu_ExecuteSequence_FusedCopy(ZSTDGPU_RW_TYPED_BUFFER(uint32_t, uint8_t) dstData,
+                                              ZSTDGPU_PARAM_INOUT(uint32_t) dstOfs,
+                                              ZSTDGPU_RO_TYPED_BUFFER(uint32_t, uint8_t) litBuf,
+                                              ZSTDGPU_PARAM_INOUT(uint32_t) litOfs,
+                                              zstdgpu_Sequence seq,
+                                              uint32_t dstEnd)
+{
+    const uint32_t laneId = WaveGetLaneIndex();
+    const uint32_t laneCount = WaveGetLaneCount();
+    const uint32_t total = seq.llen + seq.mlen;
+
+    // Fast path: fused literal and match copy when the sequence fits within the wave.
+    ZSTDGPU_BRANCH if (seq.offs >= total && total <= laneCount)
+    {
+        ZSTDGPU_BRANCH if (laneId < total)
+        {
+            // Load both literal and match values unconditionally, then select based on laneId to keep control flow wave-uniform.
+            // Hot path is bound by dependent-store latency rather than loads.
+            const uint32_t litVal   = litBuf[litOfs + laneId];
+            const uint32_t matchVal = dstData[dstOfs + laneId - seq.offs];
+            const uint32_t value    = (laneId < seq.llen) ? litVal : matchVal;
+            zstdgpu_TypedStoreU8(dstData, dstOfs + laneId, value);
+        }
+        dstOfs += total;
+        litOfs += seq.llen;
+    }
+    else
+    {
+        // Fall back to separate literal and match copies when the fused copy conditions are not met.
+        zstdgpu_MemCpy_DstSrc(dstData, dstOfs, litBuf, litOfs, seq.llen, dstEnd);
+        zstdgpu_MatchCopy(dstData, dstOfs, seq, dstEnd);
+    }
+}
+
+static void zstdgpu_ExecuteSequencePair_FusedCopy(ZSTDGPU_RW_TYPED_BUFFER(uint32_t, uint8_t) dstData,
+                                                  ZSTDGPU_PARAM_INOUT(uint32_t) dstOfs,
+                                                  ZSTDGPU_RO_TYPED_BUFFER(uint32_t, uint8_t) litBuf,
+                                                  ZSTDGPU_PARAM_INOUT(uint32_t) litOfs,
+                                                  zstdgpu_Sequence seq0,
+                                                  zstdgpu_Sequence seq1,
+                                                  uint32_t dstEnd)
+{
+    const uint32_t laneId = WaveGetLaneIndex();
+    const uint32_t laneCount = WaveGetLaneCount();
+    const uint32_t total0 = seq0.llen + seq0.mlen;
+    const uint32_t total1 = seq1.llen + seq1.mlen;
+    const uint32_t combined = total0 + total1;
+
+    // NOTE: This function is a specialized version of zstdgpu_ExecuteSequence_FusedCopy that works on a pair of sequences
+
+    // Fast path: attempt to coalesce the two sequences into a single wave-cooperative store.
+    ZSTDGPU_BRANCH if (combined <= laneCount
+                       && seq0.offs >= total0
+                       && seq1.offs >= combined)
+    {
+        ZSTDGPU_BRANCH if (laneId < combined)
+        {
+            const bool     inSeq0 = laneId < total0;
+            const uint32_t local  = inSeq0 ? laneId : (laneId - total0);
+            const uint32_t llenL  = inSeq0 ? seq0.llen : seq1.llen;
+            const uint32_t litIdx   = inSeq0 ? (litOfs + laneId) : (litOfs + seq0.llen + local);
+            const uint32_t off      = inSeq0 ? seq0.offs : seq1.offs;
+            const uint32_t litVal   = litBuf[litIdx];
+            const uint32_t matchVal = dstData[dstOfs + laneId - off];
+            const uint32_t value    = (local < llenL) ? litVal : matchVal;
+            zstdgpu_TypedStoreU8(dstData, dstOfs + laneId, value);
+        }
+        dstOfs += combined;
+        litOfs += seq0.llen + seq1.llen;
+    }
+    // Second tier: attempt to coalesce the two sequences into a single wave-cooperative store when the combined span is up to twice the lane count.
+    else if (combined <= (laneCount << 1u)
+             && seq0.offs >= total0
+             && seq1.offs >= combined)
+    {
+        ZSTDGPU_LOOP for (uint32_t b = laneId; b < combined; b += laneCount)
+        {
+            const bool     inSeq0 = b < total0;
+            const uint32_t local  = inSeq0 ? b : (b - total0);
+            const uint32_t llenL  = inSeq0 ? seq0.llen : seq1.llen;
+            const uint32_t litIdx = inSeq0 ? (litOfs + b) : (litOfs + seq0.llen + local);
+            const uint32_t off    = inSeq0 ? seq0.offs : seq1.offs;
+            const uint32_t litVal   = litBuf[litIdx];
+            const uint32_t matchVal = dstData[dstOfs + b - off];
+            const uint32_t value    = (local < llenL) ? litVal : matchVal;
+            zstdgpu_TypedStoreU8(dstData, dstOfs + b, value);
+        }
+        dstOfs += combined;
+        litOfs += seq0.llen + seq1.llen;
+    }
+    else
+    {
+        // Fallback to separate fused copies for each sequence. This path is taken when the combined
+        // sequence cannot be safely coalesced into a single wave-cooperative store.
+        zstdgpu_ExecuteSequence_FusedCopy(dstData, dstOfs, litBuf, litOfs, seq0, dstEnd);
+        zstdgpu_ExecuteSequence_FusedCopy(dstData, dstOfs, litBuf, litOfs, seq1, dstEnd);
+    }
+}
+
 /**
  *  NOTE(pamartis): This function exists solely to allow calling the same code and passing different 'litBuf'
  *                  from different condition:
@@ -4011,11 +4110,7 @@ static void zstdgpu_ExecuteSequences_Lit(ZSTDGPU_PARAM_INOUT(zstdgpu_ExecuteSequ
                 seqNext = zstdgpu_LoadSequence(srt, prefetchSeqIdx);
             }
 
-            zstdgpu_MemCpy_DstSrc(srt.inoutUnCompressedFramesData, dstOfs, litBuf, litOfs, seq.llen, dstEnd);
-            zstdgpu_MatchCopy(srt.inoutUnCompressedFramesData, dstOfs, seq, dstEnd);
-
-            zstdgpu_MemCpy_DstSrc(srt.inoutUnCompressedFramesData, dstOfs, litBuf, litOfs, seq1.llen, dstEnd);
-            zstdgpu_MatchCopy(srt.inoutUnCompressedFramesData, dstOfs, seq1, dstEnd);
+            zstdgpu_ExecuteSequencePair_FusedCopy(srt.inoutUnCompressedFramesData, dstOfs, litBuf, litOfs, seq, seq1, dstEnd);
 
             seq = seqNext;
         }
@@ -4023,8 +4118,7 @@ static void zstdgpu_ExecuteSequences_Lit(ZSTDGPU_PARAM_INOUT(zstdgpu_ExecuteSequ
         // Tail: handle the final sequence when the sequence count in this frame is odd.
         ZSTDGPU_BRANCH if (seqIdx < seqEnd)
         {
-            zstdgpu_MemCpy_DstSrc(srt.inoutUnCompressedFramesData, dstOfs, litBuf, litOfs, seq.llen, dstEnd);
-            zstdgpu_MatchCopy(srt.inoutUnCompressedFramesData, dstOfs, seq, dstEnd);
+            zstdgpu_ExecuteSequence_FusedCopy(srt.inoutUnCompressedFramesData, dstOfs, litBuf, litOfs, seq, dstEnd);
         }
     }
 

--- a/zstd/zstdgpu/zstdgpu_shaders.h
+++ b/zstd/zstdgpu/zstdgpu_shaders.h
@@ -3248,7 +3248,8 @@ static void zstdgpu_ReadSeqBitsAndDecompress(ZSTDGPU_PARAM_INOUT(zstdgpu_Backwar
                                              ZSTDGPU_PARAM_IN(uint32_t) symbolMLen,
                                              ZSTDGPU_PARAM_INOUT(uint32_t) outLLen,
                                              ZSTDGPU_PARAM_INOUT(uint32_t) outOffs,
-                                             ZSTDGPU_PARAM_INOUT(uint32_t) outMLen)
+                                             ZSTDGPU_PARAM_INOUT(uint32_t) outMLen,
+                                             bool skipOffsRefill)
 {
     // Extra bits are low 5 bits, rest are baseline.
     // It could be better/simpler to not bitpack (use uint32_t2), but the LLVM-SROA pass in DXC might split that up; a single load is desired.
@@ -3283,7 +3284,15 @@ static void zstdgpu_ReadSeqBitsAndDecompress(ZSTDGPU_PARAM_INOUT(zstdgpu_Backwar
     const uint32_t bitcntOffs = symbolOffs_Clamped;
     const uint32_t bitcntMLen = mlenInfo & 31;
 
-    const uint32_t bitsOffs = zstdgpu_Backward_BitBuffer_V0_Get(bitBuffer, bitcntOffs);
+    uint32_t bitsOffs;
+    if (skipOffsRefill)
+    {
+        bitsOffs = zstdgpu_Backward_BitBuffer_V0_GetNoRefill(bitBuffer, bitcntOffs);
+    }
+    else
+    {
+        bitsOffs = zstdgpu_Backward_BitBuffer_V0_Get(bitBuffer, bitcntOffs);
+    }
 
     // MLen and LLen value extra bits are each <= 16 and can be read in a single packed Get()
     // Offs can need up to 28 extra bits, so it must remain a separate read.
@@ -3380,23 +3389,27 @@ static void zstdgpu_ShaderEntry_DecompressSequences_MultiStream(ZSTDGPU_PARAM_IN
         uint32_t stateOffs = ZSTDGPU_BACKWARD_BITBUF(GetNoRefill)(bitBuffer, initBitcntOffs);
         uint32_t stateMLen = ZSTDGPU_BACKWARD_BITBUF(GetNoRefill)(bitBuffer, initBitcntMLen);
 
-        for (uint32_t i = outputStart; i < outputEnd; ++i)
+        // Preload the first sequence's FSE elements and prepare the bit buffer for the initial reads.
+        uint32_t fseElemLLen = srt.inFseElems[stateLLen + startLLen];
+        uint32_t fseElemOffs = srt.inFseElems[stateOffs + startOffs];
+        uint32_t fseElemMLen = srt.inFseElems[stateMLen + startMLen];
+
+        if (!bitBuffer.hadlastrefill)
         {
-            stateLLen += startLLen;
-            stateOffs += startOffs;
-            stateMLen += startMLen;
+            ZSTDGPU_BACKWARD_BITBUF(Refill)(bitBuffer, 32u);
+        }
 
-            const uint32_t fseElemLLen = srt.inFseElems[stateLLen];
-            const uint32_t fseElemOffs = srt.inFseElems[stateOffs];
-            const uint32_t fseElemMLen = srt.inFseElems[stateMLen];
-
+        // Loop over all sequences (except the final one) while prefetching the subsequent one.
+        uint32_t i = outputStart;
+        for (; i + 1u < outputEnd; ++i)
+        {
             uint32_t llen = 0, offs = 0, mlen = 0;
             zstdgpu_ReadSeqBitsAndDecompress(
                 bitBuffer,
                 zstdgpu_FseElem_Symbol(fseElemLLen),
                 zstdgpu_FseElem_Symbol(fseElemOffs),
                 zstdgpu_FseElem_Symbol(fseElemMLen),
-                llen, offs, mlen
+                llen, offs, mlen, true
             );
             offs = zstdgpu_UpdatePreviousAndRecomputeIncoming(offset1, offset2, offset3, offs, llen);
 
@@ -3404,16 +3417,42 @@ static void zstdgpu_ShaderEntry_DecompressSequences_MultiStream(ZSTDGPU_PARAM_IN
             totalSize += llen + mlen;
             totalMLen += mlen;
 
+            // There is always a next sequence here: advance the states and prefetch the next symbol's
+            // FSE elements and bit-buffer refill to overlap with the scattered sequence stores below.
+            zstdgpu_ReadExtraBitsAndUpdateState(bitBuffer, fseElemLLen, fseElemOffs, fseElemMLen, stateLLen, stateOffs, stateMLen);
+            fseElemLLen = srt.inFseElems[stateLLen + startLLen];
+            fseElemOffs = srt.inFseElems[stateOffs + startOffs];
+            fseElemMLen = srt.inFseElems[stateMLen + startMLen];
+
+            if (!bitBuffer.hadlastrefill)
+            {
+                ZSTDGPU_BACKWARD_BITBUF(Refill)(bitBuffer, 32u);
+            }
+
             srt.inoutDecompressedSequenceLLen[i] = llen;
             srt.inoutDecompressedSequenceMLen[i] = mlen;
             srt.inoutDecompressedSequenceOffs[i] = offs;
+        }
 
-            if (i == outputEnd - 1u)
-            {
-                break;
-            }
+        // Now handle the final (or only) sequence in the current block.
+        if (i < outputEnd)
+        {
+            uint32_t llen = 0, offs = 0, mlen = 0;
+            zstdgpu_ReadSeqBitsAndDecompress(
+                bitBuffer,
+                zstdgpu_FseElem_Symbol(fseElemLLen),
+                zstdgpu_FseElem_Symbol(fseElemOffs),
+                zstdgpu_FseElem_Symbol(fseElemMLen),
+                llen, offs, mlen, true
+            );
+            offs = zstdgpu_UpdatePreviousAndRecomputeIncoming(offset1, offset2, offset3, offs, llen);
 
-            zstdgpu_ReadExtraBitsAndUpdateState(bitBuffer, fseElemLLen, fseElemOffs, fseElemMLen, stateLLen, stateOffs, stateMLen);
+            totalSize += llen + mlen;
+            totalMLen += mlen;
+
+            srt.inoutDecompressedSequenceLLen[i] = llen;
+            srt.inoutDecompressedSequenceMLen[i] = mlen;
+            srt.inoutDecompressedSequenceOffs[i] = offs;
         }
     }
 
@@ -3553,7 +3592,7 @@ static void zstdgpu_ShaderEntry_DecompressSequences_SingleStream(ZSTDGPU_PARAM_I
             zstdgpu_FseElem_Symbol(packedFseElemLLen),
             zstdgpu_FseElem_Symbol(packedFseElemOffs),
             zstdgpu_FseElem_Symbol(packedFseElemMLen),
-            llen, offs, mlen);
+            llen, offs, mlen, false);
         offs = zstdgpu_UpdatePreviousAndRecomputeIncoming(offset1, offset2, offset3, offs, llen);
 
         /*totalSize += llen + mlen;*/
@@ -3729,7 +3768,7 @@ static void zstdgpu_ShaderEntry_DecompressSequences_MultiStream_LdsOutCache(ZSTD
                     zstdgpu_FseElem_Symbol(fseElemLLen),
                     zstdgpu_FseElem_Symbol(fseElemOffs),
                     zstdgpu_FseElem_Symbol(fseElemMLen),
-                    llen, offs, mlen
+                    llen, offs, mlen, false
                 );
                 offs = zstdgpu_UpdatePreviousAndRecomputeIncoming(offset1, offset2, offset3, offs, llen);
 

--- a/zstd/zstdgpu/zstdgpu_structs.h
+++ b/zstd/zstdgpu/zstdgpu_structs.h
@@ -840,26 +840,18 @@ static uint32_t zstdgpu_UpdatePreviousAndRecomputeIncoming(ZSTDGPU_PARAM_INOUT(u
                                                            uint32_t llen)
 {
     ZSTDGPU_ASSERT_MSG(offset < 0x20000000, "Incoming 'offset'(0x%08x) overflow into 'repeat' offset bit", offset);
-    uint32_t encodedOffset = offset;
-    if (offset <= 3u)
-    {
-        offset += llen == 0u ? 1u : 0u;
-#if 0
-        if (offset == 4u)
-        {
-            encodedOffset = zstdgpu_SubtractByteFromSeqOffset(offset1);
-        }
-        else
-        {
-            encodedOffset = (offset == 3u) ? offset3 : ((offset == 2u) ? offset2 : offset1);
-        }
-#else
-        encodedOffset = (offset < 3u) ? (offset < 2u ? offset1 : offset2) : (offset < 4u ? offset3 : zstdgpu_SubtractByteFromSeqOffset(offset1));
-#endif
-    }
 
-    offset3 = offset >= 3u ? offset2 : offset3;
-    offset2 = offset >= 2u ? offset1 : offset2;
+    // NOTE: use predicated computation for repcode resolution to avoid divergent branches since
+    // repcode offsets are common and can cause divergence across active lanes.
+    
+    const bool     isRep     = offset <= 3u;
+    const uint32_t offsetAdj = offset + ((isRep && llen == 0u) ? 1u : 0u);
+    const uint32_t repOffset = (offsetAdj < 3u) ? (offsetAdj < 2u ? offset1 : offset2)
+                                                : (offsetAdj < 4u ? offset3 : zstdgpu_SubtractByteFromSeqOffset(offset1));
+    const uint32_t encodedOffset = isRep ? repOffset : offset;
+
+    offset3 = offsetAdj >= 3u ? offset2 : offset3;
+    offset2 = offsetAdj >= 2u ? offset1 : offset2;
     offset1 = encodedOffset;
     return encodedOffset;
 }


### PR DESCRIPTION
- **Fuse ExecuteSequences literal+match copies into cooperative wave stores** — add
  `zstdgpu_ExecuteSequence_FusedCopy` / `zstdgpu_ExecuteSequencePair_FusedCopy`, which
  issue a single wave-cooperative store covering a sequence (or pair) when the wave can
  cover the combined span and the match source does not alias the store region; falls
  back to the separate `MemCpy_DstSrc` + `MatchCopy` path otherwise.
- **Resolve sequence repcode offsets with predicated selection instead of branches** —
  the `offset <= 3` repcode path was a frequently-taken, data-dependent branch that
  diverges across the active lanes; compute the candidate unconditionally and select by
  predication.
- **Reorder sequence decode to prefetch the subsequent sequence** — advance FSE state,
  prefetch the next sequence's FSE elements, and top up the bit buffer before storing the
  current sequence's decoded values, overlapping dependent-load latency with the scattered
  stores.
