### PR TITLE
Adjust CI testing to execute correctness tests in batches

### DIFF
--- a/zstd/zstdgpu_ci_tests/main.cpp
+++ b/zstd/zstdgpu_ci_tests/main.cpp
@@ -123,6 +123,12 @@ static void PrintUsage(const char* exe)
               << "                          frame size cannot be read is never skipped.\n"
               << "  --idx-max <N>           Forward --idx-max N to the demo to cap the last decoded frame index\n"
               << "                          (inclusive). Omit or use a negative value to run all frames (default).\n"
+              << "  --correctness-batch-mb <N>    Max total on-disk (compressed) size in MB of clean files grouped\n"
+              << "                          into one batched correctness run (default: 256). Bounds each concatenated\n"
+              << "                          --zst @listfile run so large-texture batches don't reach multi-GB\n"
+              << "                          decompressed and exceed GPU/int32 limits. A value <= 0 disables the byte cap.\n"
+              << "  --correctness-batch-count <N> Secondary cap: max number of files per correctness batch\n"
+              << "                          (default: 64). A value <= 0 disables the count cap (size-bounded only).\n"
               << "  --adversarial-manifest <path>   Optional JSON manifest of known-adversarial fuzz files.\n"
               << "                                  If NOT specified, the wrapper auto-discovers the manifest at\n"
               << "                                  <content-path>/adversarial_manifest.json. If found (either way),\n"
@@ -217,6 +223,18 @@ static bool ParseArgs(int argc, char** argv, TestConfig& config, bool& shouldExi
             config.idxMax = std::atoi(argv[++i]);
             if (config.idxMax < 0)
                 config.idxMax = -1;   // < 0 = unset; not forwarded, demo runs all frames
+        }
+        else if (std::strcmp(argv[i], "--correctness-batch-mb") == 0 && i + 1 < argc)
+        {
+            config.correctnessBatchMB = std::atoi(argv[++i]);
+            if (config.correctnessBatchMB < 0)
+                config.correctnessBatchMB = 0;   // <= 0 = no byte cap (count-only batching)
+        }
+        else if (std::strcmp(argv[i], "--correctness-batch-count") == 0 && i + 1 < argc)
+        {
+            config.correctnessBatchCount = std::atoi(argv[++i]);
+            if (config.correctnessBatchCount < 0)
+                config.correctnessBatchCount = 0;   // <= 0 = no count cap (size-only batching)
         }
         else if (std::strcmp(argv[i], "--help-ci") == 0)
         {

--- a/zstd/zstdgpu_ci_tests/zstdgpu_ci_tests.cpp
+++ b/zstd/zstdgpu_ci_tests/zstdgpu_ci_tests.cpp
@@ -9,13 +9,15 @@
 
 // Test definitions and demo runner for the Zstd GPU CI tests.
 //
-// Parameterized test suite (ZstdGpuDemoTests) instantiated once per .zst file
-// under the content path. Each file produces the following scenarios:
+// Two parameterized suites are instantiated from the .zst corpus discovered
+// under the content path:
 //
-//   Correctness — "for all data" (ASSERT — hard fail):
+//   ZstdGpuCorrectnessTests — These scenarios are executed over the corpus in batches (where appropriate) 
 //     - ExternalMemory     : --chk-gpu --ext-mem
 //     - ExternalMemorySeq  : --chk-gpu --ext-mem --seq-cnt
 //     - D3D12DebugLayerSeq : --chk-gpu --d3d-dbg --seq-cnt  (skipped on ARM)
+//
+//   ZstdGpuDemoTests — per-file scenarios (one .zst file per parameter):
 //
 //   Correctness — GBV (ASSERT; skipped on ARM; run only on files whose largest
 //   decompressed frame is under --gbv-max-mb, optionally further reduced by an
@@ -73,6 +75,10 @@ namespace
         const std::vector<std::string>& extraFlags);
 }
 
+// Defined below; used by RunBatchedCorrectnessTest to keep fuzz content out of
+// concatenated batches (corrupt-by-design fuzz inputs would poison a batch).
+static bool IsFuzzContent(const std::string& zstFile);
+
 // Helpers
 
 // Returns the list of .zst files to parameterize over.
@@ -92,9 +98,9 @@ static std::vector<std::string> GetTestFiles()
 // (e.g. firefly_albedo.DDS.zst exists under BC1/, BC1mip0/, block4K_*, etc.),
 // causing a fatal gtest assertion at startup. Use the path relative to
 // --content-path so different folders produce different names.
-static std::string SanitizeTestName(const testing::TestParamInfo<std::string>& info)
+static std::string SanitizeRelName(const std::string& fullPath)
 {
-    std::filesystem::path full(info.param);
+    std::filesystem::path full(fullPath);
     std::filesystem::path rel;
     if (!g_testConfig.contentPath.empty())
     {
@@ -130,6 +136,23 @@ static std::string SanitizeTestName(const testing::TestParamInfo<std::string>& i
         result = "_" + result;
     }
     return result.empty() ? "Unknown" : result;
+}
+
+// GTest name functor for the per-file suite (ZstdGpuDemoTests): the GBV and
+// perf scenarios run one .zst file per parameter.
+static std::string SanitizeTestName(const testing::TestParamInfo<std::string>& info)
+{
+    return SanitizeRelName(info.param);
+}
+
+// GTest name functor for the batched-correctness suite. The suite takes a single
+// parameter — the full discovered corpus — so there is exactly one instance per
+// scenario; name it "Corpus". The batching itself is done at run time inside
+// RunBatchedCorrectnessTest (which walks the corpus), not here.
+static std::string CorrectnessCorpusName(const testing::TestParamInfo<std::vector<std::string>>& info)
+{
+    (void)info;
+    return "Corpus";
 }
 
 // Appends per-test output to the consolidated log file (--log-file).
@@ -397,6 +420,200 @@ static void RunCorrectnessTest(const std::string& zstFile, const std::vector<std
         << "  (stdout already printed above as [DEMO OUT])";
 }
 
+// Writes out a list of .zst files into a temp file for use as a batched .zst input to zstdgpu_demo.exe
+static bool WriteBatchListFile(const std::string& batchName,
+                               const std::vector<std::string>& files,
+                               std::string& outPath)
+{
+    std::error_code ec;
+    std::filesystem::path dir = g_testConfig.logDir.empty()
+        ? (std::filesystem::temp_directory_path() / "zstdgpu_batch_lists")
+        : (std::filesystem::path(g_testConfig.logDir) / "batch_lists");
+    std::filesystem::create_directories(dir, ec);
+
+    std::filesystem::path path = dir / (CurrentScenarioName() + "_" + batchName + ".txt");
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+
+    if (!out) return false;
+
+    for (const auto& f : files)
+    {
+        out << f << "\n";
+    }
+
+    out.flush();
+
+    if (!out) return false;
+
+    outPath = path.string();
+    return true;
+}
+
+// Runs each file individually with the scenario flags using non-fatal checks
+// (ADD_FAILURE) so every file is exercised and each culprit reported. Returns
+// the count that failed. Used to isolate failures after a batch run fails.
+static size_t RunCorrectnessFilesIndividually(const std::vector<std::string>& files,
+                                              const std::vector<std::string>& scenarioFlags)
+{
+    size_t failures = 0;
+    for (const auto& zstFile : files)
+    {
+        auto args = BuildCorrectnessArgs(zstFile, scenarioFlags);
+        auto result = RunDemo(g_testConfig.demoPath, args, g_testConfig.timeoutSeconds);
+        WriteToLogFile(zstFile, result);
+
+        std::cout << "[ISO CMD] " << result.commandLine << "\n";
+
+        if (!result.stdOut.empty())
+        {
+            std::cout << "[DEMO OUT] " << result.stdOut << "\n";
+        }
+
+        const bool ok = !result.timedOut && result.launchError.empty() && result.exitCode == 0;
+        if (!ok)
+        {
+            ++failures;
+            ADD_FAILURE()
+                << "Isolated file failed: " << zstFile << "\n"
+                << "  exit=" << result.exitCode
+                << (result.timedOut ? " (TIMED OUT)" : "")
+                << (result.launchError.empty() ? std::string() : ("  launchError=" + result.launchError)) << "\n"
+                << "  Command: " << result.commandLine
+                << "  (stdout already printed above as [DEMO OUT])";
+        }
+    }
+    return failures;
+}
+
+// Runs zstdgpu_demo.exe over a .zst batch
+static void RunDemoOnBatch(const std::string& batchName,
+                           const std::vector<std::string>& files,
+                           const std::vector<std::string>& scenarioFlags)
+{
+    if (files.empty()) return;
+
+
+    // Stage the list file and run the whole batch in a single demo invocation.
+    std::string listPath;
+    if (!WriteBatchListFile(batchName, files, listPath))
+    {
+        // Could not stage the list — fall back to individual runs so coverage
+        // isn't lost, and flag the staging failure.
+        ADD_FAILURE() << "Could not write batch list file for " << batchName
+                      << "; running the " << files.size() << " file(s) individually instead.";
+        RunCorrectnessFilesIndividually(files, scenarioFlags);
+        return;
+    }
+
+    auto args = BuildCorrectnessArgs("@" + listPath, scenarioFlags);
+    auto result = RunDemo(g_testConfig.demoPath, args, g_testConfig.timeoutSeconds);
+    WriteToLogFile("[batch " + batchName + "] " + listPath, result);
+
+    std::cout << "[BATCH CMD] " << result.commandLine << "\n";
+    std::cout << "[BATCH] scenario " << CurrentScenarioName() << ", " << files.size() << " file(s), list: " << listPath << "\n";
+
+    if (!result.stdOut.empty())
+    {
+        std::cout << "[DEMO OUT] " << result.stdOut << "\n";
+    }
+
+    if (!result.timedOut && result.launchError.empty() && result.exitCode == 0)
+    {
+        // Whole batch decoded and validated against the reference — all files OK.
+        return;
+    }
+
+    // Batch failed: re-run every file individually to pinpoint the culprit(s).
+    std::cout << "[BATCH] FAILED (exit " << result.exitCode
+              << (result.timedOut ? ", TIMED OUT" : "")
+              << (result.launchError.empty() ? "" : ", launch error")
+              << "); re-running " << files.size() << " file(s) individually to isolate...\n";
+
+    const size_t failed = RunCorrectnessFilesIndividually(files, scenarioFlags);
+
+    if (failed == 0)
+    {
+        ADD_FAILURE()
+            << "Batch '" << batchName << "' failed for scenario " << CurrentScenarioName()
+            << " (exit " << result.exitCode << (result.timedOut ? ", TIMED OUT" : "")
+            << ") but all " << files.size() << " file(s) passed individually. This points at a "
+            << "batch-level issue (concatenated size / GPU memory / list loading), not a per-file "
+            << "decode error. Consider lowering --correctness-batch-mb.\n"
+            << "Batch command: " << result.commandLine;
+    }
+    else
+    {
+        ADD_FAILURE()
+            << failed << " of " << files.size() << " file(s) in batch '" << batchName
+            << "' failed individual re-run for scenario " << CurrentScenarioName()
+            << " (batch exit " << result.exitCode << "). See the per-file failures above.\n"
+            << "Batch command: " << result.commandLine;
+    }
+}
+
+// Run a correctness test over a batch of files. Spawns zstdgpu_demo.exe with the batch of .zst files and scenario flags 
+// NOTE: Batching is opportunistic.  Some files are known to need to run standalone (currently).
+static void RunBatchedCorrectnessTest(const std::vector<std::string>& allFiles,
+                                      const std::vector<std::string>& scenarioFlags)
+{
+    // Determine batch bounds (reasonable limits to ensure we don't blow out VRAM with current scratch memory implementation)
+    const uint64_t budgetBytes = g_testConfig.correctnessBatchMB > 0 ? static_cast<uint64_t>(g_testConfig.correctnessBatchMB) * 1024u * 1024u : UINT64_MAX;
+    const size_t countCap = g_testConfig.correctnessBatchCount > 0 ? static_cast<size_t>(g_testConfig.correctnessBatchCount) : SIZE_MAX;
+
+    std::vector<std::string> batch;
+    uint64_t batchBytes = 0;
+    size_t batchIdx = 0;
+
+    auto runBatch = [&]()
+    {
+        if (batch.empty()) return;
+
+        std::string batchName = "Batch_" + std::to_string(batchIdx);
+        
+        RunDemoOnBatch(batchName, batch, scenarioFlags);
+        ++batchIdx;
+        batch.clear();
+        batchBytes = 0;
+    };
+
+    for (const auto& f : allFiles)
+    {
+        // Mirror per-file behavior: drop files this scenario would skip (manifest
+        // scenario-skip for this GPU, or --max-frame-mb) instead of batching them.
+        if (!ScenarioSkipReason(f).empty() || !FrameSizeSkipReason(f).empty())
+        {
+            std::cout << "[BATCH] skipping (scenario/size) " << f << "\n";
+            continue;
+        }
+
+        // Fuzz + adversarial content is run individually at present due to unavailability of per-file status in zstdgpu_demo.exe
+        const bool individual = IsFuzzContent(f) || g_testConfig.adversarialManifest.Match(f, g_testConfig.contentPath);
+        if (individual)
+        {
+            runBatch();
+            RunCorrectnessTest(f, scenarioFlags);
+            continue;
+        }
+
+        // If we got here, the file is a well formed compressed file and can be bundled with other files (within batch limits)
+        std::error_code ec;
+        uint64_t sz = std::filesystem::file_size(f, ec);
+        if (ec) sz = 0;  // unreadable size: don't let it distort the budget math
+
+        // Process the batch if it is at the batch limits and move on to the next one
+        if (!batch.empty() && (batch.size() >= countCap || batchBytes + sz > budgetBytes))
+        {
+            runBatch();
+        }
+
+        batch.push_back(f);
+        batchBytes += sz;
+    }
+
+    // Finish running the final batch
+    runBatch();
+}
+
 // Run a performance scenario. Spawns zstdgpu_demo.exe with profiling flags and requests CSV output. Uses EXPECT (not ASSERT) to verify the demo executed successfully and produced CSV output.
 // main() has already validated the demo path exists.
 static void RunPerformanceTest(const std::string& zstFile, int profilingLevel,
@@ -483,31 +700,36 @@ static void RunPerformanceTest(const std::string& zstFile, int profilingLevel,
 
 // Test fixture and test cases
 
-// Test fixture parameterized over .zst file paths (spec: ZstdGpuDemoTests).
-// Both correctness and performance tests share this fixture — correctness tests
-// use ASSERT (hard fail), performance tests use EXPECT (soft fail).
+// Per-file fixture (spec: ZstdGpuDemoTests).
+// Whole corpus is parameterized over individual .zst files
 class ZstdGpuDemoTests : public ::testing::TestWithParam<std::string>
 {
 };
 
-// --- Correctness tests — "for all data" matrix ---
-
-TEST_P(ZstdGpuDemoTests, ExternalMemory)
+// Batched fixture (spec: ZstdGpuCorrectnessTests).
+// Whole corpus is passed as a vector for batched execution
+class ZstdGpuCorrectnessTests : public ::testing::TestWithParam<std::vector<std::string>>
 {
-    RunCorrectnessTest(GetParam(), {"--chk-gpu", "--ext-mem"});
+};
+
+// --- Correctness tests — "for all data" matrix (batched) ---
+
+TEST_P(ZstdGpuCorrectnessTests, ExternalMemory)
+{
+    RunBatchedCorrectnessTest(GetParam(), {"--chk-gpu", "--ext-mem"});
 }
 
-TEST_P(ZstdGpuDemoTests, ExternalMemorySeq)
+TEST_P(ZstdGpuCorrectnessTests, ExternalMemorySeq)
 {
-    RunCorrectnessTest(GetParam(), {"--chk-gpu", "--ext-mem", "--seq-cnt"});
+    RunBatchedCorrectnessTest(GetParam(), {"--chk-gpu", "--ext-mem", "--seq-cnt"});
 }
 
-TEST_P(ZstdGpuDemoTests, D3D12DebugLayerSeq)
+TEST_P(ZstdGpuCorrectnessTests, D3D12DebugLayerSeq)
 {
 #if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_ARM64EC)
     GTEST_SKIP() << "D3D12 debug layer tests are skipped on ARM platforms.";
 #else
-    RunCorrectnessTest(GetParam(), {"--chk-gpu", "--d3d-dbg", "--seq-cnt"});
+    RunBatchedCorrectnessTest(GetParam(), {"--chk-gpu", "--d3d-dbg", "--seq-cnt"});
 #endif
 }
 
@@ -559,6 +781,12 @@ INSTANTIATE_TEST_SUITE_P(
     ZstdGpuDemoTests,
     ::testing::ValuesIn(GetTestFiles()),
     SanitizeTestName);
+
+INSTANTIATE_TEST_SUITE_P(
+    ContentTests,
+    ZstdGpuCorrectnessTests,
+    ::testing::Values(GetTestFiles()),
+    CorrectnessCorpusName);
 
 // Demo runner implementation
 //

--- a/zstd/zstdgpu_ci_tests/zstdgpu_ci_tests.h
+++ b/zstd/zstdgpu_ci_tests/zstdgpu_ci_tests.h
@@ -38,6 +38,8 @@ struct TestConfig
     int gbvMaxMB = 4;                           // Max largest-frame decompressed size (MB) for Gbv tests. Files with a bigger single frame are skipped to avoid GBV TDRs (GBV slows the GPU, so hang risk tracks the largest per-frame dispatch's decompressed output, not the whole-file total).
     int maxFrameMB = 0;                          // Skip any file whose largest on-disk zstd frame exceeds this (MB). <= 0 = disabled (run every file).
     int idxMax = -1;                             // Forwarded to the demo as --idx-max (inclusive last frame index). < 0 = unset (demo runs all frames).
+    int correctnessBatchMB = 256;                // Max total on-disk (compressed) size (MB) of clean files grouped into one correctness batch. Bounds each concatenated demo run: batching by file count alone lets large-texture batches reach multi-GB decompressed, overflowing the demo's int32 size fields (>2 GB) and exceeding a GPU buffer limit. <= 0 = no byte cap (count-only).
+    int correctnessBatchCount = 64;              // Secondary cap: max number of files per correctness batch, regardless of size. <= 0 = no count cap (size-only).
 
     // Cached list of .zst files discovered under contentPath. Populated once
     // in main() after validation; consumed by GetTestFiles() at fixture

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -91,44 +91,271 @@ static void debugPrint(const wchar_t *format, ...)
     va_end(args);
 }
 
+// Opens 'fileName' for binary reading. When 'dst' is NULL, returns the file's
+// size in bytes without reading anything (handy for sizing a buffer before a
+// read). Otherwise reads up to 'dstCapacity' bytes from the start of the file
+// into 'dst' and returns the number of bytes read. Returns 0 if the file can't
+// be opened, is empty, or on error.
+static uint32_t loadOneFile(const wchar_t *fileName, void *dst, uint32_t dstCapacity)
+{
+    FILE *file = NULL;
+    _wfopen_s(&file, fileName, L"rb");
+    if (NULL == file)
+    {
+        return 0;
+    }
+
+    fseek(file, 0, SEEK_END);
+    long size = ftell(file);
+    fseek(file, 0, SEEK_SET);
+
+    uint32_t result = 0;
+    if (size > 0)
+    {
+        if (NULL == dst)
+        {
+            result = (uint32_t)size; // size query only
+        }
+        else
+        {
+            uint32_t toRead = (uint32_t)size < dstCapacity ? (uint32_t)size : dstCapacity;
+            result = (uint32_t)fread(dst, 1, toRead, file);
+        }
+    }
+
+    fclose(file);
+    return result;
+}
+
+// Loads a batch of .zst files listed (one per line) in a text file and
+// concatenates their raw bytes into a single aligned buffer. The list file is
+// treated as ASCII; blank lines and lines whose first non-whitespace character
+// is '#' are ignored, and relative paths resolve against the current working
+// directory. Entries that cannot be opened are skipped with a warning. The
+// concatenation is byte-adjacent, so the result is a valid multi-frame zstd
+// stream that the frame scanner handles as usual.
+static void loadFileBatchAligned(void **outData, uint32_t *outDataSize, uint32_t *outBufferSize, uint32_t alignmentLog2, uint32_t bufferOffs, const wchar_t* listFileName)
+{
+    bufferOffs = zstdgpu_AlignUp(bufferOffs, 4); // NOTE(pamartis): align to 4 bytes at least for now.
+
+    *outData = NULL;
+    *outDataSize = 0;
+    *outBufferSize = 0;
+
+    // Read the entire list file (ASCII) into memory.
+    uint32_t listSize = loadOneFile(listFileName, NULL, 0);
+    if (0 == listSize)
+    {
+        debugPrint(L"[FAIL] Couldn't open (or empty) batch list file '%s'.\n", listFileName);
+        return;
+    }
+
+    char *listText = (char *)malloc((size_t)listSize + 1);
+    ZSTDGPU_ASSERT(NULL != listText);
+    if (NULL == listText)
+    {
+        return;
+    }
+    listSize = loadOneFile(listFileName, listText, listSize);
+    listText[listSize] = '\0';
+
+    // Parse the ASCII list in place into an array of char* paths, each pointing
+    // into listText (which stays alive until every file has been read).
+    char **paths = NULL;
+    uint32_t pathCount = 0;
+    uint32_t pathCapacity = 0;
+
+    uint32_t i = 0;
+    if (listSize >= 3 && (unsigned char)listText[0] == 0xEF && (unsigned char)listText[1] == 0xBB && (unsigned char)listText[2] == 0xBF)
+    {
+        i = 3; // skip UTF-8 BOM
+    }
+
+    while (i < listSize)
+    {
+        // skip leading whitespace
+        while (i < listSize && (listText[i] == ' ' || listText[i] == '\t')) { ++i; }
+
+        uint32_t lineStart = i;
+
+        // find the end of the line (or end of buffer)
+        while (i < listSize && listText[i] != '\n') { ++i; }
+
+        // capture the end of the line and move the cursor past it for the next iteration
+        uint32_t lineEnd = i++;
+
+        // strip trailing '\r' (CRLF)
+        if (lineEnd > lineStart && listText[lineEnd - 1] == '\r') { --lineEnd; }
+
+        // trim trailing whitespace
+        while (lineEnd > lineStart && (listText[lineEnd - 1] == ' ' || listText[lineEnd - 1] == '\t')) { --lineEnd; }
+
+        // Any blank lines or comments are ignored
+        if (lineEnd == lineStart || listText[lineStart] == '#') { continue; }
+
+        // terminate the path in place
+        listText[lineEnd] = '\0';
+
+        if (pathCount == pathCapacity)
+        {
+            uint32_t newCap = pathCapacity ? pathCapacity * 2 : 16;
+            char **newPaths = (char **)realloc(paths, (size_t)newCap * sizeof(char *));
+            ZSTDGPU_ASSERT(NULL != newPaths);
+            if (NULL == newPaths)
+            {
+                break;
+            }
+            paths = newPaths;
+            pathCapacity = newCap;
+        }
+
+        paths[pathCount++] = listText + lineStart;
+    }
+
+    if (0 == pathCount)
+    {
+        debugPrint(L"[WARN] Batch list file '%s' contained no usable .zst entries.\n", listFileName);
+        free(paths);
+        free(listText);
+        return;
+    }
+
+    // Pass 1: size every file, skipping ones that can't be opened.
+    uint32_t *sizes = (uint32_t *)malloc((size_t)pathCount * sizeof(uint32_t));
+    ZSTDGPU_ASSERT(NULL != sizes);
+    if (NULL == sizes)
+    {
+        free(paths);
+        free(listText);
+        return;
+    }
+
+    // Reusable buffer to widen each ASCII path for loadOneFile (which opens wide).
+    wchar_t widePath[MAX_PATH];
+
+    uint64_t totalDataSize = 0;
+    for (uint32_t p = 0; p < pathCount; ++p)
+    {
+        sizes[p] = 0;
+        if (0 == MultiByteToWideChar(CP_UTF8, 0, paths[p], -1, widePath, MAX_PATH))
+        {
+            debugPrint(L"[WARN] Batch: path invalid or longer than MAX_PATH '%S', skipping.\n", paths[p]);
+            continue;
+        }
+        uint32_t sz = loadOneFile(widePath, NULL, 0);
+        if (0 == sz)
+        {
+            debugPrint(L"[WARN] Batch: couldn't open (or empty) '%S', skipping.\n", paths[p]);
+            continue; // skip missing / empty / unsizable files
+        }
+        uint64_t projected = (uint64_t)bufferOffs + totalDataSize + (uint64_t)sz;
+        if (projected > 0xFFFFFFFFull)
+        {
+            debugPrint(L"[WARN] Batch: total size would exceed 4 GiB; stopping at '%S'.\n", paths[p]);
+            break;
+        }
+        sizes[p] = sz;
+        totalDataSize += (uint64_t)sz;
+    }
+
+    if (0 == totalDataSize)
+    {
+        debugPrint(L"[WARN] Batch list file '%s' had no readable, non-empty files.\n", listFileName);
+        free(paths);
+        free(listText);
+        free(sizes);
+        return;
+    }
+
+    // Allocate the concatenation buffer and zero the leading offset region.
+    uint32_t bufferSize = zstdgpu_AlignUp(bufferOffs + (uint32_t)totalDataSize, 1u << alignmentLog2);
+    void *data = malloc(bufferSize);
+    ZSTDGPU_ASSERT(NULL != data);
+    if (NULL == data)
+    {
+        free(paths);
+        free(listText);
+        free(sizes);
+        return;
+    }
+
+    if (bufferOffs > 0)
+    {
+        memset((char *)data, 0, bufferOffs);
+    }
+
+    // Pass 2: read each file's bytes into the buffer, byte-adjacent.
+    uint32_t ofs = bufferOffs;
+    uint32_t loadedCount = 0;
+    for (uint32_t p = 0; p < pathCount; ++p)
+    {
+        if (0 == sizes[p])
+        {
+            continue;
+        }
+        if (0 == MultiByteToWideChar(CP_UTF8, 0, paths[p], -1, widePath, MAX_PATH))
+        {
+            debugPrint(L"[WARN] Batch: '%S' became unavailable, skipping.\n", paths[p]);
+            continue;
+        }
+        uint32_t rd = loadOneFile(widePath, (char *)data + ofs, sizes[p]);
+        if (0 == rd)
+        {
+            debugPrint(L"[WARN] Batch: '%S' became unavailable, skipping.\n", paths[p]);
+            continue;
+        }
+        if (rd != sizes[p])
+        {
+            debugPrint(L"[WARN] Batch: short read on '%S' (%u of %u bytes).\n", paths[p], rd, sizes[p]);
+        }
+        ofs += rd;
+        ++loadedCount;
+    }
+
+    if (bufferSize > ofs)
+    {
+        memset((char *)data + ofs, 0, bufferSize - ofs); // zero trailing padding
+    }
+
+    debugPrint(L"[INFO] Batch: concatenated %u file(s) from '%s' -- %u bytes.\n", loadedCount, listFileName, ofs - bufferOffs);
+
+    free(paths);
+    free(listText);
+    free(sizes);
+
+    *outData = data;
+    *outDataSize = ofs - bufferOffs;
+    *outBufferSize = bufferSize;
+}
+
 static void loadFileAligned(void **outData, uint32_t *outDataSize, uint32_t *outBufferSize, uint32_t alignmentLog2, uint32_t bufferOffs, const wchar_t* fileName)
 {
     bufferOffs = zstdgpu_AlignUp(bufferOffs, 4); // NOTE(pamartis): align to 4 bytes at least for now.
 
-    uint32_t dataSize = 0;
+    uint32_t dataSize = loadOneFile(fileName, NULL, 0);
     uint32_t bufferSize = 0;
-
     void* data = NULL;
-    FILE* file = NULL;
-    _wfopen_s(&file, fileName, L"rb");
-    if (NULL != file)
+    if (dataSize > 0)
     {
-        fseek(file, 0, SEEK_END);
-        dataSize = ftell(file);
-        fseek(file, 0, SEEK_SET);
-        if (-1 != dataSize)
+        bufferSize = zstdgpu_AlignUp(bufferOffs + dataSize, 1u << alignmentLog2);
+        data = malloc(bufferSize);
+        ZSTDGPU_ASSERT(NULL != data);
+        if (NULL != data)
         {
-            bufferSize = zstdgpu_AlignUp(bufferOffs + dataSize, 1u << alignmentLog2);
-            data = malloc(bufferSize);
-            ZSTDGPU_ASSERT(NULL != data);
-            if (NULL != data)
+            // NOTE(pamarits): populate random data in the buffer with zeros for now.
+            if (bufferOffs > 0)
             {
-                // NOTE(pamarits): populate random data in the buffer with zeros for now.
-                if (bufferOffs > 0)
-                {
-                    memset((char*)data, 0, bufferOffs);
-                }
+                memset((char*)data, 0, bufferOffs);
+            }
 
-                size_t readSize = fread((char *)data + bufferOffs, 1, dataSize, file);
-                ZSTDGPU_ASSERT(readSize == dataSize);
+            uint32_t readSize = loadOneFile(fileName, (char *)data + bufferOffs, dataSize);
+            ZSTDGPU_ASSERT(readSize == dataSize);
 
-                if (bufferSize > bufferOffs + dataSize)
-                {
-                    memset((char*)data + bufferOffs + dataSize, 0, bufferSize - dataSize - bufferOffs);
-                }
+            if (bufferSize > bufferOffs + dataSize)
+            {
+                memset((char*)data + bufferOffs + dataSize, 0, bufferSize - dataSize - bufferOffs);
             }
         }
-        fclose(file);
     }
     *outData = data;
     *outDataSize = dataSize;
@@ -1235,7 +1462,7 @@ static int demoRun(void *demoCtx)
             if (1 == argc || badArg)
             {
                 debugPrint(L"USAGE:\n");
-                debugPrint(L"\t--zst <path to .zst file> [Required] Specifies a file path to .zst file to decompress. Could be absolute or relative path.\n");
+                debugPrint(L"\t--zst <path | @listfile>  [Required] Path to a .zst file (absolute or relative). If prefixed with '@', the value is a text file listing .zst paths (one per line, '#' comments allowed) loaded concatenated into one buffer.\n");
                 debugPrint(L"\t--chk-gpu                 [Optional] After running decompresssion on GPU, validates its outputs against the outputs from reference decompressor.\n");
                 debugPrint(L"\t--chk-cpu                 [Optional] Before running decompression on GPU, runs GPU decompressor code on CPU and validates its outputs against the outputs from reference decompressor.\n");
                 debugPrint(L"\t--sim-gpu                 [Optional] After running decompression on GPU, runs key GPU decompressor stages on CPU using intermediate inputs from GPU decompression and validates its outputs against the outputs from reference decompressor.\n");
@@ -1271,7 +1498,16 @@ static int demoRun(void *demoCtx)
     uint32_t zstdCompressedFramesMemorySizeInBytes = 0;
     uint32_t zstdUnCompressedFramesMemorySizeInBytes = 0;
 
-    loadFileAligned(&zstdData, &zstdDataSize, &zstdCompressedFramesMemorySizeInBytes, 2u, zstdOffs, zstFilePath);
+    // A leading '@' selects batch mode: zstFilePath names a text file listing
+    // .zst files (one per line) to load concatenated into a single buffer.
+    if (L'@' == zstFilePath[0])
+    {
+        loadFileBatchAligned(&zstdData, &zstdDataSize, &zstdCompressedFramesMemorySizeInBytes, 2u, zstdOffs, zstFilePath + 1);
+    }
+    else
+    {
+        loadFileAligned(&zstdData, &zstdDataSize, &zstdCompressedFramesMemorySizeInBytes, 2u, zstdOffs, zstFilePath);
+    }
     if (NULL == zstdData)
     {
         debugPrint(L"[FAIL] Couldn't load '%s'. Early Out.\n", zstFilePath);


### PR DESCRIPTION
Adjust the CI test harness to perform functional/correctness testing over batches of files per invocation for cases where success is generally expected.  If a batch that fails, each item is executed individually to identify the error.