### PR TITLE
Rework the CI performance testing to cover 2 marker scenarios.

### DIFF
--- a/zstd/zstdgpu_ci_tests/adversarial_manifest.cpp
+++ b/zstd/zstdgpu_ci_tests/adversarial_manifest.cpp
@@ -260,6 +260,31 @@ static bool ParseEntry(Parser& p, AdversarialEntry& entry, std::string& errorOut
     return true;
 }
 
+// Parses a JSON array of perf entries ("[ {path_glob, reason}, ... ]") into
+// `out`. Assumes the caller has consumed the array's key and ':'. Reuses
+// ParseEntry: perf entries share path_glob/reason with adversarial entries, and
+// any expected_exit_code that happens to be present is parsed and ignored.
+static bool ParsePerfEntryArray(Parser& p, std::vector<PerfEntry>& out, std::string& errorOut)
+{
+    if (!p.SkipWs() || !p.Expect('[')) { errorOut = p.error; return false; }
+    if (!p.SkipWs()) { p.Fail("unexpected eof in perf entry array"); errorOut = p.error; return false; }
+    if (p.text[p.pos] == ']') { ++p.pos; return true; }
+    while (true)
+    {
+        AdversarialEntry ae;
+        if (!ParseEntry(p, ae, errorOut)) return false;
+        PerfEntry pe;
+        pe.pathGlob = std::move(ae.pathGlob);
+        pe.reason = std::move(ae.reason);
+        out.push_back(std::move(pe));
+        if (!p.SkipWs()) { p.Fail("unexpected eof in perf entry array"); errorOut = p.error; return false; }
+        if (p.text[p.pos] == ',') { ++p.pos; continue; }
+        if (p.text[p.pos] == ']') { ++p.pos; break; }
+        p.Fail("expected ',' or ']' in perf entry array"); errorOut = p.error; return false;
+    }
+    return true;
+}
+
 // Parses one scenario_skip object. scenario_glob and gpu_name_glob are
 // required; path_glob, reason, and tracking_bug are optional; unknown fields
 // are skipped.
@@ -591,6 +616,131 @@ size_t AdversarialManifest::CountCoverage(const std::vector<std::string>& files,
                 break;
             }
         }
+    }
+
+    return filesMatched;
+}
+
+// ---------------------------------------------------------------------------
+// PerfManifest
+// ---------------------------------------------------------------------------
+
+bool PerfManifest::LoadFromFile(const std::filesystem::path& jsonPath, std::string& errorOut)
+{
+    m_latency.clear();
+    m_throughput.clear();
+    m_loaded = false;
+    m_sourcePath = jsonPath;
+
+    std::ifstream file(jsonPath, std::ios::binary);
+    if (!file)
+    {
+        errorOut = "could not open perf manifest file: " + jsonPath.string();
+        return false;
+    }
+    std::ostringstream buf;
+    buf << file.rdbuf();
+    std::string text = buf.str();
+
+    Parser p{ std::string_view(text), 0, {} };
+
+    if (!p.SkipWs() || !p.Expect('{')) { errorOut = p.error; return false; }
+
+    while (true)
+    {
+        if (!p.SkipWs()) { p.Fail("unexpected eof at top level"); errorOut = p.error; return false; }
+        if (p.text[p.pos] == '}') { ++p.pos; break; }
+
+        std::string key = p.ReadString();
+        if (p.Failed()) { errorOut = p.error; return false; }
+        if (!p.SkipWs() || !p.Expect(':')) { errorOut = p.error; return false; }
+
+        if (key == "$schema_version")
+        {
+            int v = p.ReadInt();
+            if (p.Failed()) { errorOut = p.error; return false; }
+            if (v != 1)
+            {
+                errorOut = "unsupported $schema_version " + std::to_string(v) + " (this wrapper supports version 1)";
+                return false;
+            }
+        }
+        else if (key == "latency")
+        {
+            if (!ParsePerfEntryArray(p, m_latency, errorOut)) return false;
+        }
+        else if (key == "throughput")
+        {
+            if (!ParsePerfEntryArray(p, m_throughput, errorOut)) return false;
+        }
+        else
+        {
+            // Unknown top-level field (e.g. "notes") — skip for forward compat.
+            p.SkipValue();
+            if (p.Failed()) { errorOut = p.error; return false; }
+        }
+
+        if (!p.SkipWs()) { p.Fail("unexpected eof at top level"); errorOut = p.error; return false; }
+        if (p.text[p.pos] == ',') { ++p.pos; continue; }
+        if (p.text[p.pos] == '}') { ++p.pos; break; }
+        p.Fail("expected ',' or '}' at top level"); errorOut = p.error; return false;
+    }
+
+    m_loaded = true;
+    return true;
+}
+
+std::vector<std::string> PerfManifest::SelectFiles(const std::string& scenario,
+                                                   const std::vector<std::string>& discoveredFiles,
+                                                   const std::filesystem::path& contentPath) const
+{
+    std::vector<std::string> selected;
+    if (!m_loaded)
+        return selected;
+
+    const std::vector<PerfEntry>* globs = nullptr;
+    if (scenario == "latency")         globs = &m_latency;
+    else if (scenario == "throughput") globs = &m_throughput;
+    else                               return selected;  // unknown scenario selects nothing
+
+    // Single pass over the discovered files: preserves discovery order and
+    // dedupes for free (each file is added at most once, even if several globs
+    // match it). Mirrors CountCoverage's matching.
+    for (const auto& f : discoveredFiles)
+    {
+        const std::string rel = RelativeAndNormalize(f, contentPath);
+        for (const auto& e : *globs)
+        {
+            if (GlobMatchSuffix(e.pathGlob, rel))
+            {
+                selected.push_back(f);
+                break;
+            }
+        }
+    }
+    return selected;
+}
+
+size_t PerfManifest::CountCoverage(const std::vector<std::string>& files,
+                                   const std::filesystem::path& contentPath) const
+{
+    if (!m_loaded)
+        return 0;
+
+    size_t filesMatched = 0;
+    for (const auto& f : files)
+    {
+        const std::string rel = RelativeAndNormalize(f, contentPath);
+        bool matched = false;
+        for (const auto* set : { &m_latency, &m_throughput })
+        {
+            for (const auto& e : *set)
+            {
+                if (GlobMatchSuffix(e.pathGlob, rel)) { matched = true; break; }
+            }
+            if (matched) break;
+        }
+        if (matched) ++filesMatched;
     }
 
     return filesMatched;

--- a/zstd/zstdgpu_ci_tests/adversarial_manifest.h
+++ b/zstd/zstdgpu_ci_tests/adversarial_manifest.h
@@ -97,3 +97,57 @@ private:
     std::filesystem::path m_sourcePath;
     bool m_loaded = false;
 };
+
+// One perf-manifest entry: a glob (relative to --content-path) that selects
+// files for a perf scenario, plus a human-readable reason the files qualify.
+struct PerfEntry
+{
+    std::string pathGlob;                          // Glob over the file path relative to --content-path (JSON key "path_glob")
+    std::string reason;                            // Human-readable note on why these files qualify (JSON key "reason")
+};
+
+// Perf manifest: selects the content each perf scenario runs over. Carries two
+// independent glob sets, "latency" and "throughput"; they may (and eventually
+// will) select different files even though today they glob to the same tiles.
+// This replaces the old hardcoded "path contains 64KB" selection so the perf
+// corpus is data-driven, authored beside the content rather than in code.
+//
+// Loaded once at startup, then read-only from test threads. Uses the same
+// anchored glob syntax ('*', '[a-b]') as the adversarial manifest, matched
+// against each discovered file's path relative to --content-path.
+class PerfManifest
+{
+public:
+    // Loads the "latency" and "throughput" glob arrays from a JSON file. Returns
+    // false (with a diagnostic in errorOut) if the file is missing, malformed, or
+    // has an unsupported schema_version, leaving the manifest empty/unloaded.
+    bool LoadFromFile(const std::filesystem::path& jsonPath, std::string& errorOut);
+
+    // Returns the discovered files matching at least one glob for the given
+    // scenario ("latency" or "throughput"). Files are returned in discovery
+    // order and deduplicated (a file selected by several globs appears once);
+    // an unknown scenario name selects nothing. Order/dedupe matter: the demo
+    // concatenates the result into one stream, so duplicates or reordering would
+    // double-count frames and destabilize the pooled P50/median.
+    std::vector<std::string> SelectFiles(const std::string& scenario,
+                                         const std::vector<std::string>& discoveredFiles,
+                                         const std::filesystem::path& contentPath) const;
+
+    // Startup coverage self-check: how many of `files` match at least one glob in
+    // either scenario. The wrapper fails loud when a loaded manifest matches
+    // nothing (almost always a content-path / glob-prefix mismatch).
+    size_t CountCoverage(const std::vector<std::string>& files,
+                         const std::filesystem::path& contentPath) const;
+
+    size_t LatencyCount() const { return m_latency.size(); }
+    size_t ThroughputCount() const { return m_throughput.size(); }
+    size_t Size() const { return m_latency.size() + m_throughput.size(); }
+    bool Loaded() const { return m_loaded; }
+    const std::filesystem::path& SourcePath() const { return m_sourcePath; }
+
+private:
+    std::vector<PerfEntry> m_latency;
+    std::vector<PerfEntry> m_throughput;
+    std::filesystem::path m_sourcePath;
+    bool m_loaded = false;
+};

--- a/zstd/zstdgpu_ci_tests/adversarial_manifest.sample.json
+++ b/zstd/zstdgpu_ci_tests/adversarial_manifest.sample.json
@@ -28,7 +28,7 @@
       "tracking_bug": "Replace with a bug ID, driver note, or TSG link describing why the scenario is disabled on this device class."
     },
     {
-      "scenario_glob": "PerStageTiming",
+      "scenario_glob": "D3D12DebugLayerSeq",
       "gpu_name_glob": "*Fabrikam GPU 9000*",
       "reason": "Example: quarantine a single named scenario on one specific device model.",
       "tracking_bug": "Replace with a tracking reference."

--- a/zstd/zstdgpu_ci_tests/main.cpp
+++ b/zstd/zstdgpu_ci_tests/main.cpp
@@ -107,10 +107,7 @@ static void PrintUsage(const char* exe)
               << "  --demo-path <path>      Path to zstdgpu_demo.exe (required)\n"
               << "  --log-dir <dir>         Directory for logs and CSV output\n"
               << "  --log-file <path>       Consolidated text log file\n"
-              << "  --run-count <N>         Perf test iteration count (default: 40)\n"
               << "  --timeout <seconds>     Per-test process timeout (default: no timeout)\n"
-              << "  --perf-min-mb <N>       Minimum .zst file size (MB) required for perf tests (default: 4).\n"
-              << "                          Smaller files skip perf; individually-compressed textures are not representative of throughput.\n"
               << "  --gbv-sample-count <N>  Number of files the GBV scenarios run on, sampled by an even stride\n"
               << "                          across the sorted corpus (default: 0 = no cap; run GBV on every file\n"
               << "                          within --gbv-max-mb). A positive N samples that many files by stride.\n"
@@ -137,6 +134,13 @@ static void PrintUsage(const char* exe)
               << "                                    - correctness tests expect a specific exit code + stderr signature\n"
               << "                                  If no manifest is found (no flag AND no file in content-path), the\n"
               << "                                  wrapper falls back to legacy behavior: every file expected to succeed.\n"
+              << "  --perf-manifest <path>          Optional JSON manifest selecting the perf corpus. Carries two\n"
+              << "                                  glob sets, \"latency\" and \"throughput\" (globs relative to\n"
+              << "                                  --content-path), which may select different files. If NOT\n"
+              << "                                  specified, the wrapper auto-discovers the manifest at\n"
+              << "                                  <content-path>/perf_manifest.json. Each perf scenario runs over\n"
+              << "                                  its matching files; without a manifest the perf tests fail on an\n"
+              << "                                  empty selection. Correctness tests are unaffected.\n"
               << std::endl;
 }
 
@@ -174,12 +178,6 @@ static bool ParseArgs(int argc, char** argv, TestConfig& config, bool& shouldExi
         {
             config.logFile = argv[++i];
         }
-        else if (std::strcmp(argv[i], "--run-count") == 0 && i + 1 < argc)
-        {
-            config.runCount = std::atoi(argv[++i]);
-            if (config.runCount <= 0)
-                config.runCount = 40;
-        }
         else if (std::strcmp(argv[i], "--timeout") == 0 && i + 1 < argc)
         {
             config.timeoutSeconds = std::atoi(argv[++i]);
@@ -190,15 +188,13 @@ static bool ParseArgs(int argc, char** argv, TestConfig& config, bool& shouldExi
         {
             config.adversarialManifestPath = argv[++i];
         }
+        else if (std::strcmp(argv[i], "--perf-manifest") == 0 && i + 1 < argc)
+        {
+            config.perfManifestPath = argv[++i];
+        }
         else if (std::strcmp(argv[i], "--gpu-name") == 0 && i + 1 < argc)
         {
             config.gpuName = argv[++i];
-        }
-        else if (std::strcmp(argv[i], "--perf-min-mb") == 0 && i + 1 < argc)
-        {
-            config.perfMinMB = std::atoi(argv[++i]);
-            if (config.perfMinMB < 0)
-                config.perfMinMB = 0;   // <= 0 disables the perf-size skip (all files eligible for perf)
         }
         else if (std::strcmp(argv[i], "--gbv-sample-count") == 0 && i + 1 < argc)
         {
@@ -349,6 +345,66 @@ static int ValidateAndDiscover(TestConfig& config)
         std::cout << "No adversarial manifest found (neither --adversarial-manifest passed "
                   << "nor <content-path>/adversarial_manifest.json exists). "
                   << "Running in legacy mode: every file expected to succeed.\n";
+    }
+
+    // Load the perf manifest (selects the latency/throughput perf corpus).
+    // Resolution mirrors the adversarial manifest:
+    //   1. --perf-manifest <path> is an explicit override; a missing file there
+    //      is a hard error.
+    //   2. Else auto-discover <content-path>/perf_manifest.json. Absent is NOT an
+    //      error here (correctness-only runs don't need it) — but the perf tests
+    //      fail loud on an empty selection if they run without one.
+    //   3. A file that exists but fails to parse is always a hard error.
+    bool perfManifestFromExplicitFlag = !config.perfManifestPath.empty();
+    if (!perfManifestFromExplicitFlag)
+    {
+        std::filesystem::path autoPath =
+            std::filesystem::path(config.contentPath) / "perf_manifest.json";
+        if (std::filesystem::exists(autoPath))
+        {
+            config.perfManifestPath = autoPath.string();
+        }
+    }
+
+    if (!config.perfManifestPath.empty())
+    {
+        std::string loadError;
+        if (!config.perfManifest.LoadFromFile(config.perfManifestPath, loadError))
+        {
+            return Fail("perf manifest failed to load from '" +
+                        config.perfManifestPath + "': " + loadError);
+        }
+        std::cout << "Loaded perf manifest with "
+                  << config.perfManifest.LatencyCount() << " latency + "
+                  << config.perfManifest.ThroughputCount() << " throughput entries from '"
+                  << config.perfManifestPath << "'"
+                  << (perfManifestFromExplicitFlag ? " (via --perf-manifest)." : " (auto-discovered in content-path).")
+                  << "\n";
+
+        // Coverage self-check. A loaded manifest that matches NOTHING is almost
+        // always a content-path / glob-prefix mismatch (globs authored relative
+        // to a sub-tree while --content-path points elsewhere). Left undetected it
+        // turns every perf scenario into a spurious empty-selection failure, so
+        // fail loud here with a clearer, earlier message.
+        const size_t filesMatched = config.perfManifest.CountCoverage(
+            config.discoveredFiles, config.contentPath);
+        if (config.perfManifest.Size() > 0 && filesMatched == 0)
+        {
+            return Fail("perf manifest loaded " +
+                        std::to_string(config.perfManifest.Size()) +
+                        " entries but matched 0 of " +
+                        std::to_string(config.discoveredFiles.size()) +
+                        " discovered files. This is almost certainly a content-path/glob "
+                        "prefix mismatch: manifest globs are authored relative to a sub-tree. "
+                        "Verify --content-path '" +
+                        config.contentPath + "' points at or above that tree.");
+        }
+    }
+    else
+    {
+        std::cout << "No perf manifest found (neither --perf-manifest passed "
+                  << "nor <content-path>/perf_manifest.json exists). "
+                  << "The ZstdGpuPerfTests scenarios will fail on an empty selection if run.\n";
     }
 
     return 0;

--- a/zstd/zstdgpu_ci_tests/perf_manifest.sample.json
+++ b/zstd/zstdgpu_ci_tests/perf_manifest.sample.json
@@ -1,0 +1,22 @@
+{
+  "$schema_version": 1,
+  "notes": "SAMPLE / REFERENCE perf manifest for the Zstd GPU CI wrapper. Selects the content each perf scenario runs over. The entries below are placeholders that exist only to document the schema -- do not ship it as-is. At runtime the wrapper loads a real manifest either from --perf-manifest <path> or, if that flag is absent, by auto-discovering <content-path>/perf_manifest.json. 'latency' and 'throughput' are two independent glob sets: each is a list of path globs relative to --content-path, using the same anchored '*' and '[a-b]' syntax as the adversarial manifest. Files are selected in discovery order and de-duplicated, so a file matched by several globs is used once. The two sets may select the same files today and diverge later (e.g. latency -> small single-frame tiles, throughput -> larger multi-frame streams) without any code change.",
+
+  "latency": [
+    {
+      "path_glob": "<path>/tiles_64KB/*.zst",
+      "reason": "Small frames dispatched a dozen at a time; the perf Latency scenario tiles them and reports the pooled P50 latency. '*' matches any characters within the path."
+    },
+    {
+      "path_glob": "<path>/latency_family_[0-9][0-9].zst",
+      "reason": "A family of files matched with a bracket range. '[0-9]' matches one digit."
+    }
+  ],
+
+  "throughput": [
+    {
+      "path_glob": "<path>/tiles_64KB/*.zst",
+      "reason": "Frames tiled across the throughput frame-count ladder; the Throughput scenario reports the median bandwidth at each rung (batch size)."
+    }
+  ]
+}

--- a/zstd/zstdgpu_ci_tests/zstdgpu_ci_tests.cpp
+++ b/zstd/zstdgpu_ci_tests/zstdgpu_ci_tests.cpp
@@ -25,19 +25,34 @@
 //     - Gbv                : --chk-gpu --d3d-dbg --d3d-gbv
 //     - GbvSeq             : --chk-gpu --d3d-dbg --d3d-gbv --seq-cnt
 //
-//   Performance (EXPECT — soft fail, also verify CSV output was written):
-//     - PerStageTiming     : --prf-lvl 2 --d3d-gfx --seq-cnt → results/stages_<stem>.csv
+//   ZstdGpuPerfTests — report-only perf (batches at a time)
+//     - Latency    : small fixed-size (12-frame) batches; the demo's total [PERF]
+//                    line reports the P50 latency across the corpus windows.
+//     - Throughput : a harness-owned, fixed ladder of window sizes
+//                    (64,128,192,256,384,512,768,1024). The harness invokes the
+//                    demo once per rung over the whole corpus; each rung's total
+//                    [PERF] line reports the median bandwidth across the corpus
+//                    windows at that batch size (a bandwidth-vs-window curve).
+//
+//   The demo computes and prints per-batch and pooled-total latency + bandwidth on
+//   [PERF] stdout lines; the harness only orchestrates and echoes those lines (no
+//   CSV parsing / no aggregation). An external log-analysis script consumes the
+//   [PERF] lines run-over-run.
 
 #include "zstdgpu_ci_tests.h"
 #include "zstd_frame_size.h"
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <array>
+#include <cmath>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <sstream>
 #include <thread>
 #include <unordered_set>
+#include <utility>
 #include <Windows.h>
 
 // Internal types + forward declarations
@@ -66,13 +81,6 @@ namespace
     std::vector<std::string> BuildCorrectnessArgs(
         const std::string& zstFile,
         const std::vector<std::string>& scenarioFlags);
-
-    std::vector<std::string> BuildPerformanceArgs(
-        const std::string& zstFile,
-        int profilingLevel,
-        int runCount,
-        const std::string& csvOutputPath,
-        const std::vector<std::string>& extraFlags);
 }
 
 // Defined below; used by RunBatchedCorrectnessTest to keep fuzz content out of
@@ -261,17 +269,6 @@ static bool IsSelectedForGbv(const std::string& zstFile)
 {
     const auto& sel = GbvSampledFiles();
     return sel.find(zstFile) != sel.end();
-}
-
-// True if the file is smaller than --perf-min-mb. Returns false when
-// --perf-min-mb <= 0 (disabled) or the file size cannot be read.
-static bool IsSmallForPerf(const std::string& zstFile)
-{
-    if (g_testConfig.perfMinMB <= 0) return false;
-    std::error_code ec;
-    auto size = std::filesystem::file_size(zstFile, ec);
-    if (ec) return false;
-    return size < static_cast<uintmax_t>(g_testConfig.perfMinMB) * 1024ULL * 1024ULL;
 }
 
 // Returns a GTEST_SKIP message when --max-frame-mb is set (> 0) and the file's
@@ -614,90 +611,54 @@ static void RunBatchedCorrectnessTest(const std::vector<std::string>& allFiles,
     runBatch();
 }
 
-// Run a performance scenario. Spawns zstdgpu_demo.exe with profiling flags and requests CSV output. Uses EXPECT (not ASSERT) to verify the demo executed successfully and produced CSV output.
-// main() has already validated the demo path exists.
-static void RunPerformanceTest(const std::string& zstFile, int profilingLevel,
-                                const std::vector<std::string>& extraFlags)
+// Batched perf test
+// Run the entire configured corpus of latency or throughput files
+// Latency is fixed batch sizes, throughput is a ladder of batch sizes.
+// Each run emits a perf line that is read and processed by analysis scripts
+static void RunPerfTest(int frameBatchCount, const char* scenario)
 {
-    // Skip if the manifest marks this scenario as skipped for this GPU; this
-    // takes precedence over the fuzz/size skips below.
-    if (std::string skip = ScenarioSkipReason(zstFile); !skip.empty())
-    {
-        GTEST_SKIP() << skip;
-        return;
-    }
+    const std::vector<std::string> files = g_testConfig.perfManifest.SelectFiles(
+        scenario, g_testConfig.discoveredFiles, g_testConfig.contentPath);
+    ASSERT_FALSE(files.empty())
+        << "Perf manifest selected no files for the '" << scenario << "' scenario. "
+        << "Ensure a perf manifest is loaded (--perf-manifest or "
+        << "<content-path>/perf_manifest.json) and its '" << scenario
+        << "' globs match content under '" << g_testConfig.contentPath << "'.";
 
-    // Fuzzing content mixes clean and corrupt inputs with varying code paths,
-    // so its timing isn't meaningful perf data — skip it before running the demo.
-    if (IsFuzzContent(zstFile))
-    {
-        GTEST_SKIP()
-            << "Perf test skipped: file is fuzzing content (under a 'fuzz' directory).\n"
-            << "File: " << zstFile;
-        return;
-    }
+    std::string listPath;
+    ASSERT_TRUE(WriteBatchListFile(std::string("perf_") + scenario, files, listPath))
+        << "Failed to write perf batch list file.";
 
-    // Skip files smaller than --perf-min-mb.
-    if (IsSmallForPerf(zstFile))
-    {
-        GTEST_SKIP()
-            << "Perf test skipped: file is under --perf-min-mb ("
-            << g_testConfig.perfMinMB << " MB).\n"
-            << "File: " << zstFile;
-        return;
-    }
+    std::cout << "[PERF-CFG] scenario=" << scenario
+              << " files=" << files.size()
+              << " frame-batch-count=" << frameBatchCount
+              << " run-cnt=" << g_testConfig.perfRunCount << "\n";
 
-    // Perf CSVs are written as stages_<stem>.csv under the results directory.
-    std::string stem = std::filesystem::path(zstFile).stem().string();
-    std::filesystem::path resultsDir = std::filesystem::path(g_testConfig.logDir) / "results";
-    if (!std::filesystem::exists(resultsDir))
-    {
-        std::filesystem::create_directories(resultsDir);
-    }
-    std::string csvPath = (resultsDir / ("stages_" + stem + ".csv")).string();
+    const std::vector<std::string> args = {
+        "--zst", "@" + listPath,
+        "--frame-batch-count", std::to_string(frameBatchCount),
+        "--run-cnt", std::to_string(g_testConfig.perfRunCount),
+        "--prf-lvl", "0",
+        "--seq-cnt",
+    };
 
-    auto args = BuildPerformanceArgs(zstFile, profilingLevel, g_testConfig.runCount, csvPath, extraFlags);
-    if (std::string skip = FrameSizeSkipReason(zstFile); !skip.empty())
-    {
-        GTEST_SKIP() << skip;
-        return;
-    }
     auto result = RunDemo(g_testConfig.demoPath, args, g_testConfig.timeoutSeconds);
+    WriteToLogFile(std::string("[perf ") + scenario + "]", result);
 
-    // Write to log file before assertions so logs are captured even if a check fails.
-    WriteToLogFile(zstFile, result);
-
-    // Log the output regardless of pass/fail. This IS the demo stdout capture —
-    // the assertion messages below intentionally do NOT reprint result.stdOut.
-    std::cout << "[DEMO CMD] " << result.commandLine << "\n";
+    std::cout << "[PERF-CFG] " << result.commandLine << "\n";
     if (!result.stdOut.empty())
-    {
-        std::cout << "[DEMO OUT] " << result.stdOut << "\n";
-    }
+        std::cout << result.stdOut << "\n";
 
     EXPECT_FALSE(result.timedOut)
-        << "Demo process timed out after " << g_testConfig.timeoutSeconds << " seconds.\n"
-        << "Command: " << result.commandLine;
-
+        << "Demo timed out after " << g_testConfig.timeoutSeconds << "s.\nCommand: " << result.commandLine;
     EXPECT_TRUE(result.launchError.empty())
-        << "Failed to launch demo: " << result.launchError << "\n"
-        << "Command: " << result.commandLine;
-
-    // Fuzz content was already skipped above, so any file reaching here is
-    // expected to decode successfully AND produce a CSV.
+        << "Failed to launch demo: " << result.launchError << "\nCommand: " << result.commandLine;
     EXPECT_EQ(result.exitCode, 0)
-        << "Demo process returned non-zero exit code: " << result.exitCode << "\n"
-        << "Command: " << result.commandLine
-        << "  (stdout already printed above as [DEMO OUT])";
+        << "Demo returned non-zero exit code: " << result.exitCode << "\nCommand: " << result.commandLine;
 
-    EXPECT_TRUE(std::filesystem::exists(csvPath)) << "CSV not created: " << csvPath;
-
-    if (std::filesystem::exists(csvPath))
-    {
-        std::cout << "[PERF CSV] Written to: " << csvPath << "\n";
-    }
+    if (result.stdOut.find("[PERF]") == std::string::npos)
+        ADD_FAILURE() << "Demo did not emit a [PERF] metrics line on stdout.\nCommand: " << result.commandLine;
 }
-
 // Test fixture and test cases
 
 // Per-file fixture (spec: ZstdGpuDemoTests).
@@ -709,6 +670,13 @@ class ZstdGpuDemoTests : public ::testing::TestWithParam<std::string>
 // Batched fixture (spec: ZstdGpuCorrectnessTests).
 // Whole corpus is passed as a vector for batched execution
 class ZstdGpuCorrectnessTests : public ::testing::TestWithParam<std::vector<std::string>>
+{
+};
+
+// Perf fixture (spec: ZstdGpuPerfTests).
+// Each perf scenario tiles a fixed-size frame batch across the perf-manifest's
+// selected corpus, so the cases are plain (non-parameterized) tests.
+class ZstdGpuPerfTests : public ::testing::Test
 {
 };
 
@@ -767,13 +735,34 @@ TEST_P(ZstdGpuDemoTests, GbvSeq)
 #endif
 }
 
-// --- Performance tests ---
+// --- Batched perf tests (report-only) ---
 
-// Per-stage timings (--prf-lvl 2) on the DIRECT queue (--d3d-gfx) in single-
-// submission mode (--seq-cnt). Skips fuzz content and files under --perf-min-mb.
-TEST_P(ZstdGpuDemoTests, PerStageTiming)
+// Latency: tiles the perf-manifest's latency corpus into small fixed-size
+// (12-frame) batches, one batch per GPU dispatch, over a fixed number of sweeps. The
+// demo's total [PERF] line reports the P50 latency across all the corpus windows.
+TEST_F(ZstdGpuPerfTests, Latency)
 {
-    RunPerformanceTest(GetParam(), 2, {"--d3d-gfx", "--seq-cnt"});
+    RunPerfTest(g_testConfig.perfLatencyFrameCount, "latency");
+}
+
+// Throughput: sweeps a harness-owned ladder of window sizes. The harness owns
+// the ladder and invokes the demo once per rung (batch size), each tiling the
+// whole perf-manifest throughput corpus over a fixed number of sweeps. Each rung's
+// total [PERF] line reports the median bandwidth across the corpus windows at that
+// batch size, yielding a bandwidth-vs-window curve that downstream tooling reads per rung.
+TEST_F(ZstdGpuPerfTests, Throughput)
+{
+    const std::vector<int>& ladder = g_testConfig.perfThroughputFrameCounts;
+    ASSERT_FALSE(ladder.empty())
+        << "Throughput ladder is empty (perfThroughputFrameCounts is a fixed CI constant).";
+
+    std::cout << "[THROUGHPUT] rungs=" << ladder.size() << " frame-batch-counts=";
+    for (size_t i = 0; i < ladder.size(); ++i)
+        std::cout << (i ? "," : "") << ladder[i];
+    std::cout << " run-cnt=" << g_testConfig.perfRunCount << "\n";
+
+    for (int rung : ladder)
+        RunPerfTest(rung, "throughput");
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -940,40 +929,6 @@ std::vector<std::string> BuildCorrectnessArgs(
         args.push_back(std::to_string(g_testConfig.idxMax));
     }
     for (const auto& flag : scenarioFlags)
-    {
-        args.push_back(flag);
-    }
-    return args;
-}
-
-// Builds argument list for performance tests: run N iterations at the specified
-// profiling level, optionally writing per-run timing data to a CSV file. Any
-// scenario-specific demo flags are appended from `extraFlags`.
-std::vector<std::string> BuildPerformanceArgs(
-    const std::string& zstFile,
-    int profilingLevel,
-    int runCount,
-    const std::string& csvOutputPath,
-    const std::vector<std::string>& extraFlags)
-{
-    std::vector<std::string> args;
-    args.push_back("--zst");
-    args.push_back(zstFile);
-    args.push_back("--prf-lvl");
-    args.push_back(std::to_string(profilingLevel));
-    args.push_back("--run-cnt");
-    args.push_back(std::to_string(runCount));
-    if (!csvOutputPath.empty())
-    {
-        args.push_back("--out-csv");
-        args.push_back(csvOutputPath);
-    }
-    if (g_testConfig.idxMax >= 0)
-    {
-        args.push_back("--idx-max");
-        args.push_back(std::to_string(g_testConfig.idxMax));
-    }
-    for (const auto& flag : extraFlags)
     {
         args.push_back(flag);
     }

--- a/zstd/zstdgpu_ci_tests/zstdgpu_ci_tests.h
+++ b/zstd/zstdgpu_ci_tests/zstdgpu_ci_tests.h
@@ -54,7 +54,7 @@ struct TestConfig
     // -- a bandwidth-vs-window curve. Smallest 64, top 1024, with x1.5 midpoints
     // (192/384/768) as extra rungs beyond straight doubling. A fixed CI constant.
     std::vector<int> perfThroughputFrameCounts = { 64, 128, 192, 256, 384, 512, 768, 1024 };
-    int perfRunCount = 20;                       // Measured sweeps over the whole set (a fixed CI constant), forwarded to the demo as --run-cnt.
+    int perfRunCount = 5;                        // Measured sweeps over the whole set (a fixed CI constant), forwarded to the demo as --run-cnt.  A compromise value that keeps the pooled P50/median stable while bounding CI execution time.
 
     // Cached list of .zst files discovered under contentPath. Populated once
     // in main() after validation; consumed by GetTestFiles() at fixture

--- a/zstd/zstdgpu_ci_tests/zstdgpu_ci_tests.h
+++ b/zstd/zstdgpu_ci_tests/zstdgpu_ci_tests.h
@@ -29,17 +29,32 @@ struct TestConfig
     std::string logDir;                         // Directory for logs, CSVs, and GTest XML output
     std::string logFile;                        // Consolidated text log file path (--log-file)
     std::string adversarialManifestPath;        // Optional path to adversarial_manifest.json (--adversarial-manifest)
+    std::string perfManifestPath;               // Optional path to perf_manifest.json (--perf-manifest); selects the latency/throughput perf corpus
     std::string gpuName;                        // Adapter name of the machine under test (--gpu-name). Used only for the
                                                 // manifest's scenario skips.
-    int runCount = 40;                          // Number of iterations for performance tests
     int timeoutSeconds = 0;                     // Max seconds before killing a demo process (0 = no timeout)
-    int perfMinMB = 4;                          // Min .zst size (MB) required for perf tests. Smaller files skip perf (individually-compressed textures are not representative).
     int gbvSampleCount = 0;                     // Number of files the Gbv/GbvSeq scenarios run on, chosen by an even stride across the sorted corpus. <= 0 = no cap (run GBV on all files within --gbv-max-mb).
     int gbvMaxMB = 4;                           // Max largest-frame decompressed size (MB) for Gbv tests. Files with a bigger single frame are skipped to avoid GBV TDRs (GBV slows the GPU, so hang risk tracks the largest per-frame dispatch's decompressed output, not the whole-file total).
     int maxFrameMB = 0;                          // Skip any file whose largest on-disk zstd frame exceeds this (MB). <= 0 = disabled (run every file).
     int idxMax = -1;                             // Forwarded to the demo as --idx-max (inclusive last frame index). < 0 = unset (demo runs all frames).
     int correctnessBatchMB = 256;                // Max total on-disk (compressed) size (MB) of clean files grouped into one correctness batch. Bounds each concatenated demo run: batching by file count alone lets large-texture batches reach multi-GB decompressed, overflowing the demo's int32 size fields (>2 GB) and exceeding a GPU buffer limit. <= 0 = no byte cap (count-only).
     int correctnessBatchCount = 64;              // Secondary cap: max number of files per correctness batch, regardless of size. <= 0 = no count cap (size-only).
+
+    // --- Batched perf knobs ---
+    // The perf tests tile a fixed-size frame batch across the perf-manifest's
+    // selected corpus (one batch per GPU dispatch) over a number of measured
+    // sweeps. The demo reports each batch's latency/bandwidth on [PERF] lines plus
+    // a pooled total: the P50 of the per-batch latencies and the median of the
+    // per-batch bandwidths. Latency runs a single small batch size. Throughput
+    // sweeps a ladder of batch sizes (the harness invokes the demo once per rung),
+    // so per-dispatch overhead is amortized differently at each window size.
+    int perfLatencyFrameCount = 12;              // Frames per batch for the Latency scenario (fixed CI constant).
+    // Throughput ladder: the harness invokes the demo once per rung (batch size),
+    // each tiling the whole corpus, so every rung reports its own median bandwidth
+    // -- a bandwidth-vs-window curve. Smallest 64, top 1024, with x1.5 midpoints
+    // (192/384/768) as extra rungs beyond straight doubling. A fixed CI constant.
+    std::vector<int> perfThroughputFrameCounts = { 64, 128, 192, 256, 384, 512, 768, 1024 };
+    int perfRunCount = 20;                       // Measured sweeps over the whole set (a fixed CI constant), forwarded to the demo as --run-cnt.
 
     // Cached list of .zst files discovered under contentPath. Populated once
     // in main() after validation; consumed by GetTestFiles() at fixture
@@ -51,6 +66,13 @@ struct TestConfig
     // legacy behavior of expecting every file to succeed — additive, no test
     // starts failing just because the manifest isn't wired up.
     AdversarialManifest adversarialManifest;
+
+    // Loaded once in main() from --perf-manifest (or auto-discovered at
+    // <content-path>/perf_manifest.json), then read-only. Selects the files each
+    // perf scenario (latency/throughput) runs over, replacing the old hardcoded
+    // "path contains 64KB" rule. When not loaded, the perf tests fail loud on an
+    // empty selection; correctness tests are unaffected.
+    PerfManifest perfManifest;
 };
 
 // Global config, set once in main() before RUN_ALL_TESTS(), then read-only

--- a/zstd/zstdgpu_demo/main.cpp
+++ b/zstd/zstdgpu_demo/main.cpp
@@ -12,6 +12,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <time.h>
 
 #include <winsdkver.h>
@@ -68,6 +69,8 @@ extern "C"
 #include "zstdgpu_shaders.h"
 #include "zstdgpu.h"
 
+
+
 #include "platform/zstdgpu_demo_platform.h"
 
 #ifdef __clang__
@@ -89,6 +92,25 @@ static void debugPrint(const wchar_t *format, ...)
     fflush(stdout);
     OutputDebugStringW(buffer);
     va_end(args);
+}
+
+// Ascending comparator for qsort over doubles.
+static int CompareDoubles(const void *a, const void *b)
+{
+    const double da = *(const double *)a;
+    const double db = *(const double *)b;
+    return (da < db) ? -1 : ((da > db) ? 1 : 0);
+}
+
+// Median of the first 'count' values (sorts the array in place). 0 if empty.
+static double MedianOfDoubles(double *values, uint32_t count)
+{
+    if (NULL == values || 0 == count)
+        return 0.0;
+    qsort(values, count, sizeof(double), CompareDoubles);
+    if (count & 1u)
+        return values[count / 2];
+    return 0.5 * (values[count / 2 - 1] + values[count / 2]);
 }
 
 // Opens 'fileName' for binary reading. When 'dst' is NULL, returns the file's
@@ -1299,8 +1321,11 @@ static int demoRun(void *demoCtx)
     uint32_t gpuDevId = ~0u;    // means -- find any device id
     uint32_t repCount = 10;
     uint32_t prfLevel = 0;
+    bool     prfLevelSpecified = false;
+    bool     warmup = false;
     uint32_t minFrame = 0;
     uint32_t maxFrame = ~0u;
+    uint32_t frameBatchCount = ~0u; // ~0u => one batch spanning the whole working set
     uint32_t zstdOffs = 0;
 
 #ifndef _GAMING_XBOX
@@ -1315,6 +1340,7 @@ static int demoRun(void *demoCtx)
             bool nextPrfLevel = false;
             bool nextMinFrame = false;
             bool nextMaxFrame = false;
+            bool nextFrameBatchCount = false;
             bool nextZstdOffs = false;
             bool badArg = false;
             for (argi = 1; argi < argc; ++argi)
@@ -1346,7 +1372,7 @@ static int demoRun(void *demoCtx)
                     nextGpuVenId = false;
                     nextGpuDevId = false;
                 }
-                else if (nextRepCount || nextPrfLevel || nextMinFrame || nextMaxFrame || nextZstdOffs)
+                else if (nextRepCount || nextPrfLevel || nextMinFrame || nextMaxFrame || nextFrameBatchCount || nextZstdOffs)
                 {
                     errno = 0;
                     wchar_t *end = NULL;
@@ -1356,11 +1382,16 @@ static int demoRun(void *demoCtx)
                         if (nextRepCount)
                             repCount = value;
                         else if (nextPrfLevel)
+                        {
                             prfLevel = value;
+                            prfLevelSpecified = true;
+                        }
                         else if (nextMinFrame)
                             minFrame = value;
                         else if (nextMaxFrame)
                             maxFrame = value;
+                        else if (nextFrameBatchCount)
+                            frameBatchCount = value;
                         else if (nextZstdOffs)
                             zstdOffs = value;
                     }
@@ -1369,6 +1400,7 @@ static int demoRun(void *demoCtx)
                     nextPrfLevel = false;
                     nextMinFrame = false;
                     nextMaxFrame = false;
+                    nextFrameBatchCount = false;
                     nextZstdOffs = false;
                 }
                 else if (0 == wcscmp(argv[argi], L"--chk-gpu"))
@@ -1441,6 +1473,10 @@ static int demoRun(void *demoCtx)
                 {
                     nextMaxFrame = true;
                 }
+                else if (0 == wcscmp(argv[argi], L"--frame-batch-count"))
+                {
+                    nextFrameBatchCount = true;
+                }
                 else if (0 == wcscmp(argv[argi], L"--zst-ofs"))
                 {
                     nextZstdOffs = true;
@@ -1453,6 +1489,10 @@ static int demoRun(void *demoCtx)
                 {
                     ssm = true;
                 }
+                else if (0 == wcscmp(argv[argi], L"--warmup"))
+                {
+                    warmup = true;
+                }
                 else
                 {
                     debugPrint(L"Unknown argv[%d] %s\n", argi, argv[argi]);
@@ -1462,7 +1502,7 @@ static int demoRun(void *demoCtx)
             if (1 == argc || badArg)
             {
                 debugPrint(L"USAGE:\n");
-                debugPrint(L"\t--zst <path | @listfile>  [Required] Path to a .zst file (absolute or relative). If prefixed with '@', the value is a text file listing .zst paths (one per line, '#' comments allowed) loaded concatenated into one buffer.\n");
+                debugPrint(L"\t--zst <path | @listfile>  [Required] Path to a .zst file (absolute or relative). If prefixed with '@', the value is a text file listing .zst paths (one per line, '#' comments allowed) that are loaded and concatenated, in order, into one buffer.\n");
                 debugPrint(L"\t--chk-gpu                 [Optional] After running decompresssion on GPU, validates its outputs against the outputs from reference decompressor.\n");
                 debugPrint(L"\t--chk-cpu                 [Optional] Before running decompression on GPU, runs GPU decompressor code on CPU and validates its outputs against the outputs from reference decompressor.\n");
                 debugPrint(L"\t--sim-gpu                 [Optional] After running decompression on GPU, runs key GPU decompressor stages on CPU using intermediate inputs from GPU decompression and validates its outputs against the outputs from reference decompressor.\n");
@@ -1477,10 +1517,12 @@ static int demoRun(void *demoCtx)
                 debugPrint(L"\t--seq-cnt                 [Optional] Also uses SetupBlockInfoConstants (implies --blk-cnt). Merges all stages into single submission.\n");
                 debugPrint(L"\t--prf-lvl <0, 1, 2>       [Optional] Chooses the level of profiling: 0 - overall bandwidth in GB/s, 1 - stage cost, 2 - internal pass cost.\n");
                 debugPrint(L"\t--idx-{min,max} <number>  [Optional] Chooses the {minimal, maximal} index of the frame to decompress in multi-frame .zst file. Both values are clamped to the number of available frames.\n");
+                debugPrint(L"\t--frame-batch-count <n>   [Optional] Tiles the working set into batches of <n> frames each (one batch per GPU dispatch); the whole set is decoded batch by batch. Default: one batch covering all frames. Latency/bandwidth are reported per batch, plus a pooled total (P50 latency / median bandwidth across the batches, excluding a partial final batch).\n");
                 debugPrint(L"\t--zst-ofs <byte count>    [Optional] When loading .zst file is appended to a buffer with <byte count> bytes. (Useful for testing large buffer sizes)  \n");
                 debugPrint(L"\t--out-frm                 [Optional] Outputs decompressed frames to files with <source_name.frame_N> name.\n");
                 debugPrint(L"\t--out-csv <path to .csv>  [Optional] Outputs performance information into CSV file.\n");
                 debugPrint(L"\t--ssm                     [Optional] Forces single-submission mode with automatic scratch estimation.\n");
+                debugPrint(L"\t--warmup                  [Optional] Runs a fixed warmup period (~10s) before measuring; warmup runs are excluded from the [PERF] stdout statistics.\n");
                 if (badArg)
                 {
                     ctx->retv = 1;
@@ -1538,22 +1580,15 @@ static int demoRun(void *demoCtx)
 
     const uint32_t endFrame = fbInfo.frameCount - 1;
 
-    // NOTE(pamartis): Support the option to choose a range of frame in the input package/data
-    if (minFrame > 0 || maxFrame < endFrame)
-    {
-        maxFrame = maxFrame < endFrame
-                 ? maxFrame : endFrame;
-        minFrame = minFrame < maxFrame
-                 ? minFrame : maxFrame;
-
-        zstdOffs += zstdInFrameRefs[minFrame].offs;
-        zstdDataSize = zstdInFrameRefs[maxFrame].offs - zstdInFrameRefs[minFrame].offs + zstdInFrameRefs[maxFrame].size;
-        zstdCompressedFramesMemorySizeInBytes = zstdgpu_AlignUp(zstdOffs + zstdDataSize, 4);
-
-        // NOTE(pamartis): update all structures because 'zstdOffs' has changed
-        zstdgpu_CountFramesAndBlocks(&fbInfo, (char *)zstdData + zstdOffs, zstdCompressedFramesMemorySizeInBytes - zstdOffs, zstdDataSize);
-        zstdgpu_CollectFrames(zstdInFrameRefs, zstdFrameInfo, fbInfo.frameCount, (char *)zstdData + zstdOffs, zstdCompressedFramesMemorySizeInBytes - zstdOffs, zstdDataSize);
-    }
+    // NOTE: Clamp the requested frame range [minFrame, maxFrame] to the frames
+    // actually present. Unlike the previous implementation we do NOT rebase
+    // 'zstdOffs' onto the first selected frame: that produced an unaligned scan
+    // base and tripped the GPU bit-buffer 4-byte alignment assertion for any
+    // sub-range not starting at frame 0. Instead the whole buffer is scanned once
+    // (global refs below) and the selected range is decoded batch by batch, with
+    // each batch staged into an aligned offset-0 buffer at dispatch time.
+    maxFrame = (maxFrame < endFrame) ? maxFrame : endFrame;
+    minFrame = (minFrame < maxFrame) ? minFrame : maxFrame;
 
     for (uint32_t i = 0; i < fbInfo.frameCount; ++i)
     {
@@ -1586,6 +1621,73 @@ static int demoRun(void *demoCtx)
             return 0;
         }
     }
+
+    // ---------------------------------------------------------------------------
+    // Batching setup.
+    //
+    // The working set is the clamped frame range [minFrame, maxFrame] over the
+    // concatenated input set buffer. It is decoded in batches of 'frameBatchCount'
+    // frames at a time.
+    // ---------------------------------------------------------------------------
+    const uint32_t workingLo    = minFrame;
+    const uint32_t workingHi    = maxFrame;
+    const uint32_t workingFrames = workingHi - workingLo + 1;
+    const uint32_t effBatchFrames = (frameBatchCount == 0 || frameBatchCount > workingFrames)
+                                  ? workingFrames : frameBatchCount;
+    const uint32_t numBatches   = (workingFrames + effBatchFrames - 1) / effBatchFrames;
+
+    // Check if the batch covers the entire compressed input set. If so, then we can eliminate a copy.
+    const bool isWholeBufferRun = (workingLo == 0 && workingHi == endFrame && numBatches == 1);
+
+    // Raw (unpadded) decompressed offset of each global frame inside the
+    // reference buffer built by ZSTD_decompress over the whole input.
+    uint32_t *rawRefPrefix = (uint32_t *)malloc(sizeof(uint32_t) * (fbInfo.frameCount + 1));
+    {
+        uint32_t acc = 0;
+        for (uint32_t i = 0; i < fbInfo.frameCount; ++i)
+        {
+            rawRefPrefix[i] = acc;
+            acc += zstdOutFrameRefs[i].size;
+        }
+        rawRefPrefix[fbInfo.frameCount] = acc;
+    }
+
+    // Largest batch dimensions (used to size reusable resources once).
+    uint32_t maxBatchFrames      = 0;
+    uint32_t maxBatchSpanAligned = 0;
+    uint32_t maxBatchDecompBytes = 0;
+    for (uint32_t b = 0; b < numBatches; ++b)
+    {
+        const uint32_t bLo = workingLo + b * effBatchFrames;
+        uint32_t       bHi = bLo + effBatchFrames - 1;
+        if (bHi > workingHi) bHi = workingHi;
+
+        const uint32_t frames    = bHi - bLo + 1;
+        const uint32_t byteStart = zstdInFrameRefs[bLo].offs;
+        const uint32_t byteEnd   = zstdInFrameRefs[bHi].offs + zstdInFrameRefs[bHi].size;
+        const uint32_t spanAlign = zstdgpu_AlignUp(byteEnd - byteStart, 4);
+
+        uint32_t decomp = 0;
+        for (uint32_t i = bLo; i <= bHi; ++i)
+        {
+            decomp += zstdOutFrameRefs[i].size;
+            decomp  = zstdgpu_AlignUp(decomp, 256);
+        }
+
+        if (frames    > maxBatchFrames)      maxBatchFrames      = frames;
+        if (spanAlign > maxBatchSpanAligned) maxBatchSpanAligned = spanAlign;
+        if (decomp    > maxBatchDecompBytes) maxBatchDecompBytes = decomp;
+    }
+
+    // Reusable per-batch host buffers (sized to the largest batch). The staging
+    // buffer is unused for the in-place whole-buffer run.
+    char                  *batchStaging   = isWholeBufferRun ? NULL : (char *)malloc(maxBatchSpanAligned);
+    zstdgpu_OffsetAndSize *batchInRefs    = (zstdgpu_OffsetAndSize *)malloc(sizeof(zstdgpu_OffsetAndSize) * maxBatchFrames);
+    zstdgpu_OffsetAndSize *batchOutRefs   = (zstdgpu_OffsetAndSize *)malloc(sizeof(zstdgpu_OffsetAndSize) * maxBatchFrames);
+    zstdgpu_FrameInfo     *batchFrameInfo = (zstdgpu_FrameInfo *)malloc(sizeof(zstdgpu_FrameInfo) * maxBatchFrames);
+
+    debugPrint(L"[INFO] Working set: frames [%u..%u] (%u frames), %u batch(es) of up to %u frames each.\n",
+               workingLo, workingHi, workingFrames, numBatches, effBatchFrames);
 
     static const uint32_t kBackBufferCount = 2;
 #ifdef _GAMING_XBOX
@@ -1686,8 +1788,16 @@ static int demoRun(void *demoCtx)
     const uint32_t zstdFramesRefsSizeInBytes = sizeof(zstdgpu_OffsetAndSize) * fbInfo.frameCount;
 
     void* defaultUploadCallbackUserData[2];
+
+    // The reusable output-refs upload buffer carries one extra slot so a batch
+    // that exactly fills it still leaves the MappedBuffer append cursor in the
+    // resettable (CopyBufferRegion) path, so it can be re-appended next dispatch.
+    const uint32_t maxRefsSizeInBytes = sizeof(zstdgpu_OffsetAndSize) * (maxBatchFrames + 1);
+
     if (testSourceInGpuMemory > 0)
     {
+        // Experimental external-GPU-memory path (not exercised by default and not
+        // batched): it decodes the whole working set as a single dispatch.
         d3d12aid_MappedBuffer_Create(&zstdCompressedFramesMemory, device, 1u, zstdCompressedFramesMemorySizeInBytes, D3D12_HEAP_TYPE_UPLOAD);
         d3d12aid_MappedBuffer_Create(&zstdCompressedFramesRefs, device, 1u, zstdFramesRefsSizeInBytes, D3D12_HEAP_TYPE_UPLOAD);
         d3d12aid_MappedBuffer_Create(&zstdUnCompressedFramesRefs, device, 1u, zstdFramesRefsSizeInBytes, D3D12_HEAP_TYPE_UPLOAD);
@@ -1698,63 +1808,152 @@ static int demoRun(void *demoCtx)
         d3d12aid_MappedBuffer_Append(&zstdUnCompressedFramesRefs, 0, (void *)zstdOutFrameRefs, zstdFramesRefsSizeInBytes);
 
         zstdgpu_SetupInputsAsFramesInGpuMemory(&stageCount, perRequestContext, zstdCompressedFramesMemory.bufGpu, zstdCompressedFramesMemorySizeInBytes, zstdCompressedFramesRefs.bufGpu, fbInfo.frameCount);
+
+        if (ssm)
+        {
+            zstdgpu_SetupAllStageSubmission(perRequestContext);
+        }
+        if (blkCnt)
+        {
+            zstdgpu_SetupFrameInfoConstants(perRequestContext, fbInfo.rawBlockCount, fbInfo.rleBlockCount, fbInfo.cmpBlockCount);
+            if (seqCnt)
+            {
+                zstdgpu_CountLiteralAndSequenceInfo blkInfo;
+                zstdgpu_CountCompressedLiteralsAndSequences(&blkInfo, zstdInFrameRefs, fbInfo.frameCount, zstdData, zstdCompressedFramesMemorySizeInBytes);
+                zstdgpu_SetupBlockInfoConstants(perRequestContext, blkInfo.decodedLiteralsByteCount, blkInfo.sequenceCount);
+            }
+        }
+        zstdgpu_SetupOutputs(perRequestContext, zstdUnCompressedFramesMemory.bufGpu, zstdUnCompressedFramesMemorySizeInBytes, zstdUnCompressedFramesRefs.bufGpu, fbInfo.frameCount);
     }
     else
     {
-        d3d12aid_MappedBuffer_Create(&zstdUnCompressedFramesRefs, device, 1u, zstdFramesRefsSizeInBytes, D3D12_HEAP_TYPE_UPLOAD);
-        d3d12aid_MappedBuffer_Create(&zstdUnCompressedFramesMemory, device, 1, zstdUnCompressedFramesMemorySizeInBytes, D3D12_HEAP_TYPE_READBACK);
-
-        d3d12aid_MappedBuffer_Append(&zstdUnCompressedFramesRefs, 0, (void *)zstdOutFrameRefs, zstdFramesRefsSizeInBytes);
-
-        defaultUploadCallbackUserData[0] = (void *)zstdData;
-        defaultUploadCallbackUserData[1] = (void *)zstdInFrameRefs;
-        zstdgpu_SetupInputsAsFramesInCpuMemory(&stageCount, perRequestContext, fbInfo.frameCount, zstdOffs + zstdDataSize, zstdgpu_DefaultUploadCallback, defaultUploadCallbackUserData);
+        // Default CPU-memory path (batched). The per-batch input, refs, block
+        // constants and outputs are (re)configured inside the perf loop below; here
+        // we only create the reusable GPU-side resources sized to the largest batch.
+        d3d12aid_MappedBuffer_Create(&zstdUnCompressedFramesRefs, device, 1u, maxRefsSizeInBytes, D3D12_HEAP_TYPE_UPLOAD);
+        d3d12aid_MappedBuffer_Create(&zstdUnCompressedFramesMemory, device, 1, maxBatchDecompBytes, D3D12_HEAP_TYPE_READBACK);
     }
-    if (ssm)
-    {
-        zstdgpu_SetupAllStageSubmission(perRequestContext);
-    }
-    if (blkCnt)
-    {
-        /**
-         *  NOTE(pamartis):
-         *  Depending on whether `zstdgpu_SetupAllStageSubmission` was called or not,
-         *  calling `zstdgpu_SetupFrameInfoConstants` / `zstdgpu_SetupBlockInfoConstants`
-         *  either:
-         *
-         *  - improves scratch memory estimation (`zstdgpu_SetupAllStageSubmission` was called)
-         *
-         *  - enables elimination of mandatory wait for completion on GPU of the command list
-         *    populated with commands for the previous stage (if `zstdgpu_SetupAllStageSubmission` was NOT called)
-         */
-        zstdgpu_SetupFrameInfoConstants(perRequestContext, fbInfo.rawBlockCount, fbInfo.rleBlockCount, fbInfo.cmpBlockCount);
-        if (seqCnt)
-        {
-            zstdgpu_CountLiteralAndSequenceInfo blkInfo;
-            zstdgpu_CountCompressedLiteralsAndSequences(&blkInfo, zstdInFrameRefs, fbInfo.frameCount, zstdData, zstdCompressedFramesMemorySizeInBytes);
-            zstdgpu_SetupBlockInfoConstants(perRequestContext, blkInfo.decodedLiteralsByteCount, blkInfo.sequenceCount);
-        }
-    }
-    zstdgpu_SetupOutputs(perRequestContext, zstdUnCompressedFramesMemory.bufGpu, zstdUnCompressedFramesMemorySizeInBytes, zstdUnCompressedFramesRefs.bufGpu, fbInfo.frameCount);
 
     uint64_t readbackHeapSize[3] = { 0, 0, 0 };
     uint64_t uploadHeapSize[3] = {0, 0, 0 };
     uint64_t defaultHeapSize[3] = {0, 0, 0};
     uint32_t descriptorCount[3] = { 0, 0, 0 };
 
-    for (uint32_t frameIndex = 0; frameIndex < repCount; ++frameIndex)
+    // Aggregate perf metrics. Latency/bandwidth are sampled per batch.
+    // --run-cnt is the number of times the full content is decoded.
+    // Report P50 latency + median bandwidth per batch and across the pool
+    // Warmup time is excluded from statistics.
+    const uint64_t kWarmupDurationMs = 10000; // ~10s; may be tuned in the future.
+    const bool     warmupEnabled     = warmup;
+    const uint64_t warmupStartMs     = GetTickCount64();
+    const uint32_t measuredCap       = repCount ? repCount : 1;
+    double        *perBatchUs        = (double *)malloc(sizeof(double) * (size_t)numBatches * measuredCap);
+    double        *perBatchBw        = (double *)malloc(sizeof(double) * (size_t)numBatches * measuredCap);
+    uint32_t      *perBatchFrames    = (uint32_t *)malloc(sizeof(uint32_t) * numBatches);
+    uint32_t      *perBatchBytes     = (uint32_t *)malloc(sizeof(uint32_t) * numBatches);
+    uint32_t       measuredSweeps    = 0;
+    uint32_t       warmupSweeps      = 0;
+    uint32_t       dispatchIdx       = 0;
+
+    for (uint32_t sweep = 0; measuredSweeps < repCount; ++sweep)
     {
-        if (zstdgpu_Demo_PlatformTick())
+        const bool inWarmup   = warmupEnabled && ((GetTickCount64() - warmupStartMs) < kWarmupDurationMs);
+        bool       windowOpen = true;
+
+        for (uint32_t b = 0; b < numBatches; ++b)
         {
+            const uint32_t bLo = workingLo + b * effBatchFrames;
+            uint32_t       bHi = bLo + effBatchFrames - 1;
+            if (bHi > workingHi) bHi = workingHi;
+
+            // Cleanup state between dispatches
+            if (dispatchIdx > 0)
+            {
+                void *ctxMem = NULL;
+                zstdgpu_DestroyPerRequestContext(&ctxMem, NULL, perRequestContext);
+                ZSTDGPU_ENUM(Status) reinit = zstdgpu_CreatePerRequestContext(&perRequestContext, persistentContext, ctxMem, zstdgpu_GetPerRequestContextRequiredMemorySizeInBytes());
+                ZSTDGPU_ASSERT(ZSTDGPU_ENUM_CONST(StatusSuccess) == reinit);
+            }
+
+            // ---- Per-batch setup ----------------------------------------------
+            // Stage the batch's compressed bytes into an aligned offset-0 buffer,
+            // rescan it (offset-0 refs + per-batch block counts), (re)compute the
+            // output refs and (re)wire the library inputs/outputs/constants. The
+            // whole-buffer single-batch case decodes zstdData in place so the deep
+            // --chk-gpu reference store (keyed by global indices) stays valid.
+            const uint32_t byteStart   = zstdInFrameRefs[bLo].offs;
+            const uint32_t byteEnd     = zstdInFrameRefs[bHi].offs + zstdInFrameRefs[bHi].size;
+            const uint32_t batchSpan   = byteEnd - byteStart;
+            const uint32_t batchSpanAl = zstdgpu_AlignUp(batchSpan, 4);
+
+            char *stagedPtr;
+            if (isWholeBufferRun)
+            {
+                stagedPtr = (char *)zstdData + byteStart;
+            }
+            else
+            {
+                memcpy(batchStaging, (char *)zstdData + byteStart, batchSpan);
+                if (batchSpanAl > batchSpan)
+                    memset(batchStaging + batchSpan, 0, batchSpanAl - batchSpan);
+                stagedPtr = batchStaging;
+            }
+
+            zstdgpu_CountFramesAndBlocks(&fbInfo, stagedPtr, batchSpanAl, batchSpan);
+            zstdgpu_CollectFrames(batchInRefs, batchFrameInfo, fbInfo.frameCount, stagedPtr, batchSpanAl, batchSpan);
+
+            {
+                uint32_t offs = 0;
+                for (uint32_t j = 0; j < fbInfo.frameCount; ++j)
+                {
+                    batchOutRefs[j].offs = offs;
+                    batchOutRefs[j].size = (uint32_t)batchFrameInfo[j].uncompSize;
+                    offs += batchOutRefs[j].size;
+                    offs  = zstdgpu_AlignUp(offs, 256);
+                }
+                zstdUnCompressedFramesMemorySizeInBytes = offs;
+            }
+            zstdCompressedFramesMemorySizeInBytes = batchSpanAl;
+
+            d3d12aid_MappedBuffer_Append(&zstdUnCompressedFramesRefs, 0, (void *)batchOutRefs, sizeof(zstdgpu_OffsetAndSize) * fbInfo.frameCount);
+
+            defaultUploadCallbackUserData[0] = (void *)stagedPtr;
+            defaultUploadCallbackUserData[1] = (void *)batchInRefs;
+            zstdgpu_SetupInputsAsFramesInCpuMemory(&stageCount, perRequestContext, fbInfo.frameCount, batchSpanAl, zstdgpu_DefaultUploadCallback, defaultUploadCallbackUserData);
+            if (ssm)
+            {
+                zstdgpu_SetupAllStageSubmission(perRequestContext);
+            }
+            if (blkCnt)
+            {
+                zstdgpu_SetupFrameInfoConstants(perRequestContext, fbInfo.rawBlockCount, fbInfo.rleBlockCount, fbInfo.cmpBlockCount);
+                if (seqCnt)
+                {
+                    zstdgpu_CountLiteralAndSequenceInfo blkInfo;
+                    zstdgpu_CountCompressedLiteralsAndSequences(&blkInfo, batchInRefs, fbInfo.frameCount, stagedPtr, batchSpanAl);
+                    zstdgpu_SetupBlockInfoConstants(perRequestContext, blkInfo.decodedLiteralsByteCount, blkInfo.sequenceCount);
+                }
+            }
+            zstdgpu_SetupOutputs(perRequestContext, zstdUnCompressedFramesMemory.bufGpu, zstdUnCompressedFramesMemorySizeInBytes, zstdUnCompressedFramesRefs.bufGpu, fbInfo.frameCount);
+
+            perBatchFrames[b] = fbInfo.frameCount;
+            perBatchBytes[b]  = zstdUnCompressedFramesMemorySizeInBytes;
+
+            if (!zstdgpu_Demo_PlatformTick())
+            {
+                windowOpen = false;
+                break;
+            }
+
             // Main sample loop
-            PIXBeginEvent(PIX_COLOR_DEFAULT, L"Frame %llu", frameIndex);
+            PIXBeginEvent(PIX_COLOR_DEFAULT, L"Sweep %u Batch %u", sweep, b);
 
 #ifdef _GAMING_XBOX
             D3D12XBOX_FRAME_PIPELINE_TOKEN frameOriginToken = D3D12XBOX_FRAME_PIPELINE_TOKEN_NULL;
             D3D12AID_CHECK(device->WaitFrameEventX(D3D12XBOX_FRAME_EVENT_ORIGIN, INFINITE, NULL, D3D12XBOX_WAIT_FRAME_EVENT_FLAG_NONE, &frameOriginToken));
 #endif
-            // Prepare the command list to render a new frame.
-            const uint32_t kBackBufferIndex = frameIndex % kBackBufferCount;
+            // Prepare the command list to record this batch's decode dispatch.
+            const uint32_t kBackBufferIndex = dispatchIdx % kBackBufferCount;
 
             #define ZSTDGPU_TS(name) uint32_t name##_Stamp = ~0u;
                 ZSTDGPU_TS_LIST()
@@ -1763,22 +1962,30 @@ static int demoRun(void *demoCtx)
 
             ID3D12GraphicsCommandList *cmdList = d3d12aid_CmdQueue_StartCmdList(&cmdQueue, 0 /** cmdListId */);
 
-            if (frameIndex == 0)
             {
-                if (testSourceInGpuMemory > 0)
+                // The GPU-side compressed inputs (experimental path) are static and
+                // uploaded once. The per-batch output refs change every dispatch, so
+                // they are re-homed each time: transition the destination back to
+                // COPY_DEST first (the previous dispatch's EndTransfer left it in the
+                // shader-read state), copy, then transition to the shader-read state.
+                D3D12_RESOURCE_BARRIER barriers[3];
+                uint32_t bufferCount = 0;
+
+                if (testSourceInGpuMemory > 0 && dispatchIdx == 0)
                 {
                     d3d12aid_MappedBuffer_Transfer(cmdList, &zstdCompressedFramesMemory, 0);
                     d3d12aid_MappedBuffer_Transfer(cmdList, &zstdCompressedFramesRefs, 0);
-                }
-                d3d12aid_MappedBuffer_Transfer(cmdList, &zstdUnCompressedFramesRefs, 0);
-
-                D3D12_RESOURCE_BARRIER barriers[3];
-                uint32_t bufferCount = 0;
-                if (testSourceInGpuMemory > 0)
-                {
                     d3d12aid_MappedBuffer_EndTransfer(&barriers[bufferCount ++], &zstdCompressedFramesMemory, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
                     d3d12aid_MappedBuffer_EndTransfer(&barriers[bufferCount ++], &zstdCompressedFramesRefs, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
                 }
+
+                if (dispatchIdx > 0)
+                {
+                    D3D12_RESOURCE_BARRIER toCopyDest;
+                    d3d12aid_Resource_TransitionBarrier(&toCopyDest, zstdUnCompressedFramesRefs.bufGpu, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COPY_DEST);
+                    cmdList->ResourceBarrier(1u, &toCopyDest);
+                }
+                d3d12aid_MappedBuffer_Transfer(cmdList, &zstdUnCompressedFramesRefs, 0);
                 d3d12aid_MappedBuffer_EndTransfer(&barriers[bufferCount ++], &zstdUnCompressedFramesRefs, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
 
                 cmdList->ResourceBarrier(bufferCount, barriers);
@@ -1888,7 +2095,7 @@ static int demoRun(void *demoCtx)
                     d3d12aid_MappedBuffer_Transfer(cmdList, &zstdUnCompressedFramesMemory, 0 /** works only when submissions aren't overlapped*/);
                 }
                 zstdgpu_ReadbackTimestamps(perRequestContext, cmdList);
-                if (simGpu || chkGpu)
+                if ((simGpu || chkGpu) && sweep == 0)
                 {
                     zstdgpu_ReadbackGpuResults(perRequestContext, cmdList);
                 }
@@ -1896,83 +2103,96 @@ static int demoRun(void *demoCtx)
                 d3d12aid_CmdQueue_SubmitCmdList(&cmdQueue, 0);
                 d3d12aid_CmdQueue_CpuWaitForGpuIdle(&cmdQueue);
 
-                if (simGpu || chkGpu)
+                if ((simGpu || chkGpu) && sweep == 0)
                 {
                     zstdgpu_ResourceDataCpu gpuData;
                     zstdgpu_RetrieveGpuResults(&gpuData, perRequestContext);
 
-                    if (chkGpu)
+                    // Deep per-stage checks compare GPU intermediates against the
+                    // whole-buffer reference store (zstdCpu / ReferenceStore), which
+                    // is keyed by global block indices. They are only valid when a
+                    // single batch decodes the entire input; per-batch decodes are
+                    // validated by the final decompressed-frame comparison below.
+                    if (isWholeBufferRun)
                     {
-                        zstdgpu_ReferenceStore_Validate_CompressedBlocksData(&gpuData);
+                        if (chkGpu)
+                        {
+                            zstdgpu_ReferenceStore_Validate_CompressedBlocksData(&gpuData);
+                        }
+
+                        zstdgpu_Test_DecompressHuffmanWeights(zstdCpu, gpuData, zstdCompressedFramesMemorySizeInBytes, chkGpu, simGpu);
+                        zstdgpu_Test_DecompressLiterals(zstdCpu, gpuData, zstdCompressedFramesMemorySizeInBytes, chkGpu, simGpu);
+                        zstdgpu_Test_DecompressSequences(zstdCpu, gpuData, zstdCompressedFramesMemorySizeInBytes, chkGpu, simGpu);
+
+                        if (chkCpu && chkGpu)
+                            zstdgpu_Test_BlockPrefix(zstdCpu, gpuData);
                     }
-
-                    zstdgpu_Test_DecompressHuffmanWeights(zstdCpu, gpuData, zstdCompressedFramesMemorySizeInBytes, chkGpu, simGpu);
-                    zstdgpu_Test_DecompressLiterals(zstdCpu, gpuData, zstdCompressedFramesMemorySizeInBytes, chkGpu, simGpu);
-                    zstdgpu_Test_DecompressSequences(zstdCpu, gpuData, zstdCompressedFramesMemorySizeInBytes, chkGpu, simGpu);
-
-                    if (chkCpu && chkGpu)
-                        zstdgpu_Test_BlockPrefix(zstdCpu, gpuData);
 
                     if (chkGpu)
                     {
                         uint32_t failedFrameCount = 0;
 
                         {
-                            const char *ref = (char*)zstdReferenceUncompressedData;
+                            // Slice the whole-input reference buffer at this batch's
+                            // first global frame; the batch output is offset-0.
+                            const char *ref = (char*)zstdReferenceUncompressedData + rawRefPrefix[bLo];
                             const char *tst = (char*)zstdUnCompressedFramesMemory.bufMem[0];
                             for (uint32_t i = 0; i < fbInfo.frameCount; ++i)
                             {
-                                failedFrameCount += (0 != memcmp(ref, tst + zstdOutFrameRefs[i].offs, zstdOutFrameRefs[i].size));
+                                failedFrameCount += (0 != memcmp(ref, tst + batchOutRefs[i].offs, batchOutRefs[i].size));
 
-                                ref += zstdOutFrameRefs[i].size;
+                                ref += batchOutRefs[i].size;
                             }
                         }
 
                         if (failedFrameCount > 0)
                         {
-                            const char *ref = (char*)zstdReferenceUncompressedData;
-                            const char *tst = (char*)zstdUnCompressedFramesMemory.bufMem[0];
+                            debugPrint(L"[FAIL] %u/%u frames failed validation (sweep %u, batch %u, global frames [%u..%u]).\n", failedFrameCount, fbInfo.frameCount, sweep, b, bLo, bHi);
 
-                            debugPrint(L"[FAIL] %u/%u frames failed validation.\n", failedFrameCount, fbInfo.frameCount);
+                            if (isWholeBufferRun)
+                            {
+                                const char *ref = (char*)zstdReferenceUncompressedData;
+                                const char *tst = (char*)zstdUnCompressedFramesMemory.bufMem[0];
 
-                            const uint32_t failedRawBlockCount = zstdgpu_Test_DecompressedDataPerBlockType(
-                                gpuData.GlobalBlockIndexPerRawBlock,
-                                fbInfo.rawBlockCount,
-                                gpuData.PerFrameBlockCountAll,
-                                zstdOutFrameRefs,
-                                fbInfo.frameCount,
-                                gpuData.BlockSizePrefix,
-                                ref,
-                                tst
-                            );
+                                const uint32_t failedRawBlockCount = zstdgpu_Test_DecompressedDataPerBlockType(
+                                    gpuData.GlobalBlockIndexPerRawBlock,
+                                    fbInfo.rawBlockCount,
+                                    gpuData.PerFrameBlockCountAll,
+                                    batchOutRefs,
+                                    fbInfo.frameCount,
+                                    gpuData.BlockSizePrefix,
+                                    ref,
+                                    tst
+                                );
 
-                            const uint32_t failedRleBlockCount = zstdgpu_Test_DecompressedDataPerBlockType(
-                                gpuData.GlobalBlockIndexPerRleBlock,
-                                fbInfo.rleBlockCount,
-                                gpuData.PerFrameBlockCountAll,
-                                zstdOutFrameRefs,
-                                fbInfo.frameCount,
-                                gpuData.BlockSizePrefix,
-                                ref,
-                                tst
-                            );
+                                const uint32_t failedRleBlockCount = zstdgpu_Test_DecompressedDataPerBlockType(
+                                    gpuData.GlobalBlockIndexPerRleBlock,
+                                    fbInfo.rleBlockCount,
+                                    gpuData.PerFrameBlockCountAll,
+                                    batchOutRefs,
+                                    fbInfo.frameCount,
+                                    gpuData.BlockSizePrefix,
+                                    ref,
+                                    tst
+                                );
 
-                            const uint32_t failedCmpBlockCount = zstdgpu_Test_DecompressedDataPerBlockType(
-                                gpuData.GlobalBlockIndexPerCmpBlock,
-                                fbInfo.cmpBlockCount,
-                                gpuData.PerFrameBlockCountAll,
-                                zstdOutFrameRefs,
-                                fbInfo.frameCount,
-                                gpuData.BlockSizePrefix,
-                                ref,
-                                tst
-                            );
+                                const uint32_t failedCmpBlockCount = zstdgpu_Test_DecompressedDataPerBlockType(
+                                    gpuData.GlobalBlockIndexPerCmpBlock,
+                                    fbInfo.cmpBlockCount,
+                                    gpuData.PerFrameBlockCountAll,
+                                    batchOutRefs,
+                                    fbInfo.frameCount,
+                                    gpuData.BlockSizePrefix,
+                                    ref,
+                                    tst
+                                );
 
-                            if (failedRawBlockCount > 0 || failedRleBlockCount > 0)
-                                debugPrint(L"[FAIL] %u/%u RAW blocks and %u/%u RLE blocks failed validation. Likely MemCpy/MemSet pass is broken, unless ExecuteSequence stomps the memory written by MemCpu/MemSet.\n", failedRawBlockCount, fbInfo.rawBlockCount, failedRleBlockCount, fbInfo.rleBlockCount);
+                                if (failedRawBlockCount > 0 || failedRleBlockCount > 0)
+                                    debugPrint(L"[FAIL] %u/%u RAW blocks and %u/%u RLE blocks failed validation. Likely MemCpy/MemSet pass is broken, unless ExecuteSequence stomps the memory written by MemCpu/MemSet.\n", failedRawBlockCount, fbInfo.rawBlockCount, failedRleBlockCount, fbInfo.rleBlockCount);
 
-                            if (failedCmpBlockCount > 0)
-                                debugPrint(L"[FAIL] %u/%u CMP blocks failed validation. ExecuteSequences is likely broken unless an issue happens earlier in the pipeline or unless TDR is hit.\n", failedCmpBlockCount, fbInfo.cmpBlockCount);
+                                if (failedCmpBlockCount > 0)
+                                    debugPrint(L"[FAIL] %u/%u CMP blocks failed validation. ExecuteSequences is likely broken unless an issue happens earlier in the pipeline or unless TDR is hit.\n", failedCmpBlockCount, fbInfo.cmpBlockCount);
+                            }
 
                             ctx->retv = 1;
                             return 0;
@@ -1980,14 +2200,14 @@ static int demoRun(void *demoCtx)
                     }
                 }
 
-                if (frameIndex == 0 && outFrm /** output decompressed frame data to files if requested via command line */)
+                if (sweep == 0 && outFrm /** output decompressed frame data to files if requested via command line */)
                 {
-                    const int bufferSize = ZSTDGPU_WARN_DISABLE_MSVC(4996, _snwprintf(NULL, 0, L"%s.frame_%u", zstFilePath, fbInfo.frameCount) + 1);
+                    const int bufferSize = ZSTDGPU_WARN_DISABLE_MSVC(4996, _snwprintf(NULL, 0, L"%s.frame_%u", zstFilePath, workingHi) + 1);
                     wchar_t *buffer = (wchar_t *)malloc(bufferSize * sizeof(wchar_t));
                     for (uint32_t i = 0; i < fbInfo.frameCount; ++i)
                     {
-                        ZSTDGPU_WARN_DISABLE_MSVC(4996, _snwprintf(buffer, bufferSize, L"%s.frame_%u", zstFilePath, i));
-                        saveFile(buffer, (char*)zstdUnCompressedFramesMemory.bufMem[0] + zstdOutFrameRefs[i].offs, zstdOutFrameRefs[i].size);
+                        ZSTDGPU_WARN_DISABLE_MSVC(4996, _snwprintf(buffer, bufferSize, L"%s.frame_%u", zstFilePath, bLo + i));
+                        saveFile(buffer, (char*)zstdUnCompressedFramesMemory.bufMem[0] + batchOutRefs[i].offs, batchOutRefs[i].size);
                     }
                     free(buffer);
                 }
@@ -2002,6 +2222,9 @@ static int demoRun(void *demoCtx)
                 uint64_t clks = 0;
                 uint64_t clksAll = 0;
 
+                // Open the per-run CSV once, and only when --out-csv was given.
+                // Without --out-csv no CSV is created; the aggregate metrics go to
+                // stdout after the run loop instead.
                 if (NULL == csvFile)
                 {
                     if (NULL != csvFilePathStorage)
@@ -2011,11 +2234,13 @@ static int demoRun(void *demoCtx)
                         // at the location they requested.
                         _wfopen_s(&csvFile, csvFilePath, L"w");
                     }
+#ifdef _GAMING_XBOX
                     else
                     {
-                        // --out-csv was not specified; default csvFilePath is "perf.csv".
-                        // Append the .zst stem and a timestamp so repeated interactive runs
-                        // don't clobber each other.
+                        // On Xbox there is no command-line to pass --out-csv, so keep
+                        // the demo's perf output by auto-naming the CSV.
+                        // Default csvFilePath is "perf.csv"; append the .zst stem and a
+                        // timestamp so repeated interactive runs don't clobber each other.
 
                         // find the start of .zst file name (to further add into .csv name)
                         const wchar_t *zstNameStart = wcsrchr(zstFilePath, L'\\');
@@ -2053,99 +2278,119 @@ static int demoRun(void *demoCtx)
 
                         free(printBuf);
                     }
+#endif
                 }
 
-                if (NULL != csvFile)
-                {
-                    if (0 == frameIndex)
-                    {
-                        #define WRITE_CSV_HEADER(file, scopeName, subScopeCount, subScopeNames) \
-                            if (prfLevel > 0)                                                   \
-                            {                                                                   \
-                                fwprintf_s(file, L"%s (us),", scopeName);                       \
-                                if (prfLevel > 1)                                               \
-                                {                                                               \
-                                    for (uint32_t i = 0; i < subScopeCount; ++i)                \
-                                    {                                                           \
-                                        fwprintf_s(file, L"%s :: %s (us),", scopeName, subScopeNames[i]);\
-                                    }                                                           \
-                                }                                                               \
-                            }
-                        // write the header together with the first frame
-                        fwprintf_s(csvFile, L"RunIdx,");
-
-                        timestampScopeCount = _countof(timestampScopeClocks);
-                        zstdgpu_RetrieveTimestamps(timestampScopeNames, timestampScopeClocks, &timestampScopeCount, perRequestContext, 0);
-                        WRITE_CSV_HEADER(csvFile, L"Stage 0", timestampScopeCount, timestampScopeNames);
-                        if (Readback0_Stamp != ~0u)
-                        {
-                            WRITE_CSV_HEADER(csvFile, L"Readback 0", 0, timestampScopeNames);
-                        }
-
-                        timestampScopeCount = _countof(timestampScopeClocks);
-                        zstdgpu_RetrieveTimestamps(timestampScopeNames, timestampScopeClocks, &timestampScopeCount, perRequestContext, 1);
-                        WRITE_CSV_HEADER(csvFile, L"Stage 1", timestampScopeCount, timestampScopeNames);
-                        if (Readback1_Stamp != ~0u)
-                        {
-                            WRITE_CSV_HEADER(csvFile, L"Readback 1", 0, timestampScopeNames);
-                        }
-
-                        timestampScopeCount = _countof(timestampScopeClocks);
-                        zstdgpu_RetrieveTimestamps(timestampScopeNames, timestampScopeClocks, &timestampScopeCount, perRequestContext, 2);
-                        WRITE_CSV_HEADER(csvFile, L"Stage 2", timestampScopeCount, timestampScopeNames);
-                        fwprintf_s(csvFile, L"Bandwidth (GB/s)\n");
-                        #undef WRITE_CSV_HEADER
-
-                        #define WRITE_CSV_DATA(file, scopeClks, subScopeCount, subScopeClks)    \
-                            if (prfLevel > 0)                                                   \
-                            {                                                                   \
-                                uint64_t usec = (scopeClks * 1000000) / freqGpuClocks;          \
-                                fwprintf_s(file, L"%llu,", usec);                               \
-                                if (prfLevel > 1)                                               \
-                                {                                                               \
-                                    for (uint32_t i = 0; i < subScopeCount; ++i)                \
-                                    {                                                           \
-                                        usec = (subScopeClks[i] * 1000000) / freqGpuClocks;     \
-                                        fwprintf_s(file, L"%llu,", usec);                       \
-                                    }                                                           \
-                                }                                                               \
-                            }
+                // Define the CSV helpers NULL-safe so they no-op when no CSV is
+                // active (they still require prf-lvl > 0 to emit stage columns).
+                #define WRITE_CSV_HEADER(file, scopeName, subScopeCount, subScopeNames) \
+                    if ((file) != NULL && prfLevel > 0)                                 \
+                    {                                                                   \
+                        fwprintf_s((file), L"%s (us),", scopeName);                     \
+                        if (prfLevel > 1)                                               \
+                        {                                                               \
+                            for (uint32_t i = 0; i < subScopeCount; ++i)                \
+                            {                                                           \
+                                fwprintf_s((file), L"%s :: %s (us),", scopeName, subScopeNames[i]);\
+                            }                                                           \
+                        }                                                               \
+                    }
+                #define WRITE_CSV_DATA(file, scopeClks, subScopeCount, subScopeClks)    \
+                    if ((file) != NULL && prfLevel > 0)                                 \
+                    {                                                                   \
+                        uint64_t usec = ((scopeClks) * 1000000) / freqGpuClocks;        \
+                        fwprintf_s((file), L"%llu,", usec);                             \
+                        if (prfLevel > 1)                                               \
+                        {                                                               \
+                            for (uint32_t i = 0; i < subScopeCount; ++i)                \
+                            {                                                           \
+                                usec = ((subScopeClks)[i] * 1000000) / freqGpuClocks;   \
+                                fwprintf_s((file), L"%llu,", usec);                     \
+                            }                                                           \
+                        }                                                               \
                     }
 
-                    fwprintf_s(csvFile, L"%u,", frameIndex);
+                // Write the CSV header once, alongside the first dispatch (CSV only).
+                if (NULL != csvFile && 0 == dispatchIdx)
+                {
+                    fwprintf_s(csvFile, L"RunIdx,");
 
                     timestampScopeCount = _countof(timestampScopeClocks);
-                    clks = zstdgpu_RetrieveTimestamps(timestampScopeNames, timestampScopeClocks, &timestampScopeCount, perRequestContext, 0);
-                    clksAll = clks;
-                    WRITE_CSV_DATA(csvFile, clks, timestampScopeCount, timestampScopeClocks);
+                    zstdgpu_RetrieveTimestamps(timestampScopeNames, timestampScopeClocks, &timestampScopeCount, perRequestContext, 0);
+                    WRITE_CSV_HEADER(csvFile, L"Stage 0", timestampScopeCount, timestampScopeNames);
                     if (Readback0_Stamp != ~0u)
                     {
-                        clks = d3d12aid_Timestamps_GetScopeDelta(&timestamps, kBackBufferIndex, Readback0_Stamp);
-                        clksAll += clks;
-                        WRITE_CSV_DATA(csvFile, clks, 0, timestampScopeClocks);
+                        WRITE_CSV_HEADER(csvFile, L"Readback 0", 0, timestampScopeNames);
                     }
 
                     timestampScopeCount = _countof(timestampScopeClocks);
-                    clks = zstdgpu_RetrieveTimestamps(timestampScopeNames, timestampScopeClocks, &timestampScopeCount, perRequestContext, 1);
-                    clksAll += clks;
-                    WRITE_CSV_DATA(csvFile, clks, timestampScopeCount, timestampScopeClocks);
+                    zstdgpu_RetrieveTimestamps(timestampScopeNames, timestampScopeClocks, &timestampScopeCount, perRequestContext, 1);
+                    WRITE_CSV_HEADER(csvFile, L"Stage 1", timestampScopeCount, timestampScopeNames);
                     if (Readback1_Stamp != ~0u)
                     {
-                        clks = d3d12aid_Timestamps_GetScopeDelta(&timestamps, kBackBufferIndex, Readback1_Stamp);
-                        clksAll += clks;
-                        WRITE_CSV_DATA(csvFile, clks, 0, timestampScopeClocks);
+                        WRITE_CSV_HEADER(csvFile, L"Readback 1", 0, timestampScopeNames);
                     }
 
                     timestampScopeCount = _countof(timestampScopeClocks);
-                    clks = zstdgpu_RetrieveTimestamps(timestampScopeNames, timestampScopeClocks, &timestampScopeCount, perRequestContext, 2);
-                    clksAll += clks;
-                    WRITE_CSV_DATA(csvFile, clks, timestampScopeCount, timestampScopeClocks);
-                    #undef WRITE_CSV_DATA
-
-                    const uint64_t ns = (clksAll * 1000000000) / freqGpuClocks;
-                    const double decompressionThroughput = (double)zstdUnCompressedFramesMemorySizeInBytes / ns;
-                    fwprintf_s(csvFile, L"%lf\n", decompressionThroughput);
+                    zstdgpu_RetrieveTimestamps(timestampScopeNames, timestampScopeClocks, &timestampScopeCount, perRequestContext, 2);
+                    WRITE_CSV_HEADER(csvFile, L"Stage 2", timestampScopeCount, timestampScopeNames);
+                    fwprintf_s(csvFile, L"Bandwidth (GB/s)\n");
                 }
+
+                // Always retrieve the per-stage GPU timestamps and accumulate the
+                // total marker time. The CSV columns are written only when a CSV is
+                // active; the accumulated clocks feed the aggregate stdout metrics.
+                if (NULL != csvFile)
+                    fwprintf_s(csvFile, L"%u,", dispatchIdx);
+
+                timestampScopeCount = _countof(timestampScopeClocks);
+                clks = zstdgpu_RetrieveTimestamps(timestampScopeNames, timestampScopeClocks, &timestampScopeCount, perRequestContext, 0);
+                clksAll = clks;
+                WRITE_CSV_DATA(csvFile, clks, timestampScopeCount, timestampScopeClocks);
+                if (Readback0_Stamp != ~0u)
+                {
+                    clks = d3d12aid_Timestamps_GetScopeDelta(&timestamps, kBackBufferIndex, Readback0_Stamp);
+                    clksAll += clks;
+                    WRITE_CSV_DATA(csvFile, clks, 0, timestampScopeClocks);
+                }
+
+                timestampScopeCount = _countof(timestampScopeClocks);
+                clks = zstdgpu_RetrieveTimestamps(timestampScopeNames, timestampScopeClocks, &timestampScopeCount, perRequestContext, 1);
+                clksAll += clks;
+                WRITE_CSV_DATA(csvFile, clks, timestampScopeCount, timestampScopeClocks);
+                if (Readback1_Stamp != ~0u)
+                {
+                    clks = d3d12aid_Timestamps_GetScopeDelta(&timestamps, kBackBufferIndex, Readback1_Stamp);
+                    clksAll += clks;
+                    WRITE_CSV_DATA(csvFile, clks, 0, timestampScopeClocks);
+                }
+
+                timestampScopeCount = _countof(timestampScopeClocks);
+                clks = zstdgpu_RetrieveTimestamps(timestampScopeNames, timestampScopeClocks, &timestampScopeCount, perRequestContext, 2);
+                clksAll += clks;
+                WRITE_CSV_DATA(csvFile, clks, timestampScopeCount, timestampScopeClocks);
+                #undef WRITE_CSV_DATA
+                #undef WRITE_CSV_HEADER
+
+                const uint64_t ns = (freqGpuClocks != 0) ? (clksAll * 1000000000) / freqGpuClocks : 0;
+                const double batchBw = (ns != 0) ? ((double)zstdUnCompressedFramesMemorySizeInBytes / ns) : 0.0;
+                const double batchUs = (freqGpuClocks != 0) ? (double)(clksAll * 1000000) / (double)freqGpuClocks : 0.0;
+                if (NULL != csvFile)
+                    fwprintf_s(csvFile, L"%lf\n", batchBw);
+
+                // Record this batch's latency/bandwidth for the aggregate stdout
+                // metrics. Warmup sweeps (a wall-clock window when --warmup is set)
+                // are excluded. The per-batch samples are pooled after the sweep
+                // loop to form the total [PERF] line.
+                if (!inWarmup)
+                {
+                    if (measuredSweeps < measuredCap)
+                    {
+                        if (NULL != perBatchUs) perBatchUs[(size_t)b * measuredCap + measuredSweeps] = batchUs;
+                        if (NULL != perBatchBw) perBatchBw[(size_t)b * measuredCap + measuredSweeps] = batchBw;
+                    }
+                }
+                ++dispatchIdx;
             }
 
             // Show the new frame.
@@ -2164,8 +2409,79 @@ static int demoRun(void *demoCtx)
             PIXEndEvent();
 
             PIXEndEvent();
+        } // for (b) -- one full pass over every batch in the working set
+
+        // ---- Per-sweep bookkeeping -------------------------------------------
+        // A sweep contributes to the reported statistics only if the window
+        // stayed open for every batch (a partial pass would understate the
+        // metrics) and it ran outside the warmup wall-clock window.
+        if (!windowOpen)
+            break;
+        if (inWarmup)
+        {
+            ++warmupSweeps;
         }
+        else if (measuredSweeps < measuredCap)
+        {
+            ++measuredSweeps;
+        }
+    } // for (sweep)
+
+    // Emit performance data if requested
+    if (prfLevelSpecified)
+    {
+        uint64_t totalDecompBytes = 0;
+        for (uint32_t b = 0; b < numBatches; ++b)
+        {
+            const double batchP50Us = MedianOfDoubles((NULL != perBatchUs) ? &perBatchUs[(size_t)b * measuredCap] : NULL, measuredSweeps);
+            const double batchMedBw = MedianOfDoubles((NULL != perBatchBw) ? &perBatchBw[(size_t)b * measuredCap] : NULL, measuredSweeps);
+            debugPrint(L"[PERF] batch=%u frames=%u decomp_bytes=%u p50_latency_us=%.3f bandwidth_gbps=%.4f runs=%u\n",
+                       b, perBatchFrames[b], perBatchBytes[b], batchP50Us, batchMedBw, measuredSweeps);
+            totalDecompBytes += perBatchBytes[b];
+        }
+
+        // Top-line statistics: P50 latency and bandwidth
+        uint32_t fullBatches = 0;
+        for (uint32_t b = 0; b < numBatches; ++b)
+            if (perBatchFrames[b] == effBatchFrames) ++fullBatches;
+        const bool poolFullOnly = (fullBatches > 0);
+
+        const size_t poolCap = (size_t)numBatches * measuredCap;
+        double      *poolUs  = (double *)malloc(sizeof(double) * poolCap);
+        double      *poolBw  = (double *)malloc(sizeof(double) * poolCap);
+        uint32_t     poolCnt = 0;
+        for (uint32_t b = 0; b < numBatches; ++b)
+        {
+            if (poolFullOnly && perBatchFrames[b] != effBatchFrames)
+                continue;
+            for (uint32_t s = 0; s < measuredSweeps; ++s)
+            {
+                if (NULL != poolUs && NULL != perBatchUs) poolUs[poolCnt] = perBatchUs[(size_t)b * measuredCap + s];
+                if (NULL != poolBw && NULL != perBatchBw) poolBw[poolCnt] = perBatchBw[(size_t)b * measuredCap + s];
+                ++poolCnt;
+            }
+        }
+
+        const uint32_t pooledBatches = poolFullOnly ? fullBatches : numBatches;
+        const double   totalP50Us    = MedianOfDoubles(poolUs, (NULL != poolUs) ? poolCnt : 0);
+        const double   totalMedBw    = MedianOfDoubles(poolBw, (NULL != poolBw) ? poolCnt : 0);
+        debugPrint(L"[PERF] total batches=%u pooled_batches=%u frames=%u decomp_bytes=%llu p50_latency_us=%.3f bandwidth_gbps=%.4f runs=%u warmup=%u\n",
+                   numBatches, pooledBatches, workingFrames, (unsigned long long)totalDecompBytes, totalP50Us, totalMedBw, measuredSweeps, warmupSweeps);
+
+        free(poolUs);
+        free(poolBw);
     }
+
+    free(perBatchUs);
+    free(perBatchBw);
+    free(perBatchFrames);
+    free(perBatchBytes);
+    free(rawRefPrefix);
+    free(batchStaging);
+    free(batchInRefs);
+    free(batchOutRefs);
+    free(batchFrameInfo);
+
     debugPrint(L"Finished.\n");
     return 0;
 }


### PR DESCRIPTION
Latency:  Latency is tested using a curated corpus of small content (~1 block/frame) executed in 12-frame batches to measure the intrinsic latency of the shader.  P50 values measured across the entire corpus are reported.

Throughput:  Throughput is measured using a corpus that is executed in progressively larger batches of frames (from 64 to 1024 per batch).  Each scenario is executed individually in the CI test harness and the curve of throughput vs batch size can be reconstructed by tooling analyzing the logs post-execution.